### PR TITLE
feat(noscript): extract from main tag

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,11 +1,9 @@
 <app-jsonld-metadata></app-jsonld-metadata>
 <app-release-info></app-release-info>
 <app-header></app-header>
-<main>
-  <noscript>
-    <app-no-script></app-no-script>
-  </noscript>
-  <div class="contents">
+<div class="after-header">
+  <app-no-script></app-no-script>
+  <main>
     <app-about></app-about>
-  </div>
-</main>
+  </main>
+</div>

--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -7,10 +7,11 @@
   //
   // Concretely, had this issue with my Android phone's Chrome address bar and had to switch to this way after that
   // https://blog.logrocket.com/improving-mobile-design-latest-css-viewport-units/
-  main {
+  .after-header {
     position: absolute;
     top: header.$height;
-    min-height: calc(100% - #{header.$height});
+    $headerHeight: header.$height;
+    min-height: calc(100% - $headerHeight);
     width: 100%;
 
     // Second wrapper to allow for the noscript notice in case it displays

--- a/src/app/header/header.component.html
+++ b/src/app/header/header.component.html
@@ -1,5 +1,5 @@
 <div class="bar">
-  <div class="buttons displayNoneIfNoScript">
+  <div class="toolbar displayNoneIfNoScript" role="toolbar">
     <button
       (click)="colorSchemeService.toggleDarkLight()"
       aria-label="Color scheme toggle (dark or light)"

--- a/src/app/header/header.component.scss
+++ b/src/app/header/header.component.scss
@@ -2,6 +2,7 @@
 @use 'paddings';
 @use 'header';
 @use 'z-index';
+@use 'helpers/units';
 
 :host {
   position: fixed;
@@ -14,9 +15,11 @@
     padding: header.$vertical-padding;
     flex-direction: row;
     justify-content: flex-end;
-    min-height: header.$icons-height + header.$vertical-padding-height;
+    $icons-height: header.$icons-height;
+    $vertical-padding-height: header.$vertical-padding-height;
+    min-height: calc($icons-height + $vertical-padding-height);
 
-    .buttons {
+    .toolbar {
       height: header.$icons-height;
 
       button {
@@ -31,7 +34,7 @@
           'FILL' 0,
           'wght' 200,
           'GRAD' 0,
-          'opsz' header.$icons-height-pixels;
+          'opsz' #{units.stripUnit(header.$icons-height)};
       }
     }
   }

--- a/src/app/header/header.component.ts
+++ b/src/app/header/header.component.ts
@@ -1,4 +1,4 @@
-import { Component, HostBinding } from '@angular/core'
+import { Component } from '@angular/core'
 import { DarkTheme, LightTheme } from '../material-symbols'
 import { ColorSchemeService } from './color-scheme.service'
 
@@ -8,8 +8,6 @@ import { ColorSchemeService } from './color-scheme.service'
   styleUrls: ['./header.component.scss'],
 })
 export class HeaderComponent {
-  @HostBinding('attr.role') ariaRole = 'toolbar'
-
   protected MaterialSymbol = {
     DarkTheme,
     LightTheme,

--- a/src/app/no-script/_no-script-theme.scss
+++ b/src/app/no-script/_no-script-theme.scss
@@ -3,7 +3,7 @@
 @mixin color($theme) {
   $background-palette: map-get($theme, background);
 
-  app-no-script {
+  app-no-script .contents {
     background: map-get($background-palette, z1);
     border-bottom-color: borders.panel-color($theme);
   }

--- a/src/app/no-script/no-script.component.html
+++ b/src/app/no-script/no-script.component.html
@@ -1,8 +1,14 @@
-<p>
-  <span class="material-symbols-outlined">{{ MaterialSymbol.Warning }}</span>
-  <b>Seems you don't have JavaScript enabled</b>
-</p>
-<p>
-  You are viewing a simplified version of the website<br />
-  Enable it for a better user experience
-</p>
+<noscript>
+  <div class="contents">
+    <p>
+      <span class="material-symbols-outlined">{{
+        MaterialSymbol.Warning
+      }}</span>
+      <b>Seems you don't have JavaScript enabled</b>
+    </p>
+    <p>
+      You are viewing a simplified version of the website<br />
+      Enable it for a better user experience
+    </p>
+  </div>
+</noscript>

--- a/src/app/no-script/no-script.component.scss
+++ b/src/app/no-script/no-script.component.scss
@@ -1,33 +1,44 @@
 @use 'borders';
 @use 'margins';
+@use 'header';
 @use 'paddings';
+@use 'z-index';
 
-app-no-script {
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  padding: paddings.$m;
-  gap: margins.$xs;
-  text-align: center;
-  height: 100px;
+:host {
+  position: fixed;
+  top: header.$height;
+  width: 100%;
+  z-index: z-index.$no-script;
 
-  @include borders.panel-style-width(bottom);
-
-  p:first-child {
+  .contents {
     display: flex;
+    flex-direction: column;
     justify-content: center;
-    align-items: center;
-    gap: margins.$s;
-  }
-  p:not(:first-child) {
-    font-size: 14px;
-  }
-  .material-symbols-outlined {
-    font-size: 1em;
-    font-variation-settings:
-      'FILL' 0,
-      'wght' 700,
-      'GRAD' 0,
-      'opsz' 16;
+    padding: paddings.$m;
+    gap: margins.$xs;
+    text-align: center;
+    height: 100px;
+
+    @include borders.panel-style-width(bottom);
+
+    p:first-child {
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      gap: margins.$s;
+    }
+
+    p:not(:first-child) {
+      font-size: 14px;
+    }
+
+    .material-symbols-outlined {
+      font-size: 1em;
+      font-variation-settings:
+        'FILL' 0,
+        'wght' 700,
+        'GRAD' 0,
+        'opsz' 16;
+    }
   }
 }

--- a/src/app/no-script/no-script.component.ts
+++ b/src/app/no-script/no-script.component.ts
@@ -1,11 +1,10 @@
-import { Component, ViewEncapsulation } from '@angular/core'
+import { Component } from '@angular/core'
 import { Warning } from '../material-symbols'
 
 @Component({
   selector: 'app-no-script',
   templateUrl: './no-script.component.html',
   styleUrls: ['./no-script.component.scss'],
-  encapsulation: ViewEncapsulation.None,
 })
 export class NoScriptComponent {
   protected MaterialSymbol = {

--- a/src/index.html
+++ b/src/index.html
@@ -101,8 +101,10 @@
           display: none !important;
         }
 
-        main > div.contents {
+        main {
           /** Must be kept in sync with app-no-script component **/
+          position: absolute;
+          width: 100%;
           top: 100px;
           min-height: calc(100% - 100px) !important;
         }

--- a/src/sass/_header.scss
+++ b/src/sass/_header.scss
@@ -2,8 +2,7 @@
 @use 'borders';
 
 $vertical-padding: paddings.$xs;
-$icons-height-pixels: 32;
-$icons-height: #{$icons-height-pixels}px;
+$icons-height: 32px;
 $vertical-padding-height: calc(2 * $vertical-padding);
 $border-height: borders.$panel-width;
 

--- a/src/sass/_z-index.scss
+++ b/src/sass/_z-index.scss
@@ -1,1 +1,2 @@
 $header: 255;
+$no-script: $header;

--- a/src/sass/helpers/_units.scss
+++ b/src/sass/helpers/_units.scss
@@ -1,0 +1,7 @@
+@use 'sass:math';
+
+// Strips unit from variable. ie: 32px -> 32
+// https://stackoverflow.com/a/12335841/3263250
+@function stripUnit($number) {
+  @return math.div($number, ($number * 0+1));
+}


### PR DESCRIPTION
Removes `<noscript>` and `<app-no-script>` from `<main>`. Given it's not really part of main content.

Some other refactors:
 - Move `<noscript>` inside `<pp-no-script>` for better encapsulation
 - Add SCSS `stripUnits` helper to get rid of 1 var
 - Ensure SCSS calc is applied. Use local vars to avoid WebStorm issue with CSS `calc` and SASS `@use`

Minor improvements:
 - Apply `toolbar` role just to the toolbar part of the header
