### PR TITLE
refactor(about): introduce card header details component

### DIFF
--- a/src/app/about/card/_card-theme.scss
+++ b/src/app/about/card/_card-theme.scss
@@ -2,6 +2,7 @@
 @use 'card-header-image/card-header-image-theme';
 @use 'card-header-title/card-header-title-theme';
 @use 'card-header-subtitle/card-header-subtitle-theme';
+@use 'card-header-detail/card-header-detail-theme';
 @use 'animations';
 @use 'borders';
 
@@ -15,6 +16,7 @@
 
     @include card-header-image-theme.color($theme);
     @include card-header-subtitle-theme.color($theme);
+    @include card-header-detail-theme.color($theme);
   }
 }
 
@@ -28,5 +30,6 @@
     @include card-header-image-theme.motion;
     @include card-header-title-theme.motion;
     @include card-header-subtitle-theme.motion;
+    @include card-header-detail-theme.motion;
   }
 }

--- a/src/app/about/card/card-header-detail/_card-header-detail-theme.scss
+++ b/src/app/about/card/card-header-detail/_card-header-detail-theme.scss
@@ -1,0 +1,13 @@
+@use 'sass:map';
+@use 'animations';
+
+@mixin color($theme) {
+  app-card-header-detail {
+    $text-palette: map.get($theme, text);
+    color: map.get($text-palette, secondary);
+  }
+}
+
+@mixin motion {
+  @include animations.single-transition(color);
+}

--- a/src/app/about/card/card-header-detail/card-header-detail.component.html
+++ b/src/app/about/card/card-header-detail/card-header-detail.component.html
@@ -1,0 +1,1 @@
+<ng-content></ng-content>

--- a/src/app/about/card/card-header-detail/card-header-detail.component.scss
+++ b/src/app/about/card/card-header-detail/card-header-detail.component.scss
@@ -1,0 +1,3 @@
+:host {
+  font-size: 1rem;
+}

--- a/src/app/about/card/card-header-detail/card-header-detail.component.spec.ts
+++ b/src/app/about/card/card-header-detail/card-header-detail.component.spec.ts
@@ -1,0 +1,14 @@
+import { CardHeaderDetailComponent } from './card-header-detail.component'
+import { testSetup } from '../../../../test/helpers/component-test-setup'
+import { ensureProjectsContent } from '../../../../test/helpers/component-testers'
+
+describe('CardHeaderDetailComponent', () => {
+  it('should create', () => {
+    const [fixture, component] = testSetup(CardHeaderDetailComponent)
+    fixture.detectChanges()
+
+    expect(component).toBeTruthy()
+  })
+
+  ensureProjectsContent(CardHeaderDetailComponent)
+})

--- a/src/app/about/card/card-header-detail/card-header-detail.component.ts
+++ b/src/app/about/card/card-header-detail/card-header-detail.component.ts
@@ -1,0 +1,8 @@
+import { Component } from '@angular/core'
+
+@Component({
+  selector: 'app-card-header-detail',
+  templateUrl: './card-header-detail.component.html',
+  styleUrls: ['./card-header-detail.component.scss'],
+})
+export class CardHeaderDetailComponent {}

--- a/src/app/about/education/education-item/_education-item-theme.scss
+++ b/src/app/about/education/education-item/_education-item-theme.scss
@@ -8,10 +8,6 @@
 
   app-education-item {
     .header {
-      .dates {
-        color: map.get($text-palette, secondary);
-      }
-
       .attribute {
         color: map.get($text-palette, secondary);
 

--- a/src/app/about/education/education-item/education-item.component.html
+++ b/src/app/about/education/education-item/education-item.component.html
@@ -25,9 +25,9 @@
       <app-card-header-subtitle data-test-id="area">
         {{ item.area }}
       </app-card-header-subtitle>
-      <span class="dates">
+      <app-card-header-detail>
         <app-date-range [range]="item.dateRange"></app-date-range>
-      </span>
+      </app-card-header-detail>
     </div>
     <div class="attributes">
       <div class="cum-laude attribute" *ngIf="item.cumLaude">

--- a/src/app/about/education/education-item/education-item.component.spec.ts
+++ b/src/app/about/education/education-item/education-item.component.spec.ts
@@ -14,6 +14,7 @@ import { CardHeaderImageComponent } from '../../card/card-header-image/card-head
 import { LinkComponent } from '../../link/link.component'
 import { CardHeaderTitleComponent } from '../../card/card-header-title/card-header-title.component'
 import { CardHeaderSubtitleComponent } from '../../card/card-header-subtitle/card-header-subtitle.component'
+import { CardHeaderDetailComponent } from '../../card/card-header-detail/card-header-detail.component'
 
 describe('EducationItemComponent', () => {
   let component: EducationItemComponent
@@ -37,7 +38,11 @@ describe('EducationItemComponent', () => {
         CardHeaderImageComponent,
         CardHeaderTitleComponent,
         CardHeaderSubtitleComponent,
-        MockComponents(CardComponent, DateRangeComponent),
+        MockComponents(
+          CardComponent,
+          DateRangeComponent,
+          CardHeaderDetailComponent,
+        ),
       ],
       imports: [NgOptimizedImage],
     })
@@ -141,9 +146,7 @@ describe('EducationItemComponent', () => {
       const dateRangeElement = fixture.debugElement.query(
         By.css(getComponentSelector(DateRangeComponent)),
       )
-      expect(dateRangeElement)
-        .withContext('dates range element exists')
-        .toBeTruthy()
+      expect(dateRangeElement).toBeTruthy()
     })
   })
 })

