### PR TITLE
test: add test id directive for consistency

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -5,6 +5,9 @@
     "@schematics/angular": {
       "component": {
         "module": "app"
+      },
+      "directive": {
+        "module": "app"
       }
     }
   },

--- a/src/app/about/education/education-item/education-item.component.html
+++ b/src/app/about/education/education-item/education-item.component.html
@@ -1,9 +1,6 @@
 <app-card>
   <div class="header">
-    <app-link
-      [href]="item.institution.website?.toString()"
-      data-test-id="image"
-    >
+    <app-link [href]="item.institution.website?.toString()" appTestId="image">
       <app-card-header-image
         [src]="item.institution.image.toString()"
         [alt]="item.institution.name + ' logo'"
@@ -14,15 +11,15 @@
       <app-card-header-title>
         <app-link
           [href]="item.institution.website?.toString()"
-          data-test-id="institution-name"
+          appTestId="institution-name"
         >
           {{ item.institution.name }}
         </app-link>
       </app-card-header-title>
-      <app-card-header-subtitle data-test-id="study-type">
+      <app-card-header-subtitle appTestId="study-type">
         {{ item.studyType }}
       </app-card-header-subtitle>
-      <app-card-header-subtitle data-test-id="area">
+      <app-card-header-subtitle appTestId="area">
         {{ item.area }}
       </app-card-header-subtitle>
       <app-card-header-detail>

--- a/src/app/about/education/education-item/education-item.component.spec.ts
+++ b/src/app/about/education/education-item/education-item.component.spec.ts
@@ -15,6 +15,8 @@ import { LinkComponent } from '../../link/link.component'
 import { CardHeaderTitleComponent } from '../../card/card-header-title/card-header-title.component'
 import { CardHeaderSubtitleComponent } from '../../card/card-header-subtitle/card-header-subtitle.component'
 import { CardHeaderDetailComponent } from '../../card/card-header-detail/card-header-detail.component'
