### PR TITLE
chore: cleanup after component refactor

### DIFF
--- a/src/app/about/presentation/contact-social-icons/contact-social-icons.component.scss
+++ b/src/app/about/presentation/contact-social-icons/contact-social-icons.component.scss
@@ -1,5 +1,5 @@
-@use '../../../../sass/breakpoints';
-@use '../../../../sass/margins';
+@use 'breakpoints';
+@use 'margins';
 
 :host {
   ul {

--- a/src/app/about/presentation/contact-traditional-icons/contact-traditional-icons.component.scss
+++ b/src/app/about/presentation/contact-traditional-icons/contact-traditional-icons.component.scss
@@ -1,6 +1,6 @@
-@use '../../../../sass/breakpoints';
-@use '../../../../sass/margins';
-@use '../../../../sass/material-symbols';
+@use 'breakpoints';
+@use 'margins';
+@use 'material-symbols';
 
 :host {
   ul {

--- a/src/app/about/presentation/description/description.component.scss
+++ b/src/app/about/presentation/description/description.component.scss
@@ -1,6 +1,6 @@
-@use '../../../../sass/margins';
-@use '../../../../sass/material-symbols';
-@use '../../../../sass/paddings';
+@use 'margins';
+@use 'material-symbols';
+@use 'paddings';
 
 :host {
   &.hidden {

--- a/src/app/about/presentation/presentation.component.html
+++ b/src/app/about/presentation/presentation.component.html
@@ -6,9 +6,9 @@
         <span class="real-name">{{ realName }}</span>
         <code>@{{ nickname }}</code>
       </span>
-      <!-- Duplicated for accessibility
-                        Otherwise, it was read twice: first as a group, then each element (<span>/<code>) separately.
-                        https://stackoverflow.com/a/76001309/3263250 -->
+      <!-- Duplicated for accessibility -->
+      <!-- Otherwise, it was read twice: first as a group, then each element (<span>/<code>) separately. -->
+      <!-- https://stackoverflow.com/a/76001309/3263250 -->
       <span class="sr-only"> {{ realName }} @{{ nickname }} </span>
     </h1>
     <h2>{{ title }}</h2>

--- a/src/app/about/presentation/profile-picture/_profile-picture-theme.scss
+++ b/src/app/about/presentation/profile-picture/_profile-picture-theme.scss
@@ -1,4 +1,4 @@
-@use '../../../../sass/animations';
+@use 'animations';
 
 @mixin color($theme) {
   $background-palette: map-get($theme, background);

--- a/src/app/about/presentation/profile-picture/profile-picture.component.html
+++ b/src/app/about/presentation/profile-picture/profile-picture.component.html
@@ -5,7 +5,7 @@
   }} wearing the same and in the same pose. But appears surprised"
   class="huh"
   height="128"
-  ngSrc="../../../../assets/img/profile_huh.png"
+  ngSrc="assets/img/profile_huh.png"
   width="128"
 />
 <img
@@ -14,7 +14,7 @@
   }}. Slightly smiling. Wears 80'ish glasses and a green and black plaid shirt"
   class="main"
   height="128"
-  ngSrc="../../../../assets/img/profile.png"
+  ngSrc="assets/img/profile.png"
   priority
   width="128"
   [tabindex]="hasBeenFocused ? -1 : 0"

--- a/src/app/about/presentation/profile-picture/profile-picture.component.scss
+++ b/src/app/about/presentation/profile-picture/profile-picture.component.scss
@@ -1,6 +1,6 @@
-@use '../../../../sass/touch-or-pointer';
-@use '../../../../sass/margins';
-@use '../../../../sass/paddings';
+@use 'touch-or-pointer';
+@use 'margins';
+@use 'paddings';
 
 $picture-size: 128px;
 


### PR DESCRIPTION
Cleans up refactor in #49 

Some SCSS paths were relativized in the automatic refactor
Split HTML comment lines to avoid formatter to weirdly indent when formatting
Remove relativized `ngSrc` image source