--- a/src/app/about/experience/experience-item/_experience-item-theme.scss
+++ b/src/app/about/experience/experience-item/_experience-item-theme.scss
@@ -8,10 +8,6 @@
 
   app-experience-item {
     .header {
-      .dates {
-        color: map.get($text-palette, secondary);
-      }
-
       .attribute {
         color: map.get($text-palette, secondary);
 

--- a/src/app/about/experience/experience-item/experience-item.component.html
+++ b/src/app/about/experience/experience-item/experience-item.component.html
@@ -19,9 +19,9 @@
       <app-card-header-subtitle data-test-id="role">
         {{ item.role }}
       </app-card-header-subtitle>
-      <span class="dates"
-        ><app-date-range [range]="item.dateRange"></app-date-range
-      ></span>
+      <app-card-header-detail>
+        <app-date-range [range]="item.dateRange"></app-date-range>
+      </app-card-header-detail>
     </div>
     <div class="attributes">
       <div class="freelance attribute">

--- a/src/app/about/experience/experience-item/experience-item.component.spec.ts
+++ b/src/app/about/experience/experience-item/experience-item.component.spec.ts
@@ -27,6 +27,7 @@ import { CardHeaderImageComponent } from '../../card/card-header-image/card-head
 import { LinkComponent } from '../../link/link.component'
 import { CardHeaderTitleComponent } from '../../card/card-header-title/card-header-title.component'
 import { CardHeaderSubtitleComponent } from '../../card/card-header-subtitle/card-header-subtitle.component'
+import { CardHeaderDetailComponent } from '../../card/card-header-detail/card-header-detail.component'
 
 describe('ExperienceItem', () => {
   let component: ExperienceItemComponent
@@ -50,7 +51,11 @@ describe('ExperienceItem', () => {
         CardHeaderImageComponent,
         CardHeaderTitleComponent,
         CardHeaderSubtitleComponent,
-        MockComponents(CardComponent, DateRangeComponent),
+        MockComponents(
+          CardComponent,
+          DateRangeComponent,
+          CardHeaderDetailComponent,
+        ),
       ],
       imports: [NgOptimizedImage, NoopAnimationsModule],
     })
@@ -138,9 +143,7 @@ describe('ExperienceItem', () => {
       const dateRangeElement = fixture.debugElement.query(
         By.css(getComponentSelector(DateRangeComponent)),
       )
-      expect(dateRangeElement)
-        .withContext('date range element exists')
-        .toBeTruthy()
+      expect(dateRangeElement).toBeTruthy()
     })
   })
   describe('attributes', () => {

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -32,6 +32,7 @@ import { CardHeaderImageComponent } from './about/card/card-header-image/card-he
 import { CardHeaderTitleComponent } from './about/card/card-header-title/card-header-title.component'
 import { LinkComponent } from './about/link/link.component'
 import { CardHeaderSubtitleComponent } from './about/card/card-header-subtitle/card-header-subtitle.component'
+import { CardHeaderDetailComponent } from './about/card/card-header-detail/card-header-detail.component'
 
 @NgModule({
   declarations: [
@@ -59,6 +60,7 @@ import { CardHeaderSubtitleComponent } from './about/card/card-header-subtitle/c
     CardHeaderTitleComponent,
     LinkComponent,
     CardHeaderSubtitleComponent,
+    CardHeaderDetailComponent,
   ],
   imports: [
     BrowserModule,


### PR DESCRIPTION
Adds card header details component. A bit of duplication reduced in experience and education items.

Renames card theme SCSS to contain the `_` prefix
