### PR TITLE
refactor(about): add chipped content

### DIFF
--- a/src/app/about/chipped-content/chipped-content.component.html
+++ b/src/app/about/chipped-content/chipped-content.component.html
@@ -1,0 +1,11 @@
+<div class="chips displayNoneIfNoScript">
+  <app-chip
+    *ngFor="let content of contents"
+    [selected]="selectedContentId === content.id"
+    (selectedChange)="setSelectedContent(content.id)"
+    [appTestId]="content.id"
+  >
+    {{ content.displayName }}
+  </app-chip>
+</div>
+<ng-template #contentHost></ng-template>

--- a/src/app/about/chipped-content/chipped-content.component.scss
+++ b/src/app/about/chipped-content/chipped-content.component.scss
@@ -1,0 +1,28 @@
+@use 'margins';
+
+:host {
+  display: flex;
+  flex-direction: column;
+  gap: margins.$m;
+
+  .chips {
+    display: flex;
+    gap: margins.$s;
+  }
+
+  app-chip {
+    display: inline-block;
+  }
+
+  > ::ng-deep app-chip.displayBlockIfNoScript {
+    display: none;
+  }
+
+  > ::ng-deep * {
+    display: block;
+
+    &.hidden {
+      display: none;
+    }
+  }
+}

--- a/src/app/about/chipped-content/chipped-content.component.spec.ts
+++ b/src/app/about/chipped-content/chipped-content.component.spec.ts
@@ -11,6 +11,7 @@ import {
 } from '../../../test/helpers/visibility'
 import { byTestId } from '../../../test/helpers/test-id'
 import { TestIdDirective } from '../../common/test-id.directive'