+import { byTestId } from '../../../../test/helpers/test-id'
+import { TestIdDirective } from '../../../common/test-id.directive'
 
 describe('EducationItemComponent', () => {
   let component: EducationItemComponent
@@ -38,6 +40,7 @@ describe('EducationItemComponent', () => {
         CardHeaderImageComponent,
         CardHeaderTitleComponent,
         CardHeaderSubtitleComponent,
+        TestIdDirective,
         MockComponents(
           CardComponent,
           DateRangeComponent,
@@ -69,7 +72,7 @@ describe('EducationItemComponent', () => {
       fixture.detectChanges()
 
       const anchorElement = fixture.debugElement
-        .query(By.css("[data-test-id='image']"))
+        .query(byTestId('image'))
         .query(By.css('a'))
       expect(anchorElement).toBeTruthy()
       expect(anchorElement.attributes['href']).toEqual(institutionUrl)
@@ -95,7 +98,7 @@ describe('EducationItemComponent', () => {
       fixture.detectChanges()
 
       const anchorElement = fixture.debugElement
-        .query(By.css("[data-test-id='institution-name']"))
+        .query(byTestId('institution-name'))
         .query(By.css('a'))
       expect(anchorElement).toBeTruthy()
       expect(anchorElement.attributes['href']).toEqual(institutionUrl)
@@ -112,9 +115,7 @@ describe('EducationItemComponent', () => {
       component.item = educationItem
       fixture.detectChanges()
 
-      const areaElement = fixture.debugElement.query(
-        By.css("[data-test-id='area']"),
-      )
+      const areaElement = fixture.debugElement.query(byTestId('area'))
       expect(areaElement).toBeTruthy()
       expect(areaElement.nativeElement.textContent.trim()).toEqual(
         educationItem.area,
@@ -129,7 +130,7 @@ describe('EducationItemComponent', () => {
       fixture.detectChanges()
 
       const studyTypeElement = fixture.debugElement.query(
-        By.css("[data-test-id='study-type']"),
+        byTestId('study-type'),
       )
       expect(studyTypeElement).toBeTruthy()
       expect(studyTypeElement.nativeElement.textContent.trim()).toEqual(

--- a/src/app/about/experience/experience-item/experience-item.component.html
+++ b/src/app/about/experience/experience-item/experience-item.component.html
@@ -1,6 +1,6 @@
 <app-card>
   <div class="header">
-    <app-link [href]="item.company.website?.toString()" data-test-id="image">
+    <app-link [href]="item.company.website?.toString()" appTestId="image">
       <app-card-header-image
         [src]="item.company.image.toString()"
         [alt]="item.company.name + ' logo'"
@@ -11,12 +11,12 @@
       <app-card-header-title>
         <app-link
           [href]="item.company.website?.toString()"
-          data-test-id="company-name"
+          appTestId="company-name"
         >
           {{ item.company.name }}
         </app-link>
       </app-card-header-title>
-      <app-card-header-subtitle data-test-id="role">
+      <app-card-header-subtitle appTestId="role">
         {{ item.role }}
       </app-card-header-subtitle>
       <app-card-header-detail>

--- a/src/app/about/experience/experience-item/experience-item.component.spec.ts
+++ b/src/app/about/experience/experience-item/experience-item.component.spec.ts
@@ -28,6 +28,8 @@ import { LinkComponent } from '../../link/link.component'
 import { CardHeaderTitleComponent } from '../../card/card-header-title/card-header-title.component'
 import { CardHeaderSubtitleComponent } from '../../card/card-header-subtitle/card-header-subtitle.component'
 import { CardHeaderDetailComponent } from '../../card/card-header-detail/card-header-detail.component'
+import { byTestId } from '../../../../test/helpers/test-id'
+import { TestIdDirective } from '../../../common/test-id.directive'
 
 describe('ExperienceItem', () => {
   let component: ExperienceItemComponent
@@ -51,6 +53,7 @@ describe('ExperienceItem', () => {
         CardHeaderImageComponent,
         CardHeaderTitleComponent,
         CardHeaderSubtitleComponent,
+        TestIdDirective,
         MockComponents(
           CardComponent,
           DateRangeComponent,
@@ -82,7 +85,7 @@ describe('ExperienceItem', () => {
       fixture.detectChanges()
 
       const anchorElement = fixture.debugElement
-        .query(By.css("[data-test-id='image']"))
+        .query(byTestId('image'))
         .query(By.css('a'))
       expect(anchorElement).toBeTruthy()
       expect(anchorElement.attributes['href']).toEqual(companyUrl)
@@ -108,7 +111,7 @@ describe('ExperienceItem', () => {
       fixture.detectChanges()
 
       const anchorElement = fixture.debugElement
-        .query(By.css("[data-test-id='company-name']"))
+        .query(byTestId('company-name'))
         .query(By.css('a'))
       expect(anchorElement).toBeTruthy()
       expect(anchorElement.attributes['href']).toEqual(companyUrl)
@@ -124,9 +127,7 @@ describe('ExperienceItem', () => {
       component.item = experienceItem
       fixture.detectChanges()
 
-      const roleElement = fixture.debugElement.query(
-        By.css("[data-test-id='role']"),
-      )
+      const roleElement = fixture.debugElement.query(byTestId('role'))
       expect(roleElement).toBeTruthy()
       expect(roleElement.nativeElement.textContent.trim()).toEqual(
         experienceItem.role,

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -33,6 +33,7 @@ import { CardHeaderTitleComponent } from './about/card/card-header-title/card-he
 import { LinkComponent } from './about/link/link.component'
 import { CardHeaderSubtitleComponent } from './about/card/card-header-subtitle/card-header-subtitle.component'
 import { CardHeaderDetailComponent } from './about/card/card-header-detail/card-header-detail.component'
+import { TestIdDirective } from './common/test-id.directive'
 
 @NgModule({
   declarations: [
@@ -61,6 +62,7 @@ import { CardHeaderDetailComponent } from './about/card/card-header-detail/card-
     LinkComponent,
     CardHeaderSubtitleComponent,
     CardHeaderDetailComponent,
+    TestIdDirective,
   ],
   imports: [
     BrowserModule,

--- a/src/app/common/test-id.directive.spec.ts
+++ b/src/app/common/test-id.directive.spec.ts
@@ -1,0 +1,40 @@
+import { TEST_ID_ATTRIBUTE, TestIdDirective } from './test-id.directive'
+import { TestBed } from '@angular/core/testing'
+import { Component, Type } from '@angular/core'
+import { By } from '@angular/platform-browser'
+
+describe('TestIdDirective', () => {
+  it('should set the element test id attribute to the given id', () => {
+    const elementTag = 'p'
+    const testId = 'foobie'
+    const component = makeComponentWithChildElementHavingTestIdDirectiveSetTo({
+      elementTag,
+      testId,
+    })
+    TestBed.configureTestingModule({
+      declarations: [component, TestIdDirective],
+    })
+    const fixture = TestBed.createComponent(component)
+    fixture.detectChanges()
+
+    const childElement = fixture.debugElement.query(By.css(elementTag))
+    expect(childElement).toBeTruthy()
+    expect(childElement.attributes[TEST_ID_ATTRIBUTE]).toEqual(testId)
+  })
+})
+
+function makeComponentWithChildElementHavingTestIdDirectiveSetTo({
+  elementTag,
+  testId,
+}: {
+  elementTag: string
+  testId: string
+}): Type<unknown> {
+  @Component({
+    template: `<${elementTag} [appTestId]="testId"></${elementTag}>`,
+  })
+  class TestIdComponent {
+    public readonly testId = testId
+  }
+  return TestIdComponent
+}

--- a/src/app/common/test-id.directive.ts
+++ b/src/app/common/test-id.directive.ts
@@ -1,0 +1,16 @@
+import { Directive, ElementRef, Input, OnChanges } from '@angular/core'
+
+@Directive({
+  selector: '[appTestId]',
+})
+export class TestIdDirective implements OnChanges {
+  @Input('appTestId') public id!: string
+
+  constructor(private el: ElementRef) {}
+
+  ngOnChanges(): void {
+    this.el.nativeElement.setAttribute(TEST_ID_ATTRIBUTE, this.id)
+  }
+}
+
+export const TEST_ID_ATTRIBUTE = 'data-test-id'

--- a/src/test/helpers/test-id.ts
+++ b/src/test/helpers/test-id.ts
@@ -1,0 +1,6 @@
+import { By } from '@angular/platform-browser'
+import { TEST_ID_ATTRIBUTE } from '../../app/common/test-id.directive'
+
+export function byTestId(testId: string) {
+  return By.css(`[${TEST_ID_ATTRIBUTE}='${testId}']`)
+}


### PR DESCRIPTION
Adds an Angular directive `appTestId` to ensure all test ids use the same element attribute. And also provide a test helper to retrieve an element querying by that test id. So no magic string with that attribute around.

This could also allow removing that attribute when building for production. However, a quick test using environment to do so was unsuccessful. Given the environment injected in tests is the production one (I was expecting the development one). 

One could use `isDevMode` which is `true` when running tests (https://stackoverflow.com/a/39535462/3263250)

But how can we mock that to ensure that in tests? Another injection token? Also, seems not very reliable given if enabling optimization in the `ng build` command, this would return `true` even if not in prod (see https://angular.io/api/core/isDevMode)
