### PR TITLE
refactor(about): org website optional, better test, use link in org name

### DIFF
--- a/src/app/about/education/education-item/education-item.component.html
+++ b/src/app/about/education/education-item/education-item.component.html
@@ -1,6 +1,9 @@
 <app-card>
   <div class="header">
-    <app-link [href]="item.institution.website.toString()">
+    <app-link
+      [href]="item.institution.website?.toString()"
+      data-test-id="image"
+    >
       <app-card-header-image
         [src]="item.institution.image.toString()"
         [alt]="item.institution.name + ' logo'"
@@ -8,11 +11,12 @@
       </app-card-header-image>
     </app-link>
     <div class="text">
-      <span class="institution">
-        <a [href]="item.institution.website.toString()">
-          {{ item.institution.name }}
-        </a>
-      </span>
+      <app-link
+        [href]="item.institution.website?.toString()"
+        data-test-id="institution-name"
+      >
+        {{ item.institution.name }}
+      </app-link>
       <div class="studyType">{{ item.studyType }}</div>
       <div class="area">{{ item.area }}</div>
       <span class="dates"

--- a/src/app/about/education/education-item/education-item.component.spec.ts
+++ b/src/app/about/education/education-item/education-item.component.spec.ts
@@ -20,7 +20,6 @@ describe('EducationItemComponent', () => {
     institution: new Organization({
       name: 'Fake institution',
       image: new URL('https://fake.example.org/logo.png'),
-      website: new URL('https://fake.example.org'),
     }),
     area: 'Fake area',
     studyType: 'Fake study type',
@@ -32,12 +31,9 @@ describe('EducationItemComponent', () => {
     TestBed.configureTestingModule({
       declarations: [
         EducationItemComponent,
-        MockComponents(
-          CardComponent,
-          LinkComponent,
-          CardHeaderImageComponent,
-          DateRangeComponent,
-        ),
+        LinkComponent,
+        CardHeaderImageComponent,
+        MockComponents(CardComponent, DateRangeComponent),
       ],
       imports: [NgOptimizedImage],
     })
@@ -51,37 +47,50 @@ describe('EducationItemComponent', () => {
 
   describe('institution', () => {
     it('should display institution image with link to its website', () => {
-      component.item = new EducationItem(newEducationItemArgs)
-      fixture.detectChanges()
-
-      const linkElement = fixture.debugElement.query(
-        By.css(getComponentSelector(LinkComponent)),
-      )
-      expect(linkElement).toBeTruthy()
-
-      const headerImageElement = linkElement.query(
-        By.css(getComponentSelector(CardHeaderImageComponent)),
-      )
-      expect(headerImageElement).toBeTruthy()
-    })
-
-    it("should display institution name with link to company's website", () => {
-      const fakeEducationItem = new EducationItem(newEducationItemArgs)
+      const institutionUrl = 'https://example.org/'
+      const fakeEducationItem = new EducationItem({
+        ...newEducationItemArgs,
+        institution: new Organization({
+          name: newEducationItemArgs.institution.name,
+          image: new URL('https://example.org/logo.png'),
+          website: new URL(institutionUrl),
+        }),
+      })
       component.item = fakeEducationItem
       fixture.detectChanges()
 
-      const institutionElement = fixture.debugElement.query(
-        By.css('.institution'),
-      )
-      expect(institutionElement)
-        .withContext('institution name container element exists')
-        .toBeTruthy()
+      const anchorElement = fixture.debugElement
+        .query(By.css("[data-test-id='image']"))
+        .query(By.css('a'))
+      expect(anchorElement).toBeTruthy()
+      expect(anchorElement.attributes['href']).toEqual(institutionUrl)
 
-      const anchorElement = institutionElement.query(By.css('a'))
-      expect(anchorElement).withContext('link exists').toBeTruthy()
-      expect(anchorElement.attributes['href'])
-        .withContext('link points to institution website')
-        .toEqual(fakeEducationItem.institution.website.toString())
+      const imageElement = anchorElement.query(By.css('img'))
+      expect(imageElement).toBeTruthy()
+      expect(imageElement.attributes['src']).toEqual(
+        fakeEducationItem.institution.image.toString(),
+      )
+    })
+
+    it("should display institution name with link to company's website", () => {
+      const institutionUrl = 'https://example.org/'
+      const fakeEducationItem = new EducationItem({
+        ...newEducationItemArgs,
+        institution: new Organization({
+          name: newEducationItemArgs.institution.name,
+          image: new URL('https://example.org/logo.png'),
+          website: new URL(institutionUrl),
+        }),
+      })
+      component.item = fakeEducationItem
+      fixture.detectChanges()
+
+      const anchorElement = fixture.debugElement
+        .query(By.css("[data-test-id='institution-name']"))
+        .query(By.css('a'))
+      expect(anchorElement).toBeTruthy()
+      expect(anchorElement.attributes['href']).toEqual(institutionUrl)
+
       expect(anchorElement.nativeElement.textContent.trim()).toEqual(
         fakeEducationItem.institution.name,
       )

--- a/src/app/about/education/json-resume-education-item-adapter.service.spec.ts
+++ b/src/app/about/education/json-resume-education-item-adapter.service.spec.ts
@@ -43,11 +43,11 @@ describe('JsonResumeEducationItemAdapterService', () => {
         expect(educationItem.institution.name).toEqual(
           fakeJsonResumeEducationItem.institution,
         )
-        expect(educationItem.institution.website.toString()).toEqual(
-          fakeJsonResumeEducationItem.url,
+        expect(educationItem.institution.website).toEqual(
+          new URL(fakeJsonResumeEducationItem.url),
         )
-        expect(educationItem.institution.image.toString()).toEqual(
-          fakeJsonResumeEducationItem.image,
+        expect(educationItem.institution.image).toEqual(
+          new URL(fakeJsonResumeEducationItem.image),
         )
       })
 

--- a/src/app/about/experience/experience-item/experience-item.component.html
+++ b/src/app/about/experience/experience-item/experience-item.component.html
@@ -1,6 +1,6 @@
 <app-card>
   <div class="header">
-    <app-link [href]="item.company.website.toString()">
+    <app-link [href]="item.company.website?.toString()" data-test-id="image">
       <app-card-header-image
         [src]="item.company.image.toString()"
         [alt]="item.company.name + ' logo'"
@@ -8,11 +8,12 @@
       </app-card-header-image>
     </app-link>
     <div class="text">
-      <span class="company">
-        <a [href]="item.company.website.toString()">
-          {{ item.company.name }}
-        </a>
-      </span>
+      <app-link
+        [href]="item.company.website?.toString()"
+        data-test-id="company-name"
+      >
+        {{ item.company.name }}
+      </app-link>
       <div class="role">
         {{ item.role }}
       </div>

--- a/src/app/about/experience/experience-item/experience-item.component.spec.ts
+++ b/src/app/about/experience/experience-item/experience-item.component.spec.ts
@@ -34,7 +34,6 @@ describe('ExperienceItem', () => {
       company: new Organization({
         name: 'Fake company',
         image: new URL('https://fakeCompany.example.com/logo.jpg'),
-        website: new URL('https://fake.example.org'),
       }),
       summary: 'Fake summary',
       role: 'Fake role',
@@ -45,12 +44,9 @@ describe('ExperienceItem', () => {
     TestBed.configureTestingModule({
       declarations: [
         ExperienceItemComponent,
-        MockComponents(
-          CardComponent,
-          LinkComponent,
-          CardHeaderImageComponent,
-          DateRangeComponent,
-        ),
+        LinkComponent,
+        CardHeaderImageComponent,
+        MockComponents(CardComponent, DateRangeComponent),
       ],
       imports: [NgOptimizedImage, NoopAnimationsModule],
     })
@@ -64,35 +60,50 @@ describe('ExperienceItem', () => {
 
   describe('company', () => {
     it("should display company image with link to company's website", () => {
-      component.item = new ExperienceItem(newExperienceItemArgs)
-      fixture.detectChanges()
-
-      const linkElement = fixture.debugElement.query(
-        By.css(getComponentSelector(LinkComponent)),
-      )
-      expect(linkElement).toBeTruthy()
-
-      const headerImageElement = linkElement.query(
-        By.css(getComponentSelector(CardHeaderImageComponent)),
-      )
-      expect(headerImageElement).toBeTruthy()
-    })
-
-    it("should display company name with link to company's website", () => {
-      const experienceItem = new ExperienceItem(newExperienceItemArgs)
+      const companyUrl = 'https://example.org/'
+      const experienceItem = new ExperienceItem({
+        ...newExperienceItemArgs,
+        company: new Organization({
+          name: newExperienceItemArgs.company.name,
+          image: new URL('https://example.org/logo.png'),
+          website: new URL(companyUrl),
+        }),
+      })
       component.item = experienceItem
       fixture.detectChanges()
 
-      const companyElement = fixture.debugElement.query(By.css('.company'))
-      expect(companyElement)
-        .withContext('company name container element exists')
-        .toBeTruthy()
+      const anchorElement = fixture.debugElement
+        .query(By.css("[data-test-id='image']"))
+        .query(By.css('a'))
+      expect(anchorElement).toBeTruthy()
+      expect(anchorElement.attributes['href']).toEqual(companyUrl)
 
-      const anchorElement = companyElement.query(By.css('a'))
-      expect(anchorElement).withContext('link exists').toBeTruthy()
-      expect(anchorElement.attributes['href'])
-        .withContext('link points to company website')
-        .toEqual(experienceItem.company.website.toString())
+      const imageElement = anchorElement.query(By.css('img'))
+      expect(imageElement).toBeTruthy()
+      expect(imageElement.attributes['src']).toEqual(
+        experienceItem.company.image.toString(),
+      )
+    })
+
+    it("should display company name with link to company's website", () => {
+      const companyUrl = 'https://example.org/'
+      const experienceItem = new ExperienceItem({
+        ...newExperienceItemArgs,
+        company: new Organization({
+          name: newExperienceItemArgs.company.name,
+          image: new URL('https://example.org/logo.png'),
+          website: new URL(companyUrl),
+        }),
+      })
+      component.item = experienceItem
+      fixture.detectChanges()
+
+      const anchorElement = fixture.debugElement
+        .query(By.css("[data-test-id='company-name']"))
+        .query(By.css('a'))
+      expect(anchorElement).toBeTruthy()
+      expect(anchorElement.attributes['href']).toEqual(companyUrl)
+
       expect(anchorElement.nativeElement.textContent.trim()).toEqual(
         experienceItem.company.name,
       )

--- a/src/app/about/experience/json-resume-experience-item-adapter.service.spec.ts
+++ b/src/app/about/experience/json-resume-experience-item-adapter.service.spec.ts
@@ -41,11 +41,11 @@ describe('JsonResumeExperienceItemAdapterService', () => {
         const experienceItem = sut.adapt(jsonResumeWorkItem)
 
         expect(experienceItem.company.name).toEqual(jsonResumeWorkItem.name)
-        expect(experienceItem.company.website.toString()).toEqual(
-          jsonResumeWorkItem.url,
+        expect(experienceItem.company.website).toEqual(
+          new URL(jsonResumeWorkItem.url),
         )
-        expect(experienceItem.company.image.toString()).toEqual(
-          jsonResumeWorkItem.image,
+        expect(experienceItem.company.image).toEqual(
+          new URL(jsonResumeWorkItem.image),
         )
       })
 

--- a/src/app/about/organization.ts
+++ b/src/app/about/organization.ts
@@ -1,6 +1,6 @@
 export class Organization {
   public readonly name: string
-  public readonly website: URL
+  public readonly website?: URL
   public readonly image: URL
 
   constructor({
@@ -9,7 +9,7 @@ export class Organization {
     image,
   }: {
     name: string
-    website: URL
+    website?: URL
     image: URL
   }) {
     this.name = name


### PR DESCRIPTION
Make optional an organization's website field. Improve tests for organization name, link and image in experience and education components.
