### PR TITLE
feat(about): remove useless animations, col layout

### DIFF
--- a/src/app/about/about.component.scss
+++ b/src/app/about/about.component.scss
@@ -6,15 +6,7 @@
 
 :host {
   display: flex;
-  flex-wrap: wrap;
-
-  > * {
-    flex-grow: 1;
-  }
-
-  app-presentation {
-    flex-basis: 100%;
-  }
+  flex-direction: column;
 }
 
 ::ng-deep app-presentation app-h2 h2 {

--- a/src/app/about/card/_card-theme.scss
+++ b/src/app/about/card/_card-theme.scss
@@ -1,6 +1,5 @@
 @use 'sass:map';
 @use 'card-header/card-header-image/card-header-image-theme';
-@use 'card-header/card-header-title/card-header-title-theme';
 @use 'card-header/card-header-subtitle/card-header-subtitle-theme';
 @use 'card-header/card-header-detail/card-header-detail-theme';
 @use 'animations';
@@ -28,8 +27,5 @@
     );
 
     @include card-header-image-theme.motion;
-    @include card-header-title-theme.motion;
-    @include card-header-subtitle-theme.motion;
-    @include card-header-detail-theme.motion;
   }
 }

--- a/src/app/about/card/card-header/card-header-detail/_card-header-detail-theme.scss
+++ b/src/app/about/card/card-header/card-header-detail/_card-header-detail-theme.scss
@@ -7,7 +7,3 @@
     color: map.get($text-palette, secondary);
   }
 }
-
-@mixin motion {
-  @include animations.single-transition(color);
-}

--- a/src/app/about/card/card-header/card-header-subtitle/_card-header-subtitle-theme.scss
+++ b/src/app/about/card/card-header/card-header-subtitle/_card-header-subtitle-theme.scss
@@ -8,9 +8,3 @@
     color: map.get($text-palette, secondary);
   }
 }
-
-@mixin motion {
-  app-card-header-subtitle {
-    @include animations.single-transition(color, animations.$emphasized-style);
-  }
-}

--- a/src/app/about/card/card-header/card-header-title/_card-header-title-theme.scss
+++ b/src/app/about/card/card-header/card-header-title/_card-header-title-theme.scss
@@ -1,7 +1,0 @@
-@use 'animations';
-
-@mixin motion {
-  app-card-header-title {
-    @include animations.single-transition(color, animations.$emphasized-style);
-  }
-}


### PR DESCRIPTION
Makes the about page have a column layout. Otherwise cards opening and closing may shift the whole layout in mid/big viewports.

Removes useless animations that were making title, subtitle and detail text in cards animate strangely (for instance, title took a lot of time and seems did many transitions)
