### PR TITLE
build(ide): add linting run config

### DIFF
--- a/.idea/runConfigurations/Lint.xml
+++ b/.idea/runConfigurations/Lint.xml
@@ -1,0 +1,12 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Lint" type="js.build_tools.npm">
+    <package-json value="$PROJECT_DIR$/package.json" />
+    <command value="run" />
+    <scripts>
+      <script value="lint" />
+    </scripts>
+    <node-interpreter value="project" />
+    <envs />
+    <method v="2" />
+  </configuration>
+</component>


### PR DESCRIPTION
To avoid using `CI: Lint` existing one if you don't want to. And use the regular one.