### PR TITLE
ci: build artifact to contain assets directly

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -45,5 +45,5 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: ${{ inputs.artifact-name }}
-          path: 'dist/@davidlj95/website'
+          path: 'dist/@davidlj95/website/browser'
           retention-days: 5

--- a/.github/workflows/reusable-deploy-cloudflare-pages.yml
+++ b/.github/workflows/reusable-deploy-cloudflare-pages.yml
@@ -65,5 +65,5 @@ jobs:
           # https://github.com/cloudflare/pages-action/issues/97
           branch: ${{ github.head_ref || github.ref_name }}
           projectName: 'davidlj95'
-          directory: 'browser'
+          directory: '.'
           gitHubToken: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/reusable-deploy-github-pages.yml
+++ b/.github/workflows/reusable-deploy-github-pages.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v2
         with:
-          path: 'browser'
+          path: '.'
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v2

--- a/lighthouserc.js
+++ b/lighthouserc.js
@@ -5,9 +5,7 @@ module.exports = {
       url: ['http://localhost/'],
     },
     collect: {
-      staticDistDir: process.env.CI
-        ? 'browser'
-        : 'dist/@davidlj95/website/browser',
+      staticDistDir: process.env.CI ? '.' : 'dist/@davidlj95/website/browser',
     },
     assert: {
       preset: 'lighthouse:no-pwa',


### PR DESCRIPTION
Currently, the build artifact in GitHub Actions CI/CD workflows contains a `browser` directory. Inside that directory, the app built assets live. But it's kind of a magic string. Better to place all assets directly in the build artifact.
