### PR TITLE
refactor(about): introduce card header title component

### DIFF
--- a/src/app/about/card/card-header-title/_card-header-title-theme.scss
+++ b/src/app/about/card/card-header-title/_card-header-title-theme.scss
@@ -1,0 +1,7 @@
+@use 'animations';
+
+@mixin motion {
+  app-card-header-title {
+    @include animations.single-transition(color, animations.$emphasized-style);
+  }
+}

--- a/src/app/about/card/card-header-title/card-header-title.component.html
+++ b/src/app/about/card/card-header-title/card-header-title.component.html
@@ -1,0 +1,1 @@
+<ng-content></ng-content>

--- a/src/app/about/card/card-header-title/card-header-title.component.scss
+++ b/src/app/about/card/card-header-title/card-header-title.component.scss
@@ -1,0 +1,3 @@
+:host {
+  font-size: 1.15rem;
+}

--- a/src/app/about/card/card-header-title/card-header-title.component.spec.ts
+++ b/src/app/about/card/card-header-title/card-header-title.component.spec.ts
@@ -1,0 +1,14 @@
+import { CardHeaderTitleComponent } from './card-header-title.component'
+import { testSetup } from '../../../../test/helpers/component-test-setup'
+import { ensureProjectsContent } from '../../../../test/helpers/component-testers'
+
+describe('CardHeaderTitleComponent', () => {
+  it('should create', () => {
+    const [fixture, component] = testSetup(CardHeaderTitleComponent)
+    fixture.detectChanges()
+
+    expect(component).toBeTruthy()
+  })
+
+  ensureProjectsContent(CardHeaderTitleComponent)
+})

--- a/src/app/about/card/card-header-title/card-header-title.component.ts
+++ b/src/app/about/card/card-header-title/card-header-title.component.ts
@@ -1,0 +1,8 @@
+import { Component } from '@angular/core'
+
+@Component({
+  selector: 'app-card-header-title',
+  templateUrl: './card-header-title.component.html',
+  styleUrls: ['./card-header-title.component.scss'],
+})
+export class CardHeaderTitleComponent {}

--- a/src/app/about/card/card-theme.scss
+++ b/src/app/about/card/card-theme.scss
@@ -1,5 +1,6 @@
 @use 'sass:map';
 @use 'card-header-image/card-header-image-theme';
+@use 'card-header-title/card-header-title-theme';
 @use 'animations';
 @use 'borders';
 
@@ -23,5 +24,6 @@
     );
 
     @include card-header-image-theme.motion;
+    @include card-header-title-theme.motion;
   }
 }

--- a/src/app/about/education/education-item/education-item.component.html
+++ b/src/app/about/education/education-item/education-item.component.html
@@ -11,12 +11,14 @@
       </app-card-header-image>
     </app-link>
     <div class="text">
-      <app-link
-        [href]="item.institution.website?.toString()"
-        data-test-id="institution-name"
-      >
-        {{ item.institution.name }}
-      </app-link>
+      <app-card-header-title>
+        <app-link
+          [href]="item.institution.website?.toString()"
+          data-test-id="institution-name"
+        >
+          {{ item.institution.name }}
+        </app-link>
+      </app-card-header-title>
       <div class="studyType">{{ item.studyType }}</div>
       <div class="area">{{ item.area }}</div>
       <span class="dates"

--- a/src/app/about/education/education-item/education-item.component.spec.ts
+++ b/src/app/about/education/education-item/education-item.component.spec.ts
@@ -12,6 +12,7 @@ import { MockComponents } from 'ng-mocks'
 import { CardComponent } from '../../card/card.component'
 import { CardHeaderImageComponent } from '../../card/card-header-image/card-header-image.component'
 import { LinkComponent } from '../../link/link.component'