+import { Subscription } from 'rxjs'
 
 @Component({
   selector: 'app-foo',
@@ -124,14 +125,25 @@ describe('ChippedContentComponent', () => {
 
   describe('when tapping on a chip', () => {
     let fooChipElement: DebugElement
+    let subscription: Subscription
+    let contentDisplayed: boolean
 
     beforeEach(() => {
       fooChipElement = fixture.debugElement.query(byTestId(fooContent.id))
       expect(fooChipElement).toBeTruthy()
 
+      subscription = component.contentDisplayedChange.subscribe(
+        (newContentDisplayed) => {
+          contentDisplayed = newContentDisplayed
+        },
+      )
       fooChipElement.triggerEventHandler('selectedChange')
 
       fixture.detectChanges()
+    })
+
+    afterEach(() => {
+      subscription.unsubscribe()
     })
 
     it('should mark the chip as selected', () => {
@@ -144,6 +156,10 @@ describe('ChippedContentComponent', () => {
       )
       expect(fooContentElement).toBeTruthy()
       expectIsVisible(fooContentElement.nativeElement)
+    })
+
+    it('should emit event indicating content has been displayed', () => {
+      expect(contentDisplayed).toBe(true)
     })
 
     describe('when tapping same chip again', () => {
@@ -162,6 +178,10 @@ describe('ChippedContentComponent', () => {
         )
         expect(fooContentElement).toBeTruthy()
         expectIsHidden(fooContentElement.nativeElement)
+      })
+
+      it('should emit event indicating content has been hidden', () => {
+        expect(contentDisplayed).toBe(false)
       })
     })
     describe('when tapping another chip', () => {
@@ -192,6 +212,10 @@ describe('ChippedContentComponent', () => {
         )
         expect(barContentElement).toBeTruthy()
         expectIsVisible(barContentElement.nativeElement)
+      })
+
+      it('should emit event indicating content has been displayed', () => {
+        expect(contentDisplayed).toBe(true)
       })
     })
   })

--- a/src/app/about/chipped-content/chipped-content.component.spec.ts
+++ b/src/app/about/chipped-content/chipped-content.component.spec.ts
@@ -1,0 +1,198 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing'
+import { ChippedContentComponent } from './chipped-content.component'
+import { Component, DebugElement } from '@angular/core'
+import { ChippedContent } from './chipped-content'
+import { By } from '@angular/platform-browser'
+import { getComponentSelector } from '../../../test/helpers/component-testers'
+import { ChipComponent } from '../chip/chip.component'
+import {
+  expectIsHidden,
+  expectIsVisible,
+} from '../../../test/helpers/visibility'
+import { byTestId } from '../../../test/helpers/test-id'
+import { TestIdDirective } from '../../common/test-id.directive'
+
+@Component({
+  selector: 'app-foo',
+  template: `{{ data }}`,
+})
+class FooComponent {
+  public data?: string
+}
+@Component({
+  selector: 'app-bar',
+  template: `{{ data }}`,
+})
+class BarComponent {
+  public data?: string
+}
+
+describe('ChippedContentComponent', () => {
+  let component: ChippedContentComponent
+  let fixture: ComponentFixture<ChippedContentComponent>
+  const fooContentData = 'foo-data'
+  const fooContent = new ChippedContent({
+    id: 'foo',
+    displayName: 'Foo',
+    component: FooComponent,
+    setupComponent: (component) => {
+      component.data = fooContentData
+    },
+  })
+  const barContentData = 'bar-data'
+  const barContent = new ChippedContent({
+    id: 'bar',
+    displayName: 'Bar',
+    component: BarComponent,
+    setupComponent: (component) => {
+      component.data = barContentData
+    },
+  })
+  const contents = [fooContent, barContent]
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      declarations: [ChippedContentComponent, ChipComponent, TestIdDirective],
+    })
+    fixture = TestBed.createComponent(ChippedContentComponent)
+    component = fixture.componentInstance
+    component.contents = contents
+    fixture.detectChanges()
+  })
+
+  it('should create', () => {
+    expect(component).toBeTruthy()
+  })
+
+  it('should display all chips unselected with their display names', () => {
+    const selectableChipsContainerElement = fixture.debugElement.query(
+      By.css('.chips'),
+    )
+    expect(selectableChipsContainerElement).toBeTruthy()
+
+    const chipElements = selectableChipsContainerElement.queryAll(
+      By.css(getComponentSelector(ChipComponent)),
+    )
+    expect(chipElements.length).toEqual(contents.length)
+    chipElements.forEach((chipElement, index) => {
+      const content = contents[index]
+      expect(chipElement.attributes['ng-reflect-selected'])
+        .withContext(`chip ${index} is unselected`)
+        .toBe('false')
+      expect(chipElement.nativeElement.textContent.trim())
+        .withContext(`chip ${index} display name`)
+        .toEqual(content.displayName)
+    })
+  })
+
+  it('should add and setup all content components, but hidden', () => {
+    const fooElement = fixture.debugElement.query(
+      By.css(getComponentSelector(FooComponent)),
+    )
+    expect(fooElement).toBeTruthy()
+    expect(fooElement.nativeElement.textContent.trim())
+      .withContext(`foo element contents`)
+      .toEqual(fooContentData)
+    expectIsHidden(fooElement.nativeElement)
+
+    const barElement = fixture.debugElement.query(
+      By.css(getComponentSelector(BarComponent)),
+    )
+    expect(barElement).toBeTruthy()
+    expect(barElement.nativeElement.textContent.trim())
+      .withContext(`bar element contents`)
+      .toEqual(barContentData)
+    expectIsHidden(barElement.nativeElement)
+  })
+
+  // They're displayed in non-JS version thanks to helper classes
+  it('should add hidden non selectable chips for non-JS version', () => {
+    const chipElements = fixture.debugElement.children.filter(
+      (element) =>
+        element.properties['localName'] === getComponentSelector(ChipComponent),
+    )
+    expect(chipElements.length).toEqual(contents.length)
+
+    chipElements.forEach((chipElement, index) => {
+      const content = contents[index]
+      expect(chipElement.nativeElement.textContent.trim())
+        .withContext(`chip ${index} contents`)
+        .toEqual(content.displayName)
+      expectIsHidden(chipElement.nativeElement)
+    })
+  })
+
+  describe('when tapping on a chip', () => {
+    let fooChipElement: DebugElement
+
+    beforeEach(() => {
+      fooChipElement = fixture.debugElement.query(byTestId(fooContent.id))
+      expect(fooChipElement).toBeTruthy()
+
+      fooChipElement.triggerEventHandler('selectedChange')
+
+      fixture.detectChanges()
+    })
+
+    it('should mark the chip as selected', () => {
+      expect(fooChipElement.attributes['ng-reflect-selected']).toBe('true')
+    })
+
+    it('should display its content', () => {
+      const fooContentElement = fixture.debugElement.query(
+        By.css(getComponentSelector(FooComponent)),
+      )
+      expect(fooContentElement).toBeTruthy()
+      expectIsVisible(fooContentElement.nativeElement)
+    })
+
+    describe('when tapping same chip again', () => {
+      beforeEach(() => {
+        fooChipElement.triggerEventHandler('selectedChange')
+        fixture.detectChanges()
+      })
+
+      it('should mark the chip as unselected', () => {
+        expect(fooChipElement.attributes['ng-reflect-selected']).toBe('false')
+      })
+
+      it('should hide its content', () => {
+        const fooContentElement = fixture.debugElement.query(
+          By.css(getComponentSelector(FooComponent)),
+        )
+        expect(fooContentElement).toBeTruthy()
+        expectIsHidden(fooContentElement.nativeElement)
+      })
+    })
+    describe('when tapping another chip', () => {
+      let barChipElement: DebugElement
+      beforeEach(() => {
+        barChipElement = fixture.debugElement.query(byTestId(barContent.id))
+        expect(barChipElement).toBeTruthy()
+
+        barChipElement.triggerEventHandler('selectedChange')
+
+        fixture.detectChanges()
+      })
+
+      it('should mark the previous chip as unselected and just tapped chip as selected', () => {
+        expect(fooChipElement.attributes['ng-reflect-selected']).toBe('false')
+        expect(barChipElement.attributes['ng-reflect-selected']).toBe('true')
+      })
+
+      it('should hide its content and display the content of the tapped chip', () => {
+        const fooContentElement = fixture.debugElement.query(
+          By.css(getComponentSelector(FooComponent)),
+        )
+        expect(fooContentElement).toBeTruthy()
+        expectIsHidden(fooContentElement.nativeElement)
+
+        const barContentElement = fixture.debugElement.query(
+          By.css(getComponentSelector(BarComponent)),
+        )
+        expect(barContentElement).toBeTruthy()
+        expectIsVisible(barContentElement.nativeElement)
+      })
+    })
+  })
+})

