### PR TITLE
test: add util to query by component type

### DIFF
--- a/src/app/about/chipped-content/chipped-content.component.spec.ts
+++ b/src/app/about/chipped-content/chipped-content.component.spec.ts
@@ -3,7 +3,6 @@ import { ChippedContentComponent } from './chipped-content.component'
 import { Component, DebugElement, PLATFORM_ID } from '@angular/core'
 import { ChippedContent } from './chipped-content'
 import { By } from '@angular/platform-browser'
-import { getComponentSelector } from '../../../test/helpers/component-testers'
 import { ChipComponent } from '../chip/chip.component'
 import {
   expectIsHidden,
@@ -18,6 +17,10 @@ import {
   PLATFORM_SERVER_ID,
   PlatformId,
 } from '../../../test/helpers/platform-ids'
+import {
+  byComponent,
+  getComponentSelector,
+} from '../../../test/helpers/component-query-predicates'
 
 @Component({
   selector: 'app-foo',
@@ -86,7 +89,7 @@ describe('ChippedContentComponent', () => {
       expect(selectableChipsContainerElement).toBeTruthy()
 
       const chipElements = selectableChipsContainerElement.queryAll(
-        By.css(getComponentSelector(ChipComponent)),
+        byComponent(ChipComponent),
       )
       expect(chipElements.length).toEqual(contents.length)
       chipElements.forEach((chipElement, index) => {
@@ -115,18 +118,14 @@ describe('ChippedContentComponent', () => {
 
     // They're displayed in non-JS version thanks to helper classes
     it('should add and setup all content components, but hidden', () => {
-      const fooElement = fixture.debugElement.query(
-        By.css(getComponentSelector(FooComponent)),
-      )
+      const fooElement = fixture.debugElement.query(byComponent(FooComponent))
       expect(fooElement).toBeTruthy()
       expect(fooElement.nativeElement.textContent.trim())
         .withContext(`foo element contents`)
         .toEqual(fooContentData)
       expectIsHidden(fooElement.nativeElement)
 
-      const barElement = fixture.debugElement.query(
-        By.css(getComponentSelector(BarComponent)),
-      )
+      const barElement = fixture.debugElement.query(byComponent(BarComponent))
       expect(barElement).toBeTruthy()
       expect(barElement.nativeElement.textContent.trim())
         .withContext(`bar element contents`)
@@ -167,14 +166,10 @@ describe('ChippedContentComponent', () => {
     )
 
     it('should not add any content component or non-selectable chip', () => {
-      const fooElement = fixture.debugElement.query(
-        By.css(getComponentSelector(FooComponent)),
-      )
+      const fooElement = fixture.debugElement.query(byComponent(FooComponent))
       expect(fooElement).toBeFalsy()
 
-      const barElement = fixture.debugElement.query(
-        By.css(getComponentSelector(BarComponent)),
-      )
+      const barElement = fixture.debugElement.query(byComponent(BarComponent))
       expect(barElement).toBeFalsy()
 
       const chipElements = fixture.debugElement.children.filter(
@@ -214,7 +209,7 @@ describe('ChippedContentComponent', () => {
 
       it('should display its content', () => {
         const fooContentElement = fixture.debugElement.query(
-          By.css(getComponentSelector(FooComponent)),
+          byComponent(FooComponent),
         )
         expect(fooContentElement).toBeTruthy()
         expectIsVisible(fooContentElement.nativeElement)
@@ -236,7 +231,7 @@ describe('ChippedContentComponent', () => {
 
         it('should remove its content', () => {
           const fooContentElement = fixture.debugElement.query(
-            By.css(getComponentSelector(FooComponent)),
+            byComponent(FooComponent),
           )
           expect(fooContentElement).toBeFalsy()
         })
@@ -263,12 +258,12 @@ describe('ChippedContentComponent', () => {
 
         it('should remove its content and display the content of the tapped chip', () => {
           const fooContentElement = fixture.debugElement.query(
-            By.css(getComponentSelector(FooComponent)),
+            byComponent(FooComponent),
           )
           expect(fooContentElement).toBeFalsy()
 
           const barContentElement = fixture.debugElement.query(
-            By.css(getComponentSelector(BarComponent)),
+            byComponent(BarComponent),
           )
           expect(barContentElement).toBeTruthy()
           expectIsVisible(barContentElement.nativeElement)

--- a/src/app/about/education/education-item/education-item.component.spec.ts
+++ b/src/app/about/education/education-item/education-item.component.spec.ts
@@ -5,7 +5,6 @@ import { EducationItem } from './education-item'
 import { Organization } from '../../organization'
 import { By } from '@angular/platform-browser'
 import { NgOptimizedImage } from '@angular/common'
-import { getComponentSelector } from '../../../../test/helpers/component-testers'
 import { DateRangeComponent } from '../../date-range/date-range.component'
 import { DateRange } from '../../date-range/date-range'
 import { MockComponents } from 'ng-mocks'
@@ -21,6 +20,7 @@ import { CardHeaderComponent } from '../../card/card-header/card-header.componen
 import { CardHeaderTextsComponent } from '../../card/card-header/card-header-texts/card-header-texts.component'
 import { CardHeaderAttributesComponent } from '../../card/card-header/card-header-attributes/card-header-attributes.component'
 import { AttributeComponent } from '../../attribute/attribute.component'
+import { byComponent } from '../../../../test/helpers/component-query-predicates'
 
 describe('EducationItemComponent', () => {
   let component: EducationItemComponent
@@ -118,7 +118,7 @@ describe('EducationItemComponent', () => {
     setEducationItem(fixture)
 
     const dateRangeElement = fixture.debugElement.query(
-      By.css(getComponentSelector(DateRangeComponent)),
+      byComponent(DateRangeComponent),
     )
     expect(dateRangeElement).toBeTruthy()
   })

--- a/src/app/about/education/education.component.spec.ts
+++ b/src/app/about/education/education.component.spec.ts
@@ -5,8 +5,7 @@ import { MockComponents } from 'ng-mocks'
 import { H2Component } from '../h2/h2.component'
 import { EducationItemComponent } from './education-item/education-item.component'
 import { EducationItemsService } from './education-items.service'
-import { By } from '@angular/platform-browser'
-import { getComponentSelector } from '../../../test/helpers/component-testers'
+import { byComponent } from '../../../test/helpers/component-query-predicates'
 
 describe('EducationComponent', () => {
   let component: EducationComponent
@@ -31,7 +30,7 @@ describe('EducationComponent', () => {
   it('should display all items', () => {
     const educationItemsService = TestBed.inject(EducationItemsService)
     const educationItemElements = fixture.debugElement.queryAll(
-      By.css(getComponentSelector(EducationItemComponent)),
+      byComponent(EducationItemComponent),
     )
     expect(educationItemElements.length).toBe(
       educationItemsService.getEducationItems().length,

--- a/src/app/about/experience/experience-item/experience-item.component.spec.ts
+++ b/src/app/about/experience/experience-item/experience-item.component.spec.ts
@@ -10,10 +10,7 @@ import { By } from '@angular/platform-browser'
 import { NoopAnimationsModule } from '@angular/platform-browser/animations'
 import { Organization } from '../../organization'
 import { DateRange } from '../../date-range/date-range'
-import {
-  ensureHasComponent,
-  getComponentSelector,
-} from '../../../../test/helpers/component-testers'
+import { ensureHasComponent } from '../../../../test/helpers/component-testers'
 import { DateRangeComponent } from '../../date-range/date-range.component'
 import { MockComponents } from 'ng-mocks'
 import { CardComponent } from '../../card/card.component'
@@ -33,6 +30,7 @@ import { ChippedContentComponent } from '../../chipped-content/chipped-content.c
 import { ExperienceItemSummaryComponent } from './experience-item-summary/experience-item-summary.component'
 import { ChippedContent } from '../../chipped-content/chipped-content'
 import { ExperienceItemHighlightsComponent } from './experience-item-highlights/experience-item-highlights.component'
+import { byComponent } from '../../../../test/helpers/component-query-predicates'
 
 describe('ExperienceItem', () => {
   let component: ExperienceItemComponent
@@ -132,7 +130,7 @@ describe('ExperienceItem', () => {
       setExperienceItem(fixture)
 
       const dateRangeElement = fixture.debugElement.query(
-        By.css(getComponentSelector(DateRangeComponent)),
+        byComponent(DateRangeComponent),
       )
       expect(dateRangeElement).toBeTruthy()
     })
@@ -272,7 +270,7 @@ describe('ExperienceItem', () => {
       setExperienceItem(fixture, { summary })
 
       const chippedContentElement = fixture.debugElement.query(
-        By.css(getComponentSelector(ChippedContentComponent)),
+        byComponent(ChippedContentComponent),
       )
       expect(chippedContentElement).toBeTruthy()
       chippedContentElement.triggerEventHandler('contentDisplayedChange', true)
@@ -291,7 +289,7 @@ describe('ExperienceItem', () => {
       setExperienceItem(fixture, { summary })
 
       const chippedContentElement = fixture.debugElement.query(
-        By.css(getComponentSelector(ChippedContentComponent)),
+        byComponent(ChippedContentComponent),
       )
       expect(chippedContentElement).toBeTruthy()
       chippedContentElement.triggerEventHandler('contentDisplayedChange', false)

--- a/src/app/about/experience/experience.component.spec.ts
+++ b/src/app/about/experience/experience.component.spec.ts
@@ -3,12 +3,9 @@ import { ExperienceComponent } from './experience.component'
 import { MockComponents } from 'ng-mocks'
 import { ExperienceItemComponent } from './experience-item/experience-item.component'
 import { H2Component } from '../h2/h2.component'
-import {
-  ensureHasComponent,
-  getComponentSelector,
-} from '../../../test/helpers/component-testers'
-import { By } from '@angular/platform-browser'
+import { ensureHasComponent } from '../../../test/helpers/component-testers'
 import { ExperienceItemsService } from './experience-items.service'
+import { byComponent } from '../../../test/helpers/component-query-predicates'
 
 describe('ExperienceComponent', () => {
   let component: ExperienceComponent
@@ -33,7 +30,7 @@ describe('ExperienceComponent', () => {
   it('should display all items', () => {
     const experienceItemsService = TestBed.inject(ExperienceItemsService)
     const itemElements = fixture.debugElement.queryAll(
-      By.css(getComponentSelector(ExperienceItemComponent)),
+      byComponent(ExperienceItemComponent),
     )
     expect(itemElements.length).toBe(
       experienceItemsService.getExperienceItems().length,

--- a/src/app/about/presentation/contact-social-icons/contact-social-icons.component.spec.ts
+++ b/src/app/about/presentation/contact-social-icons/contact-social-icons.component.spec.ts
@@ -3,11 +3,11 @@ import { ComponentFixture, TestBed } from '@angular/core/testing'
 import { By } from '@angular/platform-browser'
 import { FaIconComponent } from '@fortawesome/angular-fontawesome'
 import { MockProvider } from 'ng-mocks'
-import { getComponentSelector } from '../../../../test/helpers/component-testers'
 import { METADATA } from '../../../common/injection-tokens'
 import { Metadata } from '../../../metadata'
 
 import { ContactSocialIconsComponent } from './contact-social-icons.component'
+import { byComponent } from '../../../../test/helpers/component-query-predicates'
 
 describe('ContactSocialIconsComponent', () => {
   let component: ContactSocialIconsComponent
@@ -58,9 +58,7 @@ describe('ContactSocialIconsComponent', () => {
       .toBe(component.items.length)
     component.items.forEach((item, index) => {
       const itemElement = itemElements[index]
-      const iconElement = itemElement.query(
-        By.css(getComponentSelector(FaIconComponent)),
-      )
+      const iconElement = itemElement.query(byComponent(FaIconComponent))
       expect(getIconNameFromFontAwesomeElement(iconElement))
         .withContext(`item ${index} icon`)
         .toEqual(item.icon.iconName)

--- a/src/app/about/presentation/description/description.component.spec.ts
+++ b/src/app/about/presentation/description/description.component.spec.ts
@@ -8,7 +8,6 @@ import {
 import { By } from '@angular/platform-browser'
 import { NoopAnimationsModule } from '@angular/platform-browser/animations'
 import { MockProvider } from 'ng-mocks'
-import { getComponentSelector } from '../../../../test/helpers/component-testers'
 import { MATERIAL_SYMBOLS_SELECTOR } from '../../../../test/helpers/material-symbols'
 import {
   PLATFORM_BROWSER_ID,
@@ -26,6 +25,7 @@ import {
   DescriptionComponent,
 } from './description.component'
 import { MaterialSymbolDirective } from '../../../common/material-symbol.directive'
+import { byComponent } from '../../../../test/helpers/component-query-predicates'
 
 describe('DescriptionComponent', () => {
   let component: DescriptionComponent
@@ -132,7 +132,7 @@ describe('DescriptionComponent', () => {
         childrenElements.forEach((childElement, index) => {
           // Contains line element
           const childLineElement = childElement.query(
-            By.css(getComponentSelector(DescriptionComponent)),
+            byComponent(DescriptionComponent),
           )
           expect(childLineElement)
             .withContext(`child ${index} line element`)

--- a/src/test/helpers/component-query-predicates.ts
+++ b/src/test/helpers/component-query-predicates.ts
@@ -1,0 +1,61 @@
+import {
+  DebugElement,
+  Predicate,
+  reflectComponentType,
+  Type,
+} from '@angular/core'
+import { isClass } from './types'
+import { By } from '@angular/platform-browser'
+
+/**
+ * Creates a predicate to query for a debug element given the component type to look for
+ *
+ * So instead of
+ * ```
+ * const componentDebugElement = fixture.debugElement.query(By.css('app-foo'));
+ * ```
+ *
+ * You can just
+ *
+ * ```
+ * const componentDebugElement = fixture.debugElement.query(byComponent(FooComponent));
+ * ```
+ */
+export function byComponent<C>(component: Type<C>): Predicate<DebugElement> {
+  return By.css(getComponentSelector(component))
+}
+
+/**
+ * Returns the component HTML tag name (selector) given its type
+ *
+ * Useful to identify a component without hard-coding the component's HTML tag
+ *
+ * @see byComponent for simple queries by component type
+ *
+ * So instead of
+ * ```
+ * const componentDebugElement = fixture.debugElement.query(
+ *  By.css('app-foo.selected')
+ * );
+ * ```
+ *
+ * You can just
+ *
+ * ```
+ * const componentDebugElement = fixture.debugElement.query(
+ *  By.css(`${getComponentSelector(FooComponent)}.selected`)
+ * );
+ * ```
+ */
+export function getComponentSelector<C>(component: Type<C>) {
+  if (!isClass(component)) {
+    throw new Error('Component argument is not a class')
+  }
+  const selector = reflectComponentType(component)?.selector
+  if (!selector) {
+    throw new Error(
+      `Selector not found for alleged component: ${component.constructor.name}`,
+    )
+  }
+  return selector
+}

--- a/src/test/helpers/component-test-setup.ts
+++ b/src/test/helpers/component-test-setup.ts
@@ -1,6 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing'
 import { Component, Type } from '@angular/core'
-import { getComponentSelector } from './component-testers'
+import { getComponentSelector } from './component-query-predicates'
 
 /**
  * Sets up a basic component test given the component to test

--- a/src/test/helpers/component-testers.ts
+++ b/src/test/helpers/component-testers.ts
@@ -1,16 +1,10 @@
-import {
-  DebugElement,
-  Predicate,
-  reflectComponentType,
-  Type,
-} from '@angular/core'
+import { DebugElement, Predicate, Type } from '@angular/core'
 import { ComponentFixture } from '@angular/core/testing'
-import { By } from '@angular/platform-browser'
-import { isClass } from './types'
 import {
   makeHostComponent,
   testSetupWithHostComponent,
 } from './component-test-setup'
+import { byComponent } from './component-query-predicates'
 
 const COMPONENT_CLASS_SUFFIX = 'Component'
 
@@ -31,7 +25,7 @@ export function ensureHasComponent<T, U>(
       .toLowerCase()
   it(`should render the ${name}`, () => {
     const debugElement = fixtureGetter().debugElement.query(
-      By.css(getComponentSelector(component)),
+      byComponent(component),
     )
     expect(debugElement).toBeTruthy()
   })
@@ -52,33 +46,6 @@ export function ensureHasComponents<T>(
 }
 
 /**
- * Useful to identify a component without hard-coding the component's HTML tag
- *
- * So instead of
- * ```
- * const componentDebugElement = fixture.debugElement.query(By.css('app-foo'));
- * ```
- *
- * You can just
- *
- * ```
- * const componentDebugElement = fixture.debugElement.query(By.css(getComponentSelector(FooComponent)));
- * ```
- */
-export function getComponentSelector<C>(component: Type<C>) {
-  if (!isClass(component)) {
-    throw new Error('Component argument is not a class')
-  }
-  const selector = reflectComponentType(component)?.selector
-  if (!selector) {
-    throw new Error(
-      `Selector not found for alleged component: ${component.constructor.name}`,
-    )
-  }
-  return selector
-}
-
-/**
  * Ensures the given component contains the child content passed to it
  *
  * @see https://stackoverflow.com/a/61724478/3263250
@@ -93,9 +60,7 @@ export function ensureProjectsContent(
     const [fixture] = testSetupWithHostComponent(hostComponent, component)
     // No change detection triggered given nothing may have changed
 
-    const componentElement = fixture.debugElement.query(
-      By.css(getComponentSelector(component)),
-    )
+    const componentElement = fixture.debugElement.query(byComponent(component))
     expect(componentElement).toBeTruthy()
 
     const projectionContainerElement = !projectionContainerPredicate


### PR DESCRIPTION
Instead of `By.css(getComponentSelector(FooComponent))` -> `byComponent(FooComponent)`
