### PR TITLE
chore(experience): toggle image URL map

### DIFF
--- a/src/app/about/professional-experience/json-resume-position-adapter.service.spec.ts
+++ b/src/app/about/professional-experience/json-resume-position-adapter.service.spec.ts
@@ -18,114 +18,140 @@ describe('JsonResumePositionAdapterService', () => {
   const sampleJsonResumeWorkPosition = resume.work[0]
 
   describe('#adapt', () => {
-    let sut: JsonResumePositionAdapterService
-    const fakeCanonicalUrl = new URL('https://example.org/canonical/')
+    describe('when images mapping is disabled', () => {
+      let sut: JsonResumePositionAdapterService
 
-    beforeEach(() => {
-      const fakeEnvironment: Pick<Environment, 'canonicalUrl'> = {
-        canonicalUrl: fakeCanonicalUrl,
-      }
-      TestBed.configureTestingModule({
-        providers: [MockProvider(ENVIRONMENT, fakeEnvironment)],
+      beforeEach(() => {
+        const fakeEnvironment: Pick<Environment, 'mapJsonResumeImages'> = {
+          mapJsonResumeImages: false,
+        }
+        TestBed.configureTestingModule({
+          providers: [MockProvider(ENVIRONMENT, fakeEnvironment)],
+        })
+        sut = TestBed.inject(JsonResumePositionAdapterService)
       })
-      sut = TestBed.inject(JsonResumePositionAdapterService)
-    })
 
-    it('should map the company name and website', () => {
-      const fakeJsonResumePosition: JsonResumeWorkPosition = {
-        ...sampleJsonResumeWorkPosition,
-        company: 'Fake company name',
-        website: 'https://example.org/',
-      }
-      const position = sut.adapt(
-        fakeJsonResumePosition as JsonResumeWorkPosition,
-      )
-
-      expect(position.company.name).toEqual(fakeJsonResumePosition.company)
-      expect(position.company.website.toString()).toEqual(
-        fakeJsonResumePosition.website,
-      )
-    })
-    it('should map the company image into a custom URL using canonical URL, custom assets path and kebab-cased+no special chars name', () => {
-      const fakeJsonResumePosition: JsonResumeWorkPosition = {
-        ...sampleJsonResumeWorkPosition,
-        company: 'Fake còmpány  Name',
-      }
-      const expectedImageFileName = 'fake-company-name'
-      const position = sut.adapt(
-        fakeJsonResumePosition as JsonResumeWorkPosition,
-      )
-
-      expect(position.company.image.toString()).toEqual(
-        fakeCanonicalUrl.toString() +
-          sut.COMPANIES_IMAGE_ASSETS_PATH +
-          expectedImageFileName +
-          sut.IMAGE_EXTENSION,
-      )
-    })
-    it('should map the role, summary and highlights', () => {
-      const fakeHighlights = ['Fake highlight 1', 'Fake highlight 2']
-      const fakeJsonResumePosition: JsonResumeWorkPosition = {
-        ...sampleJsonResumeWorkPosition,
-        position: 'Fake position',
-        summary: 'Foo bar',
-        highlights: fakeHighlights,
-      } as JsonResumeWorkPosition
-      const position = sut.adapt(
-        fakeJsonResumePosition as JsonResumeWorkPosition,
-      )
-
-      expect(position.role).toEqual(fakeJsonResumePosition.position)
-      expect(position.summary).toEqual(fakeJsonResumePosition.summary)
-      expect(position.highlights).toEqual(fakeHighlights)
-    })
-    it('should map the start and end date', () => {
-      const fakeStartDate = '2022-12-31'
-      const fakeEndDate = '2024-01-01'
-      const fakeJsonResumePosition: JsonResumeWorkPosition = {
-        ...sampleJsonResumeWorkPosition,
-        startDate: fakeStartDate,
-        endDate: fakeEndDate,
-      } as JsonResumeWorkPosition
-      const position = sut.adapt(
-        fakeJsonResumePosition as JsonResumeWorkPosition,
-      )
-
-      expect(position.startDate).toEqual(new Date(fakeStartDate))
-      expect(position.endDate).toEqual(new Date(fakeEndDate))
-    })
-    describe('when no end date', () => {
-      it('should map no end date exists too', () => {
+      it('should map the company name, image and website', () => {
         const fakeJsonResumePosition: JsonResumeWorkPosition = {
           ...sampleJsonResumeWorkPosition,
-          endDate: undefined,
+          company: 'Fake company name',
+          website: 'https://example.org/',
+          image: 'https://example.org/logo.png',
+        }
+        const position = sut.adapt(
+          fakeJsonResumePosition as JsonResumeWorkPosition,
+        )
+
+        expect(position.company.name).toEqual(fakeJsonResumePosition.company)
+        expect(position.company.website.toString()).toEqual(
+          fakeJsonResumePosition.website,
+        )
+        expect(position.company.image.toString()).toEqual(
+          fakeJsonResumePosition.image,
+        )
+      })
+
+      it('should map the role, summary and highlights', () => {
+        const fakeHighlights = ['Fake highlight 1', 'Fake highlight 2']
+        const fakeJsonResumePosition: JsonResumeWorkPosition = {
+          ...sampleJsonResumeWorkPosition,
+          position: 'Fake position',
+          summary: 'Foo bar',
+          highlights: fakeHighlights,
+        } as JsonResumeWorkPosition
+        const position = sut.adapt(
+          fakeJsonResumePosition as JsonResumeWorkPosition,
+        )
+
+        expect(position.role).toEqual(fakeJsonResumePosition.position)
+        expect(position.summary).toEqual(fakeJsonResumePosition.summary)
+        expect(position.highlights).toEqual(fakeHighlights)
+      })
+      it('should map the start and end date', () => {
+        const fakeStartDate = '2022-12-31'
+        const fakeEndDate = '2024-01-01'
+        const fakeJsonResumePosition: JsonResumeWorkPosition = {
+          ...sampleJsonResumeWorkPosition,
+          startDate: fakeStartDate,
+          endDate: fakeEndDate,
+        } as JsonResumeWorkPosition
+        const position = sut.adapt(
+          fakeJsonResumePosition as JsonResumeWorkPosition,
+        )
+
+        expect(position.startDate).toEqual(new Date(fakeStartDate))
+        expect(position.endDate).toEqual(new Date(fakeEndDate))
+      })
+      describe('when no end date', () => {
+        it('should map no end date exists too', () => {
+          const fakeJsonResumePosition: JsonResumeWorkPosition = {
+            ...sampleJsonResumeWorkPosition,
+            endDate: undefined,
+          } as unknown as JsonResumeWorkPosition
+          const position = sut.adapt(
+            fakeJsonResumePosition as JsonResumeWorkPosition,
+          )
+
+          expect(position.endDate).toBeUndefined()
+        })
+      })
+      // Non JSON Resume standard!
+
+      it('should map the freelance, internship, promotions and otherRoles fields', () => {
+        const fakePromotions = true
+        const fakeOtherRoles = true
+        const fakeJsonResumePosition: JsonResumeWorkPosition = {
+          ...sampleJsonResumeWorkPosition,
+          freelance: true,
+          internship: true,
+          promotions: fakePromotions,
+          otherRoles: fakeOtherRoles,
         } as unknown as JsonResumeWorkPosition
         const position = sut.adapt(
           fakeJsonResumePosition as JsonResumeWorkPosition,
         )
 
-        expect(position.endDate).toBeUndefined()
+        expect(position.freelance).toBeTrue()
+        expect(position.internship).toBeTrue()
+        expect(position.promotions).toEqual(fakePromotions)
+        expect(position.otherRoles).toEqual(fakeOtherRoles)
       })
     })
-    // Non JSON Resume standard!
-    it('should map the freelance, internship, promotions and otherRoles fields', () => {
-      const fakePromotions = true
-      const fakeOtherRoles = true
-      const fakeJsonResumePosition: JsonResumeWorkPosition = {
-        ...sampleJsonResumeWorkPosition,
-        freelance: true,
-        internship: true,
-        promotions: fakePromotions,
-        otherRoles: fakeOtherRoles,
-      } as unknown as JsonResumeWorkPosition
-      const position = sut.adapt(
-        fakeJsonResumePosition as JsonResumeWorkPosition,
-      )
+    describe('when images mapping is enabled', () => {
+      const fakeCanonicalUrl = new URL('https://example.org/canonical/')
+      let sut: JsonResumePositionAdapterService
 
-      expect(position.freelance).toBeTrue()
-      expect(position.internship).toBeTrue()
-      expect(position.promotions).toEqual(fakePromotions)
-      expect(position.otherRoles).toEqual(fakeOtherRoles)
+      beforeEach(() => {
+        const fakeEnvironment: Pick<
+          Environment,
+          'canonicalUrl' | 'mapJsonResumeImages'
+        > = {
+          canonicalUrl: fakeCanonicalUrl,
+          mapJsonResumeImages: true,
+        }
+        TestBed.configureTestingModule({
+          providers: [MockProvider(ENVIRONMENT, fakeEnvironment)],
+        })
+        sut = TestBed.inject(JsonResumePositionAdapterService)
+      })
+
+      it('should map the company image into a custom URL using canonical URL, assets path and slug from name', () => {
+        const fakeJsonResumePosition: JsonResumeWorkPosition = {
+          ...sampleJsonResumeWorkPosition,
+          company: 'Fake còmpány  Name',
+        }
+        const expectedImageFileName = 'fake-company-name'
+        const position = sut.adapt(
+          fakeJsonResumePosition as JsonResumeWorkPosition,
+        )
+
+        expect(position.company.image.toString()).toEqual(
+          fakeCanonicalUrl.toString() +
+            sut.COMPANIES_IMAGE_ASSETS_PATH +
+            expectedImageFileName +
+            sut.IMAGE_EXTENSION,
+        )
+      })
     })
   })
 })

--- a/src/app/about/professional-experience/json-resume-position-adapter.service.ts
+++ b/src/app/about/professional-experience/json-resume-position-adapter.service.ts
@@ -12,12 +12,14 @@ export class JsonResumePositionAdapterService {
   public readonly COMPANIES_IMAGE_ASSETS_PATH = 'assets/companies/'
   public readonly IMAGE_EXTENSION = '.png'
   private readonly canonicalURL: URL
+  private readonly mapJsonResumeImages: boolean
 
   constructor(
     @Inject(ENVIRONMENT) environment: Environment,
     private slugGenerator: SlugGeneratorService,
   ) {
     this.canonicalURL = environment.canonicalUrl
+    this.mapJsonResumeImages = environment.mapJsonResumeImages
   }
 
   adapt(position: JsonResumeWorkPosition): Position {
@@ -26,7 +28,9 @@ export class JsonResumePositionAdapterService {
         name: position.company,
         // Point to assets in this repo using canonical URL from env, so we can change the image and preview it.
         // Links in resume.json work anyway
-        image: this.imageUrlFromCompanyName(position.company),
+        image: this.mapJsonResumeImages
+          ? this.imageUrlFromCompanyName(position.company)
+          : new URL(position.image),
         website: new URL(position.website),
       }),
       role: position.position,

--- a/src/environments/environment-interface.ts
+++ b/src/environments/environment-interface.ts
@@ -1,4 +1,5 @@
 export interface Environment {
   production: boolean
+  mapJsonResumeImages: boolean
   canonicalUrl: URL
 }

--- a/src/environments/environment.development.ts
+++ b/src/environments/environment.development.ts
@@ -2,6 +2,7 @@ import { Environment } from './environment-interface'
 
 export const environment: Environment = {
   production: false,
+  mapJsonResumeImages: true,
   // ⚠️ When running locally production SSR version, server will run at http://localhost:4000 by default
   //    However, given was built with production profile, canonical URL will be production's one.
   //    Nothing too bad happens right now given it's used just for SEO metadata. But to bear in mind.

--- a/src/environments/environment.pull-request.ts.liquid
+++ b/src/environments/environment.pull-request.ts.liquid
@@ -10,5 +10,6 @@ const CLOUDFLARE_PAGES_PREVIEW_BRANCH_ALIAS_URL = new URL(
 )
 export const environment: Environment = {
   production: false,
+  mapJsonResumeImages: false,
   canonicalUrl: CLOUDFLARE_PAGES_PREVIEW_BRANCH_ALIAS_URL,
 }

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -3,5 +3,6 @@ import { Environment } from './environment-interface'
 
 export const environment: Environment = {
   production: true,
+  mapJsonResumeImages: false,
   canonicalUrl: new URL(`https://${METADATA.domainName}`),
 }


### PR DESCRIPTION
Fixes [CI pipeline error](https://github.com/davidlj95/website/actions/runs/6484533751/job/17608692531?pr=71) in #71

Issue is that 404/500 errors appear in the console when Lighthouse is testing the built page. Those errors refer to the work experience position images do not exist. Because the work experience position images aren't there yet as deploy doesn't happen until Lighthouse test passes. That's because we try and use the images from the repository. But here we have a dependency cycle.

In order to workaround this, a toggle is added so that when running in pull requests (and in production), no image URL mapping happens. And the images used for work experience positions are the ones in `resume.json`, that have already been deployed beforehand.