--- a/src/app/about/chipped-content/chipped-content.component.ts
+++ b/src/app/about/chipped-content/chipped-content.component.ts
@@ -1,0 +1,81 @@
+import {
+  Component,
+  ElementRef,
+  Input,
+  OnInit,
+  ViewChild,
+  ViewContainerRef,
+} from '@angular/core'
+import { ChippedContent } from './chipped-content'
+import { ChipComponent } from '../chip/chip.component'
+
+@Component({
+  selector: 'app-chipped-content',
+  templateUrl: './chipped-content.component.html',
+  styleUrls: ['./chipped-content.component.scss'],
+})
+export class ChippedContentComponent implements OnInit {
+  @Input({ required: true }) public contents!: ReadonlyArray<
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ChippedContent<any, any>
+  >
+  @ViewChild('contentHost', { read: ViewContainerRef, static: true })
+  public contentHost!: ViewContainerRef
+  private contentElementRefsById!: Map<string, ElementRef>
+  private HIDDEN_CLASS = 'hidden'
+
+  public selectedContentId?: string
+
+  ngOnInit(): void {
+    const viewContainerRef = this.contentHost
+    this.contentElementRefsById = new Map<string, ElementRef>()
+    viewContainerRef.clear()
+    for (const content of this.contents) {
+      // Add chip for non JS version
+      const chipComponentRef = viewContainerRef.createComponent(ChipComponent)
+      const chipComponentElement = chipComponentRef.location
+        .nativeElement as HTMLElement
+      chipComponentElement.classList.add('displayBlockIfNoScript')
+      chipComponentElement.innerHTML = content.displayName
+      // Add content
+      const contentComponentRef = viewContainerRef.createComponent(
+        content.component,
+      )
+      content.setupComponent(contentComponentRef.instance)
+      this.hideContentElement(contentComponentRef.location)
+      const contentComponentElement = contentComponentRef.location
+        .nativeElement as HTMLElement
+      contentComponentElement.classList.add('displayBlockIfNoScript')
+      this.contentElementRefsById.set(content.id, contentComponentRef.location)
+    }
+  }
+
+  setSelectedContent(id: string) {
+    const contentElement = this.contentElementRefsById.get(id)!
+
+    if (this.selectedContentId === id) {
+      this.hideContentElement(contentElement)
+      this.selectedContentId = undefined
+      return
+    }
+
+    if (this.selectedContentId) {
+      const previousContentElement = this.contentElementRefsById.get(
+        this.selectedContentId,
+      )!
+      this.hideContentElement(previousContentElement)
+    }
+
+    this.selectedContentId = id
+    this.showContentElement(contentElement)
+  }
+
+  private hideContentElement(elementRef: ElementRef) {
+    ;(elementRef.nativeElement as HTMLElement).classList.add(this.HIDDEN_CLASS)
+  }
+  private showContentElement(elementRef: ElementRef) {
+    ;(elementRef.nativeElement as HTMLElement).classList.remove(
+      this.HIDDEN_CLASS,
+    )
+  }
+}

--- a/src/app/about/chipped-content/chipped-content.component.ts
+++ b/src/app/about/chipped-content/chipped-content.component.ts
@@ -1,8 +1,10 @@
 import {
   Component,
   ElementRef,
+  EventEmitter,
   Input,
   OnInit,
+  Output,
   ViewChild,
   ViewContainerRef,
 } from '@angular/core'
@@ -25,6 +27,7 @@ export class ChippedContentComponent implements OnInit {
   private HIDDEN_CLASS = 'hidden'
 
   public selectedContentId?: string
+  @Output() contentDisplayedChange = new EventEmitter<boolean>()
 
   ngOnInit(): void {
     const viewContainerRef = this.contentHost
@@ -56,6 +59,7 @@ export class ChippedContentComponent implements OnInit {
     if (this.selectedContentId === id) {
       this.hideContentElement(contentElement)
       this.selectedContentId = undefined
+      this.contentDisplayedChange.emit(false)
       return
     }
 
@@ -64,6 +68,8 @@ export class ChippedContentComponent implements OnInit {
         this.selectedContentId,
       )!
       this.hideContentElement(previousContentElement)
+    } else {
+      this.contentDisplayedChange.emit(true)
     }
 
     this.selectedContentId = id

--- a/src/app/about/chipped-content/chipped-content.ts
+++ b/src/app/about/chipped-content/chipped-content.ts
@@ -1,0 +1,25 @@
+import { Type } from '@angular/core'
+
+export class ChippedContent<T, U> {
+  public readonly id: T
+  public readonly displayName: string
+  public readonly component: Type<U>
+  public readonly setupComponent: (component: U) => void
+
+  constructor({
+    id,
+    displayName,
+    component,
+    setupComponent,
+  }: {
+    id: T
+    displayName: string
+    component: Type<U>
+    setupComponent: (component: U) => void
+  }) {
+    this.id = id
+    this.displayName = displayName
+    this.component = component
+    this.setupComponent = setupComponent
+  }
+}

--- a/src/app/about/experience/experience-item/experience-item-highlights/experience-item-highlights.component.scss
+++ b/src/app/about/experience/experience-item/experience-item-highlights/experience-item-highlights.component.scss
@@ -1,0 +1,9 @@
+@use 'margins';
+
+:host {
+  ul {
+    display: flex;
+    flex-direction: column;
+    gap: margins.$s;
+  }
+}

--- a/src/app/about/experience/experience-item/experience-item-highlights/experience-item-highlights.component.scss
+++ b/src/app/about/experience/experience-item/experience-item-highlights/experience-item-highlights.component.scss
@@ -6,4 +6,5 @@
     flex-direction: column;
     gap: margins.$s;
   }
+  overflow: hidden;
 }

--- a/src/app/about/experience/experience-item/experience-item-highlights/experience-item-highlights.component.spec.ts
+++ b/src/app/about/experience/experience-item/experience-item-highlights/experience-item-highlights.component.spec.ts
@@ -1,0 +1,34 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing'
+
+import { ExperienceItemHighlightsComponent } from './experience-item-highlights.component'
+import { By } from '@angular/platform-browser'
+
+describe('ExperienceItemHighlightsComponent', () => {
+  let component: ExperienceItemHighlightsComponent
+  let fixture: ComponentFixture<ExperienceItemHighlightsComponent>
+  const highlights = ['Sample highlight 1', 'Sample highlight 2']
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      declarations: [ExperienceItemHighlightsComponent],
+    })
+    fixture = TestBed.createComponent(ExperienceItemHighlightsComponent)
+    component = fixture.componentInstance
+    component.highlights = highlights
+    fixture.detectChanges()
+  })
+
+  it('should create', () => {
+    expect(component).toBeTruthy()
+  })
+
+  it('should display all highlights', () => {
+    const listElements = fixture.debugElement.queryAll(By.css('li'))
+    expect(listElements.length).toBe(highlights.length)
+    listElements.forEach((listElement, index) => {
+      expect(listElement.nativeElement.textContent.trim()).toEqual(
+        highlights[index],
+      )
+    })
+  })
+})

