### PR TITLE
refactor(about): layout change to allow content after presentation

### DIFF
--- a/src/app/about/about.component.html
+++ b/src/app/about/about.component.html
@@ -1,4 +1,3 @@
 <app-jsonld-metadata></app-jsonld-metadata>
-<section>
-  <app-presentation></app-presentation>
-</section>
+<app-presentation></app-presentation>
+<div class="after-presentation"></div>

--- a/src/app/about/about.component.scss
+++ b/src/app/about/about.component.scss
@@ -1,0 +1,13 @@
+@use 'page';
+
+:host {
+  @include page.full-size;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  .after-presentation {
+    position: absolute;
+    top: 100%;
+  }
+}

--- a/src/app/about/presentation/presentation.component.html
+++ b/src/app/about/presentation/presentation.component.html
@@ -1,21 +1,19 @@
-<div class="contents" role="presentation">
-  <div class="profile">
-    <app-profile-picture></app-profile-picture>
-    <h1>
-      <span class="visible-header" aria-hidden="true">
-        <span class="real-name">{{ realName }}</span>
-        <code>@{{ nickname }}</code>
-      </span>
-      <!-- Duplicated for accessibility -->
-      <!-- Otherwise, it was read twice: first as a group, then each element (<span>/<code>) separately. -->
-      <!-- https://stackoverflow.com/a/76001309/3263250 -->
-      <span class="sr-only"> {{ realName }} @{{ nickname }} </span>
-    </h1>
-    <h2>{{ title }}</h2>
-    <div class="contacts">
-      <app-contact-traditional-icons></app-contact-traditional-icons>
-      <app-contact-social-icons></app-contact-social-icons>
-    </div>
+<div class="profile">
+  <app-profile-picture></app-profile-picture>
+  <h1>
+    <span class="visible-header" aria-hidden="true">
+      <span class="real-name">{{ realName }}</span>
+      <code>@{{ nickname }}</code>
+    </span>
+    <!-- Duplicated for accessibility -->
+    <!-- Otherwise, it was read twice: first as a group, then each element (<span>/<code>) separately. -->
+    <!-- https://stackoverflow.com/a/76001309/3263250 -->
+    <span class="sr-only"> {{ realName }} @{{ nickname }} </span>
+  </h1>
+  <h2>{{ title }}</h2>
+  <div class="contacts">
+    <app-contact-traditional-icons></app-contact-traditional-icons>
+    <app-contact-social-icons></app-contact-social-icons>
   </div>
-  <app-description [line]="rootLine"></app-description>
 </div>
+<app-description [line]="rootLine"></app-description>

--- a/src/app/about/presentation/presentation.component.scss
+++ b/src/app/about/presentation/presentation.component.scss
@@ -5,48 +5,41 @@
 @use 'page';
 
 :host {
-  @include page.full-size;
   display: flex;
   flex-direction: column;
-  justify-content: center;
-  align-items: center;
+  gap: margins.$l;
+  padding: paddings.$m paddings.$l;
 
-  .contents {
+  .profile {
     display: flex;
     flex-direction: column;
-    gap: margins.$l;
-    padding: paddings.$m paddings.$l;
+    flex-wrap: wrap;
+    gap: margins.$s;
 
-    .profile {
+    h1 > span.visible-header {
       display: flex;
       flex-direction: column;
-      flex-wrap: wrap;
-      gap: margins.$s;
 
-      h1 > span.visible-header {
-        display: flex;
-        flex-direction: column;
-
-        .real-name {
-          font-size: 1.75rem;
-          font-weight: bold;
-        }
-        code {
-          font-size: 1.5rem;
-        }
+      .real-name {
+        font-size: 1.75rem;
+        font-weight: bold;
       }
 
-      h2 {
+      code {
         font-size: 1.5rem;
       }
+    }
 
-      .contacts {
-        display: flex;
-        gap: margins.$m;
-        flex-wrap: wrap;
-        flex-direction: row;
-        margin-top: margins.$s;
-      }
+    h2 {
+      font-size: 1.5rem;
+    }
+
+    .contacts {
+      display: flex;
+      gap: margins.$m;
+      flex-wrap: wrap;
+      flex-direction: row;
+      margin-top: margins.$s;
     }
   }
 }

--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -13,13 +13,5 @@
     $headerHeight: header.$height;
     min-height: calc(100% - $headerHeight);
     width: 100%;
-
-    // Second wrapper to allow for the noscript notice in case it displays
-    // min-height and top changes in case noscript displays. Check index.html styles.
-    .contents {
-      position: absolute;
-      width: 100%;
-      min-height: 100%;
-    }
   }
 }

--- a/src/index.html
+++ b/src/index.html
@@ -106,7 +106,7 @@
           position: absolute;
           width: 100%;
           top: 100px;
-          min-height: calc(100% - 100px) !important;
+          min-height: calc(100% - 100px);
         }
       </style>
     </noscript>


### PR DESCRIPTION
When adding more content to the about page, found out it was not easy to add content below the presentation due to the `min-height` & related absolute positioning tricks. Here we fix that by making the about component (the whole page) take `min-height: 100%` and be `position:absolute`. Because then we can add some div with `position:absolute` and `top:100%` inside it and it will position right afterwards. Was a bit tricky tbh!

Also some cleanups:
 - Remove unneeded app component `.contents` styling. Doesn't exist anymore
 - Remove `!important` in `index.html` style for `main` when no JavaScript enabled. Not needed, no one is styling that elsewhere.