+import { CardHeaderTitleComponent } from '../../card/card-header-title/card-header-title.component'
 
 describe('EducationItemComponent', () => {
   let component: EducationItemComponent
@@ -33,6 +34,7 @@ describe('EducationItemComponent', () => {
         EducationItemComponent,
         LinkComponent,
         CardHeaderImageComponent,
+        CardHeaderTitleComponent,
         MockComponents(CardComponent, DateRangeComponent),
       ],
       imports: [NgOptimizedImage],

--- a/src/app/about/experience/experience-item/experience-item.component.html
+++ b/src/app/about/experience/experience-item/experience-item.component.html
@@ -8,12 +8,14 @@
       </app-card-header-image>
     </app-link>
     <div class="text">
-      <app-link
-        [href]="item.company.website?.toString()"
-        data-test-id="company-name"
-      >
-        {{ item.company.name }}
-      </app-link>
+      <app-card-header-title>
+        <app-link
+          [href]="item.company.website?.toString()"
+          data-test-id="company-name"
+        >
+          {{ item.company.name }}
+        </app-link>
+      </app-card-header-title>
       <div class="role">
         {{ item.role }}
       </div>

--- a/src/app/about/experience/experience-item/experience-item.component.spec.ts
+++ b/src/app/about/experience/experience-item/experience-item.component.spec.ts
@@ -25,6 +25,7 @@ import { MockComponents } from 'ng-mocks'
 import { CardComponent } from '../../card/card.component'
 import { CardHeaderImageComponent } from '../../card/card-header-image/card-header-image.component'
 import { LinkComponent } from '../../link/link.component'
+import { CardHeaderTitleComponent } from '../../card/card-header-title/card-header-title.component'
 
 describe('ExperienceItem', () => {
   let component: ExperienceItemComponent
@@ -46,6 +47,7 @@ describe('ExperienceItem', () => {
         ExperienceItemComponent,
         LinkComponent,
         CardHeaderImageComponent,
+        CardHeaderTitleComponent,
         MockComponents(CardComponent, DateRangeComponent),
       ],
       imports: [NgOptimizedImage, NoopAnimationsModule],

--- a/src/app/about/link/link.component.spec.ts
+++ b/src/app/about/link/link.component.spec.ts
@@ -1,11 +1,15 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing'
+import { ComponentFixture } from '@angular/core/testing'
 import { LinkComponent } from './link.component'
 import { By } from '@angular/platform-browser'
 import { Component, Type } from '@angular/core'
+import {
+  testSetup,
+  testSetupWithHostComponent,
+} from '../../../test/helpers/component-test-setup'
 
 describe('LinkComponent', () => {
   it('should create', () => {
-    const [fixture, component] = testSetup()
+    const [fixture, component] = setup()
     fixture.detectChanges()
     expect(component).toBeTruthy()
   })
@@ -14,7 +18,7 @@ describe('LinkComponent', () => {
     it("should contain element's content", () => {
       const someText = 'some text here'
       const hostComponent = makeHostComponent(someText, href)
-      const [fixture] = testSetupWithHostComponent(hostComponent)
+      const [fixture] = setupWithHostComponent(hostComponent)
       fixture.detectChanges()
 
       expect(fixture.debugElement.nativeElement.textContent.trim()).toEqual(
@@ -25,7 +29,7 @@ describe('LinkComponent', () => {
 
   describe('when no href is given', () => {
     it('should not contain the anchor element', () => {
-      const [fixture] = testSetup()
+      const [fixture] = setup()
 
       const anchorElement = fixture.debugElement.query(By.css('a'))
       expect(anchorElement).toBeFalsy()
@@ -38,7 +42,7 @@ describe('LinkComponent', () => {
     const href = 'https://example.org'
 
     it('should contain the anchor element with given href attribute', () => {
-      const [fixture, component] = testSetup()
+      const [fixture, component] = setup()
       component.href = href
       fixture.detectChanges()
 
@@ -50,22 +54,14 @@ describe('LinkComponent', () => {
   })
 })
 
-function testSetup(): [ComponentFixture<LinkComponent>, LinkComponent] {
-  TestBed.configureTestingModule({
-    declarations: [LinkComponent],
-  })
-  const fixture = TestBed.createComponent(LinkComponent)
-  return [fixture, fixture.componentInstance]
+function setup(): [ComponentFixture<LinkComponent>, LinkComponent] {
+  return testSetup(LinkComponent)
 }
 
-function testSetupWithHostComponent<T>(
+function setupWithHostComponent<T>(
   hostComponent: Type<T>,
 ): [ComponentFixture<T>, T] {
-  TestBed.configureTestingModule({
-    declarations: [hostComponent, LinkComponent],
-  })
-  const fixture = TestBed.createComponent(hostComponent)
-  return [fixture, fixture.componentInstance]
+  return testSetupWithHostComponent(hostComponent, LinkComponent)
 }
 
 function makeHostComponent(

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -29,6 +29,7 @@ import { EducationItemComponent } from './about/education/education-item/educati
 import { DateRangeComponent } from './about/date-range/date-range.component'
 import { CardComponent } from './about/card/card.component'
 import { CardHeaderImageComponent } from './about/card/card-header-image/card-header-image.component'
+import { CardHeaderTitleComponent } from './about/card/card-header-title/card-header-title.component'
 import { LinkComponent } from './about/link/link.component'
 
 @NgModule({
@@ -54,6 +55,7 @@ import { LinkComponent } from './about/link/link.component'
     DateRangeComponent,
     CardComponent,
     CardHeaderImageComponent,
+    CardHeaderTitleComponent,
     LinkComponent,
   ],
   imports: [

--- a/src/test/helpers/component-test-setup.ts
+++ b/src/test/helpers/component-test-setup.ts
@@ -1,0 +1,64 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing'
+import { Component, Type } from '@angular/core'
+import { getComponentSelector } from './component-testers'
+
+/**
+ * Sets up a basic component test given the component to test
+ *
+ * Returns the fixture and component (last one can be retrieved from fixture, but just for dx purposes)
+ *
+ * So you can do:
+ *
+ * ```
+ * const [fixture, component] = componentTestSetup(FooComponent)
+ * ```
+ */
+export function testSetup<T>(component: Type<T>): [ComponentFixture<T>, T] {
+  TestBed.configureTestingModule({
+    declarations: [component],
+  })
+  const fixture = TestBed.createComponent(component)
+  return [fixture, fixture.componentInstance]
+}
+
+/**
+ * Sets up a basic component test with a host component and a child component. This is useful to test if content
+ * projection (<ng-content>) is used.
+ *
+ * @see [ensureProjectsContent]
+ *
+ * Returns the fixture and component for the host component
+ */
+export function testSetupWithHostComponent<T>(
+  hostComponent: Type<T>,
+  childComponent: Type<unknown>,
+): [ComponentFixture<T>, T] {
+  TestBed.configureTestingModule({
+    declarations: [hostComponent, childComponent],
+  })
+  const fixture = TestBed.createComponent(hostComponent)
+  return [fixture, fixture.componentInstance]
+}
+
+/**
+ * Creates a host component including the given child component.
+ *
+ * Embeds inside that child component the given content.
+ * Useful to check if a component includes child contents
+ *
+ * @see [ensureProjectsContent]
+ *
+ * Returns the host component type
+ */
+export function makeHostComponent(
+  childComponent: Type<unknown>,
+  innerHtml: string,
+): Type<unknown> {
+  const childComponentSelector = getComponentSelector(childComponent)
+  // noinspection AngularMissingOrInvalidDeclarationInModule
+  @Component({
+    template: `<${childComponentSelector}>${innerHtml}</${childComponentSelector}>`,
+  })
+  class TestHostComponent {}
+  return TestHostComponent
+}

--- a/src/test/helpers/component-testers.ts
+++ b/src/test/helpers/component-testers.ts
@@ -2,6 +2,10 @@ import { reflectComponentType, Type } from '@angular/core'
 import { ComponentFixture } from '@angular/core/testing'
 import { By } from '@angular/platform-browser'
 import { isClass } from './types'
+import {
+  makeHostComponent,
+  testSetupWithHostComponent,
+} from './component-test-setup'
 
 const COMPONENT_CLASS_SUFFIX = 'Component'
 
@@ -67,4 +71,26 @@ export function getComponentSelector<C>(component: Type<C>) {
     )
   }
   return selector
+}
+
+/**
+ * Ensures the given component contains the child content passed to it
+ *
+ * @see https://stackoverflow.com/a/61724478/3263250
+ */
+export function ensureProjectsContent(component: Type<unknown>) {
+  it(`should project its content`, () => {
+    const contentToProject = '<b>Foo</b><i>bar</i>'
+    const hostComponent = makeHostComponent(component, contentToProject)
+    const [fixture] = testSetupWithHostComponent(hostComponent, component)
+    // No change detection triggered given nothing may have changed
+
+    const componentElement = fixture.debugElement.query(
+      By.css(getComponentSelector(component)),
+    )
+    expect(componentElement).toBeTruthy()
+    expect(componentElement.nativeElement.innerHTML.trim()).toEqual(
+      contentToProject,
+    )
+  })
 }


### PR DESCRIPTION
Adds component for card header titles. Reduces just 1 line of SCSS duplication in experience and education items, but adds semantics.

Adds test util to ensure content projection is enabled for a component. Adds util to reduce duplicated test setup code.
