### PR TITLE
feat(description): several improvements when no JS

### DIFF
--- a/src/app/about/description/description.component.html
+++ b/src/app/about/description/description.component.html
@@ -1,4 +1,6 @@
-<ng-container *ngIf="!isCollapsible; else collapsibleTemplate">
+<ng-container
+  *ngIf="!isCollapsible || !isRenderingOnBrowser; else collapsibleTemplate"
+>
   <div class="data" *ngIf="line.data">
     <ng-container [ngTemplateOutlet]="dataTemplate"></ng-container>
   </div>
@@ -11,7 +13,7 @@
     [attr.aria-controls]="sluggedId"
     (click)="isExpanded ? this.collapse() : this.expand()"
   >
-    <span class="caret displayNoneIfNoScript" aria-hidden="true">{{
+    <span class="caret" aria-hidden="true">{{
       isExpanded ? config.expandedIcon : config.collapsedIcon
     }}</span>
     <ng-container [ngTemplateOutlet]="dataTemplate"></ng-container>

--- a/src/app/about/description/description.component.scss
+++ b/src/app/about/description/description.component.scss
@@ -3,7 +3,7 @@
 
 :host {
   &.hidden {
-    visibility: hidden;
+    display: none;
   }
 
   ul {

--- a/src/app/about/description/description.component.spec.ts
+++ b/src/app/about/description/description.component.spec.ts
@@ -249,8 +249,14 @@ describe('DescriptionComponent', () => {
           let caretElement: DebugElement
           let listElement: DebugElement
 
-          function testShouldBeExpanded(checkVisibility: boolean = true) {
-            it('should be expanded', () => {
+          function testChildListShouldBeExpanded() {
+            it('child list should be expanded', () => {
+              expectIsVisible(listElement.nativeElement)
+            })
+          }
+
+          function testButtonShouldIndicateItsExpandedAndShowCollapseIcon() {
+            it('button should indicate it is expanded and show collapse icon', () => {
               expect(dataElement).toBeTruthy()
               expect(dataElement.attributes['aria-expanded']).toBe(
                 true.toString(),
@@ -259,15 +265,11 @@ describe('DescriptionComponent', () => {
               expect(caretElement.nativeElement.textContent).toBe(
                 fakeConfig.expandedIcon,
               )
-
-              if (checkVisibility) {
-                expectIsVisible(listElement.nativeElement)
-              }
             })
           }
 
-          function testShouldBeCollapsed() {
-            it('should be collapsed', () => {
+          function testButtonShouldIndicateItsCollapsedAndShowExpandIcon() {
+            it('button should indicate it is collapsed and show expand icon', () => {
               expect(dataElement).toBeTruthy()
               expect(dataElement.attributes['aria-expanded']).toBe(
                 false.toString(),
@@ -276,7 +278,11 @@ describe('DescriptionComponent', () => {
               expect(caretElement.nativeElement.textContent).toBe(
                 fakeConfig.collapsedIcon,
               )
+            })
+          }
 
+          function testShouldBeCollapsed() {
+            it('child list should be collapsed', () => {
               expectIsHidden(listElement.nativeElement)
             })
           }
@@ -294,7 +300,7 @@ describe('DescriptionComponent', () => {
               caretElement = dataElement.query(CARET_SELECTOR)
               listElement = fixture.debugElement.query(LIST_SELECTOR)
             })
-            testShouldBeExpanded(false)
+            testChildListShouldBeExpanded()
 
             // to avoid layout shifts
             it('should be hidden', () => {
@@ -315,6 +321,7 @@ describe('DescriptionComponent', () => {
             })
             describe('by default', () => {
               testShouldBeCollapsed()
+              testButtonShouldIndicateItsCollapsedAndShowExpandIcon()
               it('should make the component visible', () => {
                 expectIsVisible(fixture.debugElement.nativeElement)
               })
@@ -327,7 +334,8 @@ describe('DescriptionComponent', () => {
 
                 fixture.detectChanges()
               }))
-              testShouldBeExpanded()
+              testButtonShouldIndicateItsExpandedAndShowCollapseIcon()
+              testChildListShouldBeExpanded()
             })
             describe('when clicking twice', () => {
               beforeEach(fakeAsync(() => {
@@ -339,6 +347,7 @@ describe('DescriptionComponent', () => {
                 tick() // animation to complete
                 fixture.detectChanges()
               }))
+              testButtonShouldIndicateItsCollapsedAndShowExpandIcon()
               testShouldBeCollapsed()
             })
           })

--- a/src/app/about/description/description.component.ts
+++ b/src/app/about/description/description.component.ts
@@ -60,13 +60,15 @@ export class DescriptionComponent {
   @Input() protected parent?: DescriptionComponent
 
   // 👇 Using `protected` to avoid being marked as unused
-  @HostBinding('class.visibleIfNoScript') protected visibleIfNoScript = true
-  @HostBinding('class.hidden') protected hidden = true
+  @HostBinding('class.displayBlockIfNoScript') protected visibleIfNoScript =
+    true
+  @HostBinding('class.hidden') protected hidden = !this.isRenderingOnBrowser
 
   private EXPANDED_DEFAULT_NO_JS = true
   private EXPANDED_DEFAULT_JS_ENABLED = false
-  public isExpanded = this.EXPANDED_DEFAULT_NO_JS
-
+  public isExpanded = this.isRenderingOnBrowser
+    ? this.EXPANDED_DEFAULT_JS_ENABLED
+    : this.EXPANDED_DEFAULT_NO_JS
   @ViewChildren(DescriptionComponent)
   private children!: QueryList<DescriptionComponent>
 
@@ -74,11 +76,10 @@ export class DescriptionComponent {
     protected sanitizer: DomSanitizer,
     @Inject(COLLAPSIBLE_CONFIG) protected config: CollapsibleConfiguration,
     @Inject(PLATFORM_ID) private platformId: object,
-  ) {
-    if (isPlatformBrowser(this.platformId)) {
-      this.isExpanded = this.EXPANDED_DEFAULT_JS_ENABLED
-      this.hidden = false
-    }
+  ) {}
+
+  protected get isRenderingOnBrowser() {
+    return isPlatformBrowser(this.platformId)
   }
 
   public get isCollapsible(): boolean {

--- a/src/index.html
+++ b/src/index.html
@@ -93,8 +93,8 @@
       <!--suppress CssUnusedSymbol (used in inner components, but WebStorm doesn't go so far :P) -->
       <style>
         /* Helpers to show or hide depending if JavaScript is enabled or not */
-        .visibleIfNoScript {
-          visibility: visible !important;
+        .displayBlockIfNoScript {
+          display: block !important;
         }
 
         .displayNoneIfNoScript {


### PR DESCRIPTION
- Do not show collapsible button
- Use `display` instead of `visibility` for hide when loading in client to avoid big layout shift
- Remove unneeded caret hide class, whole button is hidden now
- Refactor tests: do not test controls when rendering on server (they're not there)