--- a/src/app/about/experience/experience-item/experience-item-highlights/experience-item-highlights.component.spec.ts
+++ b/src/app/about/experience/experience-item/experience-item-highlights/experience-item-highlights.component.spec.ts
@@ -2,6 +2,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing'
 
 import { ExperienceItemHighlightsComponent } from './experience-item-highlights.component'
 import { By } from '@angular/platform-browser'
+import { NoopAnimationsModule } from '@angular/platform-browser/animations'
 
 describe('ExperienceItemHighlightsComponent', () => {
   let component: ExperienceItemHighlightsComponent
@@ -11,6 +12,7 @@ describe('ExperienceItemHighlightsComponent', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       declarations: [ExperienceItemHighlightsComponent],
+      imports: [NoopAnimationsModule],
     })
     fixture = TestBed.createComponent(ExperienceItemHighlightsComponent)
     component = fixture.componentInstance

--- a/src/app/about/experience/experience-item/experience-item-highlights/experience-item-highlights.component.ts
+++ b/src/app/about/experience/experience-item/experience-item-highlights/experience-item-highlights.component.ts
@@ -1,4 +1,5 @@
-import { Component, Input } from '@angular/core'
+import { Component, HostBinding, Input } from '@angular/core'
+import { slideDownOnEnterAndSlideUpOnLeave } from '../../../../common/animations'
 
 @Component({
   selector: 'app-experience-item-highlights',
@@ -8,7 +9,9 @@ import { Component, Input } from '@angular/core'
     </li>
   </ul>`,
   styleUrls: ['./experience-item-highlights.component.scss'],
+  animations: [slideDownOnEnterAndSlideUpOnLeave('enterAndLeave')],
 })
 export class ExperienceItemHighlightsComponent {
+  @HostBinding('@enterAndLeave') public enterAndLeaveAnimation = true
   @Input({ required: true }) public highlights!: readonly string[]
 }

--- a/src/app/about/experience/experience-item/experience-item-highlights/experience-item-highlights.component.ts
+++ b/src/app/about/experience/experience-item/experience-item-highlights/experience-item-highlights.component.ts
@@ -1,0 +1,14 @@
+import { Component, Input } from '@angular/core'
+
+@Component({
+  selector: 'app-experience-item-highlights',
+  template: `<ul>
+    <li *ngFor="let highlight of highlights">
+      {{ highlight }}
+    </li>
+  </ul>`,
+  styleUrls: ['./experience-item-highlights.component.scss'],
+})
+export class ExperienceItemHighlightsComponent {
+  @Input({ required: true }) public highlights!: readonly string[]
+}

--- a/src/app/about/experience/experience-item/experience-item-summary/experience-item-summary.component.spec.ts
+++ b/src/app/about/experience/experience-item/experience-item-summary/experience-item-summary.component.spec.ts
@@ -1,0 +1,29 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing'
+
+import { ExperienceItemSummaryComponent } from './experience-item-summary.component'
+
+describe('ExperienceItemSummaryComponent', () => {
+  let component: ExperienceItemSummaryComponent
+  let fixture: ComponentFixture<ExperienceItemSummaryComponent>
+  const summary = 'sample summary that explains what you did in there'
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      declarations: [ExperienceItemSummaryComponent],
+    })
+    fixture = TestBed.createComponent(ExperienceItemSummaryComponent)
+    component = fixture.componentInstance
+    component.summary = summary
+    fixture.detectChanges()
+  })
+
+  it('should create', () => {
+    expect(component).toBeTruthy()
+  })
+
+  it('should contain the summary', () => {
+    expect(fixture.debugElement.nativeElement.textContent.trim()).toEqual(
+      summary,
+    )
+  })
+})

--- a/src/app/about/experience/experience-item/experience-item-summary/experience-item-summary.component.spec.ts
+++ b/src/app/about/experience/experience-item/experience-item-summary/experience-item-summary.component.spec.ts
@@ -1,6 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing'
 
 import { ExperienceItemSummaryComponent } from './experience-item-summary.component'
+import { NoopAnimationsModule } from '@angular/platform-browser/animations'
 
 describe('ExperienceItemSummaryComponent', () => {
   let component: ExperienceItemSummaryComponent
@@ -10,6 +11,7 @@ describe('ExperienceItemSummaryComponent', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       declarations: [ExperienceItemSummaryComponent],
+      imports: [NoopAnimationsModule],
     })
     fixture = TestBed.createComponent(ExperienceItemSummaryComponent)
     component = fixture.componentInstance

--- a/src/app/about/experience/experience-item/experience-item-summary/experience-item-summary.component.ts
+++ b/src/app/about/experience/experience-item/experience-item-summary/experience-item-summary.component.ts
@@ -1,9 +1,20 @@
-import { Component, Input } from '@angular/core'
+import { Component, HostBinding, Input } from '@angular/core'
+import { slideDownOnEnterAndSlideUpOnLeave } from '../../../../common/animations'
 
 @Component({
   selector: 'app-experience-item-summary',
   template: '{{ summary }}',
+  styles: [
+    `
+      :host {
+        overflow: hidden;
+      }
+    `,
+  ],
+  animations: [slideDownOnEnterAndSlideUpOnLeave('enterAndLeave')],
 })
 export class ExperienceItemSummaryComponent {
-  @Input({ required: true }) public summary!: string
+  @HostBinding('@enterAndLeave') public readonly enterOrLeaveAnimation = true
+  @Input({ required: true })
+  public summary!: string
 }

--- a/src/app/about/experience/experience-item/experience-item-summary/experience-item-summary.component.ts
+++ b/src/app/about/experience/experience-item/experience-item-summary/experience-item-summary.component.ts
@@ -1,0 +1,9 @@
+import { Component, Input } from '@angular/core'
+
+@Component({
+  selector: 'app-experience-item-summary',
+  template: '{{ summary }}',
+})
+export class ExperienceItemSummaryComponent {
+  @Input({ required: true }) public summary!: string
+}

--- a/src/app/about/experience/experience-item/experience-item.component.html
+++ b/src/app/about/experience/experience-item/experience-item.component.html
@@ -68,5 +68,8 @@
       </app-attribute>
     </app-card-header-attributes>
   </app-card-header>
-  <app-chipped-content [contents]="contents"></app-chipped-content>
+  <app-chipped-content
+    [contents]="contents"
+    (contentDisplayedChange)="expanded = $event"
+  ></app-chipped-content>
 </app-card>

--- a/src/app/about/experience/experience-item/experience-item.component.html
+++ b/src/app/about/experience/experience-item/experience-item.component.html
@@ -68,49 +68,5 @@
       </app-attribute>
     </app-card-header-attributes>
   </app-card-header>
-  <div class="chips displayNoneIfNoScript" *ngIf="availableContentTypes">
-    <app-chip
-      *ngFor="let chip of availableContentTypes"
-      [selected]="activeContentType === chip"
-      (selectedChange)="onContentTypeSelected(chip)"
-      [appTestId]="chip.id"
-    >
-      {{ chip.displayName }}
-    </app-chip>
-  </div>
-  <div
-    class="chip displayBlockIfNoScript"
-    *ngIf="typeHasContent(SUMMARY_CONTENT_TYPE)"
-  >
-    {{ SUMMARY_CONTENT_TYPE.displayName }}
-  </div>
-  <div
-    class="content summary"
-    @contentActive
-    *ngIf="
-      !isRenderingOnBrowser || activeContentType?.id === ContentTypeId.Summary
-    "
-  >
-    {{ item.summary }}
-  </div>
-  <div
-    class="chip displayBlockIfNoScript"
-    *ngIf="typeHasContent(HIGHLIGHT_CONTENT_TYPE)"
-  >
-    {{ HIGHLIGHT_CONTENT_TYPE.displayName }}
-  </div>
-  <div
-    class="content highlights"
-    @contentActive
-    *ngIf="
-      !isRenderingOnBrowser ||
-      activeContentType?.id === ContentTypeId.Highlights
-    "
-  >
-    <ul>
-      <li *ngFor="let highlight of item.highlights">
-        {{ highlight }}
-      </li>
-    </ul>
-  </div>
+  <app-chipped-content [contents]="contents"></app-chipped-content>
 </app-card>

--- a/src/app/about/experience/experience-item/experience-item.component.scss
+++ b/src/app/about/experience/experience-item/experience-item.component.scss
@@ -3,7 +3,7 @@
     height: 100%;
   }
 
-  &.active {
+  &.expanded {
     grid-row: span 2;
   }
 }

--- a/src/app/about/experience/experience-item/experience-item.component.scss
+++ b/src/app/about/experience/experience-item/experience-item.component.scss
@@ -1,7 +1,3 @@
-@use 'borders';
-@use 'margins';
-@use 'paddings';
-
 :host {
   app-card {
     height: 100%;
@@ -9,23 +5,5 @@
 
   &.active {
     grid-row: span 2;
-  }
-
-  .chips {
-    display: flex;
-    gap: margins.$s;
-  }
-
-  .displayBlockIfNoScript {
-    display: none;
-  }
-
-  .content {
-    overflow: hidden;
-    ul {
-      display: flex;
-      flex-direction: column;
-      gap: margins.$s;
-    }
   }
 }

--- a/src/app/about/experience/experience-item/experience-item.component.spec.ts
+++ b/src/app/about/experience/experience-item/experience-item.component.spec.ts
@@ -1,17 +1,19 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing'
 import {
   Attribute,
-  ContentTypeId,
+  ContentId,
   ExperienceItemComponent,
 } from './experience-item.component'
 import { ExperienceItem } from './experience-item'
 import { NgOptimizedImage } from '@angular/common'
 import { By } from '@angular/platform-browser'
-import { DebugElement } from '@angular/core'
 import { NoopAnimationsModule } from '@angular/platform-browser/animations'
 import { Organization } from '../../organization'
 import { DateRange } from '../../date-range/date-range'
-import { getComponentSelector } from '../../../../test/helpers/component-testers'
+import {
+  ensureHasComponent,
+  getComponentSelector,
+} from '../../../../test/helpers/component-testers'
 import { DateRangeComponent } from '../../date-range/date-range.component'
 import { MockComponents } from 'ng-mocks'
 import { CardComponent } from '../../card/card.component'
@@ -27,6 +29,10 @@ import { CardHeaderTextsComponent } from '../../card/card-header/card-header-tex
 import { CardHeaderAttributesComponent } from '../../card/card-header/card-header-attributes/card-header-attributes.component'
 import { AttributeComponent } from '../../attribute/attribute.component'
 import { ChipComponent } from '../../chip/chip.component'
+import { ChippedContentComponent } from '../../chipped-content/chipped-content.component'
+import { ExperienceItemSummaryComponent } from './experience-item-summary/experience-item-summary.component'
+import { ChippedContent } from '../../chipped-content/chipped-content'
+import { ExperienceItemHighlightsComponent } from './experience-item-highlights/experience-item-highlights.component'
 
 describe('ExperienceItem', () => {
   let component: ExperienceItemComponent
@@ -60,6 +66,7 @@ describe('ExperienceItem', () => {
           CardHeaderAttributesComponent,
           AttributeComponent,
           ChipComponent,
+          ChippedContentComponent,
         ),
       ],
       imports: [NgOptimizedImage, NoopAnimationsModule],
@@ -269,164 +276,52 @@ describe('ExperienceItem', () => {
       testShouldDisplayItsAttribute(() => fixture, Attribute.MorePositions)
     })
   })
-  describe('chipped content', () => {
-    describe('when no experience', () => {
-      it('should not display chips container', () => {
-        const chipsElement = fixture.debugElement.query(By.css('.chips'))
-        expect(chipsElement)
-          .withContext("chips container doesn't exist")
-          .toBeFalsy()
+
+  ensureHasComponent(() => fixture, ChippedContentComponent)
+
+  describe('when experience has summary', () => {
+    const summary = 'sample summary'
+    beforeEach(() => {
+      component.item = new ExperienceItem({
+        ...newExperienceItemArgs,
+        summary,
       })
+      fixture.detectChanges()
     })
-    describe('when experience has summary', () => {
-      let summaryChipElement: DebugElement | undefined
-      const experienceItem: ExperienceItem = new ExperienceItem(
-        newExperienceItemArgs,
+
+    it('should generate its content item', () => {
+      const summaryContent = component.contents.find(
+        (content) => content.id === ContentId.Summary,
+      ) as ChippedContent<ContentId, ExperienceItemSummaryComponent>
+      expect(summaryContent).toBeTruthy()
+      expect(summaryContent!.component).toEqual(ExperienceItemSummaryComponent)
+      const mockSummaryComponent = {} as ExperienceItemSummaryComponent
+      summaryContent!.setupComponent(mockSummaryComponent)
+      expect(mockSummaryComponent.summary).toEqual(summary)
+    })
+  })
+
+  describe('when experience has highlights', () => {
+    const highlights = ['Sample highlight 1', 'Sample highlight 2']
+    beforeEach(() => {
+      component.item = new ExperienceItem({
+        ...newExperienceItemArgs,
+        highlights,
+      })
+      fixture.detectChanges()
+    })
+
+    it('should generate its content item', () => {
+      const highlightContent = component.contents.find(
+        (content) => content.id === ContentId.Highlights,
+      ) as ChippedContent<ContentId, ExperienceItemHighlightsComponent>
+      expect(highlightContent).toBeTruthy()
+      expect(highlightContent!.component).toEqual(
+        ExperienceItemHighlightsComponent,
       )
-
-      beforeEach(() => {
-        component.item = experienceItem
-        fixture.detectChanges()
-
-        const chipsElement = fixture.debugElement.query(By.css('.chips'))
-        expect(chipsElement).withContext('chips container exists').toBeTruthy()
-
-        summaryChipElement = chipsElement.query(byTestId(ContentTypeId.Summary))
-      })
-
-      it('should display summary chip', () => {
-        expect(summaryChipElement)
-          .withContext('summary chip exists')
-          .toBeTruthy()
-      })
-
-      describe('when tapping on the summary chip', () => {
-        beforeEach(() => {
-          summaryChipElement!.triggerEventHandler('selectedChange')
-          fixture.detectChanges()
-        })
-
-        it('should mark chip as active', () => {
-          expect(summaryChipElement!.attributes['ng-reflect-selected']).toBe(
-            'true',
-          )
-        })
-
-        it('should display summary in contents', () => {
-          const contentElement = fixture.debugElement.query(
-            By.css('.content.summary'),
-          )
-          expect(contentElement)
-            .withContext('content container exists')
-            .toBeTruthy()
-
-          expect(contentElement.nativeElement.textContent.trim()).toEqual(
-            experienceItem.summary,
-          )
-        })
-
-        describe('when tapping again on the summary chip', () => {
-          beforeEach(() => {
-            summaryChipElement!.triggerEventHandler('selectedChange')
-            fixture.detectChanges()
-          })
-
-          it('should not mark chip as active', () => {
-            expect(summaryChipElement!.attributes['ng-reflect-selected']).toBe(
-              'false',
-            )
-          })
-
-          it('should not display summary in contents', () => {
-            const contentElement = fixture.debugElement.query(
-              By.css('.content.summary'),
-            )
-            expect(contentElement)
-              .withContext('content container does not exist')
-              .toBeFalsy()
-          })
-        })
-      })
-    })
-    describe('when experience has highlights', () => {
-      let highlightsChipElement: DebugElement | undefined
-      const highlights: ReadonlyArray<string> = [
-        'Fake highlight 1',
-        'Fake highlight 2',
-      ]
-
-      beforeEach(() => {
-        component.item = new ExperienceItem({
-          ...newExperienceItemArgs,
-          highlights,
-        })
-        fixture.detectChanges()
-
-        const chipsElement = fixture.debugElement.query(By.css('.chips'))
-        expect(chipsElement).withContext('chips container exists').toBeTruthy()
-
-        highlightsChipElement = chipsElement.query(
-          byTestId(ContentTypeId.Highlights),
-        )
-      })
-
-      it('should display highlights chip', () => {
-        expect(highlightsChipElement)
-          .withContext('highlights chip exists')
-          .toBeTruthy()
-      })
-
-      describe('when tapping on the highlights chip', () => {
-        beforeEach(() => {
-          highlightsChipElement!.triggerEventHandler('selectedChange')
-          fixture.detectChanges()
-        })
-
-        it('should mark chip as active', () => {
-          expect(highlightsChipElement!.attributes['ng-reflect-selected']).toBe(
-            'true',
-          )
-        })
-
-        it('should display highlights in contents', () => {
-          const contentElement = fixture.debugElement.query(
-            By.css('.content.highlights'),
-          )
-          expect(contentElement)
-            .withContext('content container exists')
-            .toBeTruthy()
-
-          const listElements = contentElement.queryAll(By.css('li'))
-          expect(listElements.length).toEqual(highlights.length)
-          listElements.forEach((listElement, index) => {
-            const highlight = highlights[index]
-            expect(listElement.nativeElement.textContent.trim())
-              .withContext(`list element ${index}`)
-              .toEqual(highlight)
-          })
-        })
-        describe('when tapping again on the highlights chip', () => {
-          beforeEach(() => {
-            highlightsChipElement!.triggerEventHandler('selectedChange')
-            fixture.detectChanges()
-          })
-
-          it('should not mark chip as active', () => {
-            expect(
-              highlightsChipElement!.attributes['ng-reflect-selected'],
-            ).toBe('false')
-          })
-
-          it('should not display highlight in contents', () => {
-            const contentElement = fixture.debugElement.query(
-              By.css('.content.highlights'),
-            )
-            expect(contentElement)
-              .withContext('content container does not exist')
-              .toBeFalsy()
-          })
-        })
-      })
+      const mockHighlightsComponent = {} as ExperienceItemHighlightsComponent
+      highlightContent!.setupComponent(mockHighlightsComponent)
+      expect(mockHighlightsComponent.highlights).toEqual(highlights)
     })
   })
 })

--- a/src/app/about/experience/experience-item/experience-item.component.spec.ts
+++ b/src/app/about/experience/experience-item/experience-item.component.spec.ts
@@ -324,4 +324,48 @@ describe('ExperienceItem', () => {
       expect(mockHighlightsComponent.highlights).toEqual(highlights)
     })
   })
+  describe('when content is displayed', () => {
+    const summary = 'summary'
+    beforeEach(() => {
+      component.item = new ExperienceItem({
+        ...newExperienceItemArgs,
+        summary,
+      })
+      fixture.detectChanges()
+      const chippedContentElement = fixture.debugElement.query(
+        By.css(getComponentSelector(ChippedContentComponent)),
+      )
+      expect(chippedContentElement).toBeTruthy()
+      chippedContentElement.triggerEventHandler('contentDisplayedChange', true)
+      fixture.detectChanges()
+    })
+
+    it('should add the expanded class to the element', () => {
+      expect(
+        fixture.debugElement.classes[ExperienceItemComponent.EXPANDED_CLASS],
+      ).toBeTrue()
+    })
+  })
+  describe('when content is hidden', () => {
+    const summary = 'summary'
+    beforeEach(() => {
+      component.item = new ExperienceItem({
+        ...newExperienceItemArgs,
+        summary,
+      })
+      fixture.detectChanges()
+      const chippedContentElement = fixture.debugElement.query(
+        By.css(getComponentSelector(ChippedContentComponent)),
+      )
+      expect(chippedContentElement).toBeTruthy()
+      chippedContentElement.triggerEventHandler('contentDisplayedChange', false)
+      fixture.detectChanges()
+    })
+
+    it('should remove the expanded class to the element', () => {
+      expect(
+        fixture.debugElement.classes[ExperienceItemComponent.EXPANDED_CLASS],
+      ).toBeFalsy()
+    })
+  })
 })

--- a/src/app/about/experience/experience-item/experience-item.component.ts
+++ b/src/app/about/experience/experience-item/experience-item.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input } from '@angular/core'
+import { Component, HostBinding, Input } from '@angular/core'
 import { ExperienceItem } from './experience-item'
 import { MATERIAL_SYMBOLS_CLASS } from '../../../common/material-symbols'
 import {
@@ -48,6 +48,7 @@ import { ExperienceItemHighlightsComponent } from './experience-item-highlights/
   ],
 })
 export class ExperienceItemComponent {
+  static readonly EXPANDED_CLASS = 'expanded'
   @Input({ required: true }) public item!: ExperienceItem
   protected readonly MATERIAL_SYMBOLS_CLASS = MATERIAL_SYMBOLS_CLASS
   protected readonly MaterialSymbol = {
@@ -87,6 +88,8 @@ export class ExperienceItemComponent {
     }
     return contents
   }
+  @HostBinding(`class.${ExperienceItemComponent.EXPANDED_CLASS}`)
+  public expanded?: boolean
 
   constructor(private slugGenerator: SlugGeneratorService) {}
 

--- a/src/app/about/experience/experience-item/experience-item.component.ts
+++ b/src/app/about/experience/experience-item/experience-item.component.ts
@@ -1,10 +1,4 @@
-import {
-  Component,
-  HostBinding,
-  Inject,
-  Input,
-  PLATFORM_ID,
-} from '@angular/core'
+import { Component, Input } from '@angular/core'
 import { ExperienceItem } from './experience-item'
 import { MATERIAL_SYMBOLS_CLASS } from '../../../common/material-symbols'
 import {
@@ -26,7 +20,9 @@ import {
   STANDARD_DURATION_MS,
   TIMING_FUNCTION,
 } from '../../../common/animations'
-import { isPlatformBrowser } from '@angular/common'
+import { ChippedContent } from '../../chipped-content/chipped-content'
+import { ExperienceItemSummaryComponent } from './experience-item-summary/experience-item-summary.component'
+import { ExperienceItemHighlightsComponent } from './experience-item-highlights/experience-item-highlights.component'
 
 @Component({
   selector: 'app-experience-item',
@@ -53,11 +49,6 @@ import { isPlatformBrowser } from '@angular/common'
 })
 export class ExperienceItemComponent {
   @Input({ required: true }) public item!: ExperienceItem
-  public readonly contentTypes: ReadonlyArray<ContentType> = [
-    SUMMARY_CONTENT_TYPE,
-    HIGHLIGHT_CONTENT_TYPE,
-  ]
-  public activeContentType?: ContentType
   protected readonly MATERIAL_SYMBOLS_CLASS = MATERIAL_SYMBOLS_CLASS
   protected readonly MaterialSymbol = {
     Badge,
@@ -67,26 +58,37 @@ export class ExperienceItemComponent {
     More,
   }
   protected readonly Attribute = Attribute
-  protected readonly ContentTypeId = ContentTypeId
-  protected readonly isRenderingOnBrowser
 
-  constructor(
-    private slugGenerator: SlugGeneratorService,
-    @Inject(PLATFORM_ID) platformId: object,
-  ) {
-    this.isRenderingOnBrowser = isPlatformBrowser(platformId)
+  public get contents() {
+    const contents = []
+    if (this.item.summary) {
+      contents.push(
+        new ChippedContent({
+          id: ContentId.Summary,
+          displayName: 'Summary',
+          component: ExperienceItemSummaryComponent,
+          setupComponent: (component) => {
+            component.summary = this.item.summary
+          },
+        }),
+      )
+    }
+    if (this.item.highlights.length > 0) {
+      contents.push(
+        new ChippedContent({
+          id: ContentId.Highlights,
+          displayName: 'Highlights',
+          component: ExperienceItemHighlightsComponent,
+          setupComponent: (component) => {
+            component.highlights = this.item.highlights
+          },
+        }),
+      )
+    }
+    return contents
   }
 
-  public get availableContentTypes(): ReadonlyArray<ContentType> {
-    return this.contentTypes.filter((contentType) =>
-      this.typeHasContent(contentType),
-    )
-  }
-
-  @HostBinding('class.active')
-  public get activeClass(): boolean {
-    return !!this.activeContentType
-  }
+  constructor(private slugGenerator: SlugGeneratorService) {}
 
   public getAttributeId(attributeName: string) {
     return `${this.itemId}${attributeName}`
@@ -97,52 +99,17 @@ export class ExperienceItemComponent {
       prefix: 'exp-pos-',
     })
   }
-
-  onContentTypeSelected(contentType: ContentType) {
-    if (this.activeContentType === contentType) {
-      this.activeContentType = undefined
-      return
-    }
-    this.activeContentType = contentType
-  }
-
-  protected typeHasContent(type: ContentType): boolean {
-    switch (type.id) {
-      case ContentTypeId.Summary:
-        return !!this.item?.summary
-      case ContentTypeId.Highlights:
-        return !!this.item && this.item.highlights.length > 0
-      default:
-        return false
-    }
-  }
-
-  protected readonly SUMMARY_CONTENT_TYPE = SUMMARY_CONTENT_TYPE
-  protected readonly HIGHLIGHT_CONTENT_TYPE = HIGHLIGHT_CONTENT_TYPE
 }
 
-export enum ContentTypeId {
-  Summary = 'summary',
-  Highlights = 'highlights',
-}
-
-interface ContentType {
-  id: ContentTypeId
-  displayName: string
-}
-
-export const SUMMARY_CONTENT_TYPE: ContentType = {
-  id: ContentTypeId.Summary,
-  displayName: 'Summary',
-}
-export const HIGHLIGHT_CONTENT_TYPE: ContentType = {
-  id: ContentTypeId.Highlights,
-  displayName: 'Highlights',
-}
 export enum Attribute {
   Freelance = 'freelance',
   Employee = 'employee',
   Internship = 'internship',
   MorePositions = 'more-positions',
   Promotions = 'promotions',
+}
+
+export enum ContentId {
+  Summary = 'summary',
+  Highlights = 'highlights',
 }

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -39,6 +39,9 @@ import { CardHeaderTextsComponent } from './about/card/card-header/card-header-t
 import { CardHeaderAttributesComponent } from './about/card/card-header/card-header-attributes/card-header-attributes.component'
 import { AttributeComponent } from './about/attribute/attribute.component'
 import { ChipComponent } from './about/chip/chip.component'
+import { ChippedContentComponent } from './about/chipped-content/chipped-content.component'
+import { ExperienceItemSummaryComponent } from './about/experience/experience-item/experience-item-summary/experience-item-summary.component'
+import { ExperienceItemHighlightsComponent } from './about/experience/experience-item/experience-item-highlights/experience-item-highlights.component'
 
 @NgModule({
   declarations: [
@@ -73,6 +76,9 @@ import { ChipComponent } from './about/chip/chip.component'
     CardHeaderAttributesComponent,
     AttributeComponent,
     ChipComponent,
+    ChippedContentComponent,
+    ExperienceItemSummaryComponent,
+    ExperienceItemHighlightsComponent,
   ],
   imports: [
     BrowserModule,

--- a/src/app/common/animations.ts
+++ b/src/app/common/animations.ts
@@ -1,4 +1,35 @@
 // To be in sync with animations in SCSS
+import {
+  animate,
+  AnimationTriggerMetadata,
+  AUTO_STYLE,
+  style,
+  transition,
+  trigger,
+} from '@angular/animations'
+
 export const STANDARD_DURATION_MS = 300
 export const EMPHASIZED_DURATION_MS = 500
 export const TIMING_FUNCTION = 'cubic-bezier(0.2, 0, 0, 1.0)'
+
+export function slideDownOnEnterAndSlideUpOnLeave(
+  triggerName: string,
+  durationInMs: number = EMPHASIZED_DURATION_MS,
+): AnimationTriggerMetadata {
+  return trigger(triggerName, [
+    transition(':enter', [
+      style({ height: '0', visibility: 'hidden' }),
+      animate(
+        `${durationInMs}ms ${TIMING_FUNCTION}`,
+        style({ height: AUTO_STYLE, visibility: AUTO_STYLE }),
+      ),
+    ]),
+    transition(':leave', [
+      style({ height: AUTO_STYLE, visibility: AUTO_STYLE }),
+      animate(
+        `${durationInMs}ms ${TIMING_FUNCTION}`,
+        style({ height: '0', visibility: 'hidden' }),
+      ),
+    ]),
+  ])
+}

--- a/src/test/helpers/platform-ids.ts
+++ b/src/test/helpers/platform-ids.ts
@@ -4,3 +4,9 @@ export const PLATFORM_BROWSER_ID = 'browser'
 export const PLATFORM_SERVER_ID = 'server'
 export const PLATFORM_WORKER_APP_ID = 'browserWorkerApp'
 export const PLATFORM_WORKER_UI_ID = 'browserWorkerUi'
+
+export type PlatformId =
+  | typeof PLATFORM_BROWSER_ID
+  | typeof PLATFORM_SERVER_ID
+  | typeof PLATFORM_WORKER_APP_ID
+  | typeof PLATFORM_WORKER_UI_ID


### PR DESCRIPTION
Adds chipped content component. To abstract & simplify implementation of chipped content in current experience items.

## TODO
- [x] When content is shown, expand experience item to take 2 rows on grid
- [x] Add animations back when showing and hiding content
