### PR TITLE
refactor: add material symbols directive

### DIFF
--- a/src/app/about/attribute/attribute.component.html
+++ b/src/app/about/attribute/attribute.component.html
@@ -1,8 +1,4 @@
-<span
-  [class]="MATERIAL_SYMBOLS_CLASS"
-  [attr.aria-describedby]="tooltipId"
-  tabindex="0"
->
+<span [attr.aria-describedby]="tooltipId" tabindex="0" appMaterialSymbol>
   {{ symbol }}
 </span>
 <div [id]="tooltipId" role="tooltip"><ng-content></ng-content></div>

--- a/src/app/about/attribute/attribute.component.spec.ts
+++ b/src/app/about/attribute/attribute.component.spec.ts
@@ -4,6 +4,7 @@ import { AttributeComponent } from './attribute.component'
 import { MATERIAL_SYMBOLS_SELECTOR } from '../../../test/helpers/material-symbols'
 import { By } from '@angular/platform-browser'
 import { ensureProjectsContent } from '../../../test/helpers/component-testers'
+import { MaterialSymbolDirective } from '../../common/material-symbol.directive'
 
 describe('AttributeComponent', () => {
   const symbol = 'some symbol'
@@ -11,7 +12,7 @@ describe('AttributeComponent', () => {
 
   function setup(): [ComponentFixture<AttributeComponent>, AttributeComponent] {
     TestBed.configureTestingModule({
-      declarations: [AttributeComponent],
+      declarations: [AttributeComponent, MaterialSymbolDirective],
     })
     const fixture = TestBed.createComponent(AttributeComponent)
     const component = fixture.componentInstance

--- a/src/app/about/attribute/attribute.component.ts
+++ b/src/app/about/attribute/attribute.component.ts
@@ -1,5 +1,4 @@
 import { Component, Input } from '@angular/core'
-import { MATERIAL_SYMBOLS_CLASS } from '../../common/material-symbols'
 
 @Component({
   selector: 'app-attribute',
@@ -7,8 +6,6 @@ import { MATERIAL_SYMBOLS_CLASS } from '../../common/material-symbols'
   styleUrls: ['./attribute.component.scss'],
 })
 export class AttributeComponent {
-  protected readonly MATERIAL_SYMBOLS_CLASS = MATERIAL_SYMBOLS_CLASS
-
   @Input({ required: true }) symbol!: string
   @Input({ required: true }) id!: string
 

--- a/src/app/about/education/education-item/education-item.component.ts
+++ b/src/app/about/education/education-item/education-item.component.ts
@@ -1,6 +1,5 @@
 import { Component, Input } from '@angular/core'
 import { EducationItem } from './education-item'
-import { MATERIAL_SYMBOLS_CLASS } from '../../../common/material-symbols'
 import { SocialLeaderboard } from '../../../material-symbols'
 import { SlugGeneratorService } from '../../../common/slug-generator.service'
 
@@ -12,7 +11,6 @@ import { SlugGeneratorService } from '../../../common/slug-generator.service'
 export class EducationItemComponent {
   @Input({ required: true }) public item!: EducationItem
 
-  protected readonly MATERIAL_SYMBOLS_CLASS = MATERIAL_SYMBOLS_CLASS
   protected readonly MaterialSymbol = {
     SocialLeaderboard,
   }

--- a/src/app/about/experience/experience-item/experience-item.component.ts
+++ b/src/app/about/experience/experience-item/experience-item.component.ts
@@ -1,6 +1,5 @@
 import { Component, HostBinding, Input } from '@angular/core'
 import { ExperienceItem } from './experience-item'
-import { MATERIAL_SYMBOLS_CLASS } from '../../../common/material-symbols'
 import {
   Badge,
   More,
@@ -50,7 +49,6 @@ import { ExperienceItemHighlightsComponent } from './experience-item-highlights/
 export class ExperienceItemComponent {
   static readonly EXPANDED_CLASS = 'expanded'
   @Input({ required: true }) public item!: ExperienceItem
-  protected readonly MATERIAL_SYMBOLS_CLASS = MATERIAL_SYMBOLS_CLASS
   protected readonly MaterialSymbol = {
     Badge,
     Work,

--- a/src/app/about/presentation/contact-traditional-icons/contact-traditional-icons.component.html
+++ b/src/app/about/presentation/contact-traditional-icons/contact-traditional-icons.component.html
@@ -1,10 +1,7 @@
 <ul>
   <li *ngFor="let item of items">
-    <a
-      [href]="item.url"
-      [attr.aria-label]="item.name"
-      [class]="MATERIAL_SYMBOLS_CLASS"
-      >{{ item.materialSymbol }}</a
-    >
+    <a [href]="item.url" [attr.aria-label]="item.name" appMaterialSymbol>{{
+      item.materialSymbol
+    }}</a>
   </li>
 </ul>

--- a/src/app/about/presentation/contact-traditional-icons/contact-traditional-icons.component.ts
+++ b/src/app/about/presentation/contact-traditional-icons/contact-traditional-icons.component.ts
@@ -1,6 +1,5 @@
 import { Component } from '@angular/core'
 import { Call, Email, MyLocation } from '../../../material-symbols'
-import { MATERIAL_SYMBOLS_CLASS } from '../../../common/material-symbols'
 
 @Component({
   selector: 'app-contact-traditional-icons',
@@ -8,7 +7,6 @@ import { MATERIAL_SYMBOLS_CLASS } from '../../../common/material-symbols'
   styleUrls: ['./contact-traditional-icons.component.scss'],
 })
 export class ContactTraditionalIconsComponent {
-  protected readonly MATERIAL_SYMBOLS_CLASS = MATERIAL_SYMBOLS_CLASS
   public readonly items: ReadonlyArray<{
     name: string
     materialSymbol: string

--- a/src/app/about/presentation/description/description.component.html
+++ b/src/app/about/presentation/description/description.component.html
@@ -20,13 +20,9 @@
   </button>
 </ng-template>
 <ng-template #dataTemplate>
-  <span
-    [class]="MATERIAL_SYMBOLS_CLASS"
-    class="symbol"
-    aria-hidden="true"
-    *ngIf="line.data"
-    >{{ line.data.symbol }}</span
-  >
+  <span class="symbol" aria-hidden="true" *ngIf="line.data" appMaterialSymbol>{{
+    line.data.symbol
+  }}</span>
   <span
     class="content"
     [innerHtml]="sanitizer.bypassSecurityTrustHtml(line.data?.html ?? '')"

--- a/src/app/about/presentation/description/description.component.spec.ts
+++ b/src/app/about/presentation/description/description.component.spec.ts
@@ -25,6 +25,7 @@ import {
   CollapsibleConfiguration,
   DescriptionComponent,
 } from './description.component'
+import { MaterialSymbolDirective } from '../../../common/material-symbol.directive'
 
 describe('DescriptionComponent', () => {
   let component: DescriptionComponent
@@ -34,7 +35,7 @@ describe('DescriptionComponent', () => {
   const CARET_SELECTOR = By.css('.caret')
 
   it('should create', () => {
-    ;[fixture, component] = makeSut()
+    ;[fixture, component] = setup()
     expect(component).toBeTruthy()
   })
 
@@ -59,7 +60,7 @@ describe('DescriptionComponent', () => {
 
   describe('data', () => {
     beforeEach(() => {
-      ;[fixture, component] = makeSut()
+      ;[fixture, component] = setup()
     })
 
     describe('when line does not have data', () => {
@@ -87,7 +88,7 @@ describe('DescriptionComponent', () => {
 
   describe('children', () => {
     beforeEach(() => {
-      ;[fixture, component] = makeSut()
+      ;[fixture, component] = setup()
     })
 
     describe('when does not have children', () => {
@@ -170,7 +171,7 @@ describe('DescriptionComponent', () => {
         html: 'Fake html',
       })
       beforeEach(() => {
-        ;[fixture, component] = makeSut()
+        ;[fixture, component] = setup()
         component.line = fakeLine
         fixture.detectChanges()
       })
@@ -189,7 +190,7 @@ describe('DescriptionComponent', () => {
 
       describe('when depth is below configured depth to start a collapsible', () => {
         beforeEach(() => {
-          ;[fixture, component] = makeSut()
+          ;[fixture, component] = setup()
           component.depth = fakeConfig.collapsibleStartAtDepth - 1
           component.line = fakeLine
           fixture.detectChanges()
@@ -215,7 +216,7 @@ describe('DescriptionComponent', () => {
           let caretElement: DebugElement
 
           beforeEach(() => {
-            ;[fixture, component] = makeSut()
+            ;[fixture, component] = setup()
             configureToBeCollapsible(component)
 
             fixture.detectChanges()
@@ -289,7 +290,7 @@ describe('DescriptionComponent', () => {
 
           describe('when rendering on server', () => {
             beforeEach(() => {
-              ;[fixture, component] = makeSut({
+              ;[fixture, component] = setup({
                 platformId: PLATFORM_SERVER_ID,
               })
               configureToBeCollapsible(component)
@@ -310,7 +311,7 @@ describe('DescriptionComponent', () => {
 
           describe('when rendering on client', () => {
             beforeEach(() => {
-              ;[fixture, component] = makeSut()
+              ;[fixture, component] = setup()
               configureToBeCollapsible(component)
 
               fixture.detectChanges()
@@ -371,7 +372,7 @@ describe('DescriptionComponent', () => {
               ],
             )
             beforeEach(() => {
-              ;[fixture, component] = makeSut()
+              ;[fixture, component] = setup()
               configureToBeCollapsible(component, fakeLineWithManyChildren)
 
               fixture.detectChanges()
@@ -424,13 +425,13 @@ describe('DescriptionComponent', () => {
   })
 })
 
-function makeSut({
+function setup({
   platformId,
 }: {
   platformId?: typeof PLATFORM_BROWSER_ID | typeof PLATFORM_SERVER_ID
 } = {}): [ComponentFixture<DescriptionComponent>, DescriptionComponent] {
   TestBed.configureTestingModule({
-    declarations: [DescriptionComponent],
+    declarations: [DescriptionComponent, MaterialSymbolDirective],
     providers: [
       MockProvider(COLLAPSIBLE_CONFIG, fakeConfig),
       MockProvider(PLATFORM_ID, platformId ?? PLATFORM_BROWSER_ID),

--- a/src/app/about/presentation/description/description.component.ts
+++ b/src/app/about/presentation/description/description.component.ts
@@ -23,7 +23,6 @@ import {
   TIMING_FUNCTION,
 } from '../../../common/animations'
 import { DescriptionLine } from '../../../metadata'
-import { MATERIAL_SYMBOLS_CLASS } from '../../../common/material-symbols'
 import { SlugGeneratorService } from '../../../common/slug-generator.service'
 
 @Component({
@@ -66,7 +65,6 @@ export class DescriptionComponent {
   protected readonly visibleIfNoScript = true
   @HostBinding('class.hidden') protected hidden = !this.isRenderingOnBrowser
 
-  protected readonly MATERIAL_SYMBOLS_CLASS = MATERIAL_SYMBOLS_CLASS
   private readonly EXPANDED_DEFAULT_NO_JS = true
   private readonly EXPANDED_DEFAULT_JS_ENABLED = false
   public isExpanded = this.isRenderingOnBrowser

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -42,6 +42,7 @@ import { ChipComponent } from './about/chip/chip.component'
 import { ChippedContentComponent } from './about/chipped-content/chipped-content.component'
 import { ExperienceItemSummaryComponent } from './about/experience/experience-item/experience-item-summary/experience-item-summary.component'
 import { ExperienceItemHighlightsComponent } from './about/experience/experience-item/experience-item-highlights/experience-item-highlights.component'
+import { MaterialSymbolDirective } from './common/material-symbol.directive'
 
 @NgModule({
   declarations: [
@@ -79,6 +80,7 @@ import { ExperienceItemHighlightsComponent } from './about/experience/experience
     ChippedContentComponent,
     ExperienceItemSummaryComponent,
     ExperienceItemHighlightsComponent,
+    MaterialSymbolDirective,
   ],
   imports: [
     BrowserModule,

--- a/src/app/common/material-symbol.directive.spec.ts
+++ b/src/app/common/material-symbol.directive.spec.ts
@@ -1,0 +1,31 @@
+import {
+  MATERIAL_SYMBOLS_CLASS,
+  MaterialSymbolDirective,
+} from './material-symbol.directive'
+import { TestBed } from '@angular/core/testing'
+import { By } from '@angular/platform-browser'
+import { Component, Type } from '@angular/core'
+
+describe('MaterialSymbolDirective', () => {
+  it('should add the material symbol class to the element', () => {
+    const elementTag = 'span'
+    const component = makeComponentWithDirective(elementTag)
+    TestBed.configureTestingModule({
+      declarations: [component, MaterialSymbolDirective],
+    })
+    const fixture = TestBed.createComponent(component)
+    fixture.detectChanges()
+
+    const childElement = fixture.debugElement.query(By.css(elementTag))
+    expect(childElement).toBeTruthy()
+    expect(childElement.classes[MATERIAL_SYMBOLS_CLASS]).toBeTrue()
+  })
+})
+
+function makeComponentWithDirective(elementTag: string): Type<unknown> {
+  @Component({
+    template: `<${elementTag} appMaterialSymbol></${elementTag}>`,
+  })
+  class MaterialSymbolComponent {}
+  return MaterialSymbolComponent
+}

--- a/src/app/common/material-symbol.directive.ts
+++ b/src/app/common/material-symbol.directive.ts
@@ -1,0 +1,15 @@
+import { Directive, ElementRef } from '@angular/core'
+
+@Directive({
+  selector: '[appMaterialSymbol]',
+})
+export class MaterialSymbolDirective {
+  constructor(private el: ElementRef) {
+    ;(this.el.nativeElement as HTMLElement).classList.add(
+      MATERIAL_SYMBOLS_CLASS,
+    )
+  }
+}
+
+// Keep in sync with Material Symbols sass
+export const MATERIAL_SYMBOLS_CLASS = 'material-symbols-outlined'

--- a/src/app/common/material-symbols.ts
+++ b/src/app/common/material-symbols.ts
@@ -1,2 +1,0 @@
-// Keep in sync with Material Symbols Sass
-export const MATERIAL_SYMBOLS_CLASS = 'material-symbols-outlined'

--- a/src/app/header/header.component.html
+++ b/src/app/header/header.component.html
@@ -5,10 +5,10 @@
       aria-label="Color scheme toggle (dark or light)"
       id="dark-light-scheme-toggle"
     >
-      <span [class]="MATERIAL_SYMBOLS_CLASS" class="light-only">{{
+      <span class="light-only" appMaterialSymbol>{{
         MaterialSymbol.DarkTheme
       }}</span>
-      <span [class]="MATERIAL_SYMBOLS_CLASS" class="dark-only">{{
+      <span class="dark-only" appMaterialSymbol>{{
         MaterialSymbol.LightTheme
       }}</span>
     </button>

--- a/src/app/header/header.component.ts
+++ b/src/app/header/header.component.ts
@@ -1,7 +1,6 @@
 import { Component } from '@angular/core'
 import { DarkTheme, LightTheme } from '../material-symbols'
 import { ColorSchemeService } from './color-scheme.service'
-import { MATERIAL_SYMBOLS_CLASS } from '../common/material-symbols'
 
 @Component({
   selector: 'app-header',
@@ -9,7 +8,6 @@ import { MATERIAL_SYMBOLS_CLASS } from '../common/material-symbols'
   styleUrls: ['./header.component.scss'],
 })
 export class HeaderComponent {
-  protected readonly MATERIAL_SYMBOLS_CLASS = MATERIAL_SYMBOLS_CLASS
   protected readonly MaterialSymbol = {
     DarkTheme,
     LightTheme,

--- a/src/app/no-script/no-script.component.html
+++ b/src/app/no-script/no-script.component.html
@@ -1,7 +1,7 @@
 <noscript>
   <div class="contents">
     <p>
-      <span [class]="MATERIAL_SYMBOLS_CLASS">{{ MaterialSymbol.Warning }}</span>
+      <span appMaterialSymbol>{{ MaterialSymbol.Warning }}</span>
       <b>Seems you don't have JavaScript enabled</b>
     </p>
     <p>

--- a/src/app/no-script/no-script.component.ts
+++ b/src/app/no-script/no-script.component.ts
@@ -1,6 +1,5 @@
 import { Component } from '@angular/core'
 import { Warning } from '../material-symbols'
-import { MATERIAL_SYMBOLS_CLASS } from '../common/material-symbols'
 
 @Component({
   selector: 'app-no-script',
@@ -8,7 +7,6 @@ import { MATERIAL_SYMBOLS_CLASS } from '../common/material-symbols'
   styleUrls: ['./no-script.component.scss'],
 })
 export class NoScriptComponent {
-  protected readonly MATERIAL_SYMBOLS_CLASS = MATERIAL_SYMBOLS_CLASS
   protected readonly MaterialSymbol = {
     Warning,
   }

--- a/src/app/not-found/not-found.component.html
+++ b/src/app/not-found/not-found.component.html
@@ -11,7 +11,7 @@
 </h2>
 <div class="tip">
   <header>
-    <span [class]="MATERIAL_SYMBOLS_CLASS">{{ MaterialSymbol.Lightbulb }}</span
+    <span appMaterialSymbol>{{ MaterialSymbol.Lightbulb }}</span
     ><b>TIP: What if this page existed before?</b>
   </header>
   <p>

--- a/src/app/not-found/not-found.component.ts
+++ b/src/app/not-found/not-found.component.ts
@@ -1,6 +1,5 @@
 import { Component, Inject } from '@angular/core'
 import { Lightbulb } from '../material-symbols'
-import { MATERIAL_SYMBOLS_CLASS } from '../common/material-symbols'
 import { Router } from '@angular/router'
 import { Environment } from '../../environments'
 import { ENVIRONMENT } from '../common/injection-tokens'
@@ -12,7 +11,6 @@ import { ENVIRONMENT } from '../common/injection-tokens'
 })
 export class NotFoundComponent {
   public readonly currentUrlInWaybackMachine: URL
-  protected readonly MATERIAL_SYMBOLS_CLASS = MATERIAL_SYMBOLS_CLASS
   protected readonly MaterialSymbol = {
     Lightbulb,
   }

--- a/src/test/helpers/material-symbols.ts
+++ b/src/test/helpers/material-symbols.ts
@@ -1,4 +1,4 @@
 import { By } from '@angular/platform-browser'
-import { MATERIAL_SYMBOLS_CLASS } from '../../app/common/material-symbols'
+import { MATERIAL_SYMBOLS_CLASS } from '../../app/common/material-symbol.directive'
 
 export const MATERIAL_SYMBOLS_SELECTOR = By.css(`.${MATERIAL_SYMBOLS_CLASS}`)


### PR DESCRIPTION
To avoid adding a class around. Requires less code (no need to import + place it on component) and is more flexible (could be an attribute instead of a class or whatever)
