### PR TITLE
fix: use animations debugger to fix dark/light animations

### DIFF
--- a/src/app/about/_about-theme.scss
+++ b/src/app/about/_about-theme.scss
@@ -18,7 +18,7 @@
   app-about {
     @include h2-theme.motion;
     @include card-theme.motion;
-    @include presentation-theme.motion();
+    @include presentation-theme.motion;
     @include attribute-theme.motion;
     @include chip-theme.motion;
   }

--- a/src/app/about/card/_card-theme.scss
+++ b/src/app/about/card/_card-theme.scss
@@ -27,5 +27,7 @@
     );
 
     @include card-header-image-theme.motion;
+    @include card-header-subtitle-theme.motion;
+    @include card-header-detail-theme.motion;
   }
 }

--- a/src/app/about/card/card-header/card-header-detail/_card-header-detail-theme.scss
+++ b/src/app/about/card/card-header/card-header-detail/_card-header-detail-theme.scss
@@ -7,3 +7,9 @@
     color: map.get($text-palette, secondary);
   }
 }
+
+@mixin motion {
+  app-card-header-detail {
+    @include animations.single-transition(color, animations.$emphasized-style);
+  }
+}

--- a/src/app/about/card/card-header/card-header-subtitle/_card-header-subtitle-theme.scss
+++ b/src/app/about/card/card-header/card-header-subtitle/_card-header-subtitle-theme.scss
@@ -8,3 +8,9 @@
     color: map.get($text-palette, secondary);
   }
 }
+
+@mixin motion {
+  app-card-header-subtitle {
+    @include animations.single-transition(color, animations.$emphasized-style);
+  }
+}

--- a/src/app/about/presentation/_presentation-theme.scss
+++ b/src/app/about/presentation/_presentation-theme.scss
@@ -14,6 +14,8 @@
 @mixin motion() {
   app-presentation {
     @include profile-picture-theme.motion();
+    @include contact-traditional-icons-theme.motion;
+    @include contact-social-icons-theme.motion;
   }
 }
 

--- a/src/app/about/presentation/contact-social-icons/_contact-social-icons-theme.scss
+++ b/src/app/about/presentation/contact-social-icons/_contact-social-icons-theme.scss
@@ -1,3 +1,5 @@
+@use 'animations';
+
 @mixin color($theme) {
   $text-palette: map-get($theme, text);
 
@@ -7,5 +9,10 @@
     li:hover {
       color: map-get($text-palette, secondary);
     }
+  }
+}
+@mixin motion {
+  app-contact-social-icons {
+    @include animations.single-transition(color, animations.$emphasized-style);
   }
 }

--- a/src/app/about/presentation/contact-traditional-icons/_contact-traditional-icons-theme.scss
+++ b/src/app/about/presentation/contact-traditional-icons/_contact-traditional-icons-theme.scss
@@ -1,3 +1,5 @@
+@use 'animations';
+
 @mixin color($theme) {
   $text-palette: map-get($theme, text);
 
@@ -7,5 +9,10 @@
     li:hover {
       color: map-get($text-palette, secondary);
     }
+  }
+}
+@mixin motion {
+  app-contact-traditional-icons {
+    @include animations.single-transition(color, animations.$emphasized-style);
   }
 }

--- a/src/app/about/presentation/description/description.component.scss
+++ b/src/app/about/presentation/description/description.component.scss
@@ -1,6 +1,5 @@
 @use 'margins';
 @use 'material-symbols';
-@use 'paddings';
 
 :host {
   &.hidden {

--- a/src/app/about/presentation/profile-picture/_profile-picture-theme.scss
+++ b/src/app/about/presentation/profile-picture/_profile-picture-theme.scss
@@ -35,7 +35,8 @@
       transition: animations.transition(opacity),
         animations.transition(visibility),
         animations.transition(filter, animations.$emphasized-style),
-        animations.transition(background-color, animations.$emphasized-style);
+        animations.transition(background-color, animations.$emphasized-style),
+        animations.transition(border-color, animations.$emphasized-style);
     }
 
     .comment {

--- a/src/app/header/_header-theme.scss
+++ b/src/app/header/_header-theme.scss
@@ -25,7 +25,7 @@
 @mixin motion() {
   app-header {
     @include animations.multiple-transitions(
-      (background-color, color),
+      (background-color, border-color),
       animations.$emphasized-style
     );
   }

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1,5 +1,6 @@
 @use 'sass:color';
 @use 'sass:map';
+@use 'animations';
 @use 'app/app-theme' as root-theme;
 @use 'app/about/about-theme';
 @use 'app/header/header-theme';
@@ -31,6 +32,10 @@ pre {
 a {
   text-decoration-line: underline;
   text-decoration-thickness: 2px;
+  @include animations.single-transition(
+    text-decoration-color,
+    animations.$emphasized-style
+  );
 }
 
 // Needed for some accessibility tricks around


### PR DESCRIPTION
Use DevTools animation debugger to ensure all item animate when switching between dark and light color schemes.

Mystery: `app-chip` does not animate. `transition-` attributes are placed but animation doesn't trigger. When placing `!important` in the background-color definition seems at least the background animates when clicking. But not when switching themes. Weeeeeird.
