### PR TITLE
feat(experience): wait for animation to collapse row span

### DIFF
--- a/src/app/about/chipped-content/chipped-content.component.ts
+++ b/src/app/about/chipped-content/chipped-content.component.ts
@@ -8,6 +8,7 @@ import {
   OnInit,
   Output,
   PLATFORM_ID,
+  Type,
   ViewChild,
   ViewContainerRef,
 } from '@angular/core'
@@ -29,7 +30,8 @@ export class ChippedContentComponent implements OnInit {
   public contentHost!: ViewContainerRef
   private HIDDEN_CLASS = 'hidden'
   public selectedContentId?: string
-  private isRenderingOnBrowser: boolean
+  private selectedContentComponent?: Type<unknown>
+  private readonly isRenderingOnBrowser: boolean
   @Output() contentDisplayedChange = new EventEmitter<boolean>()
 
   constructor(@Inject(PLATFORM_ID) platformId: object) {
@@ -57,11 +59,13 @@ export class ChippedContentComponent implements OnInit {
     }
   }
 
-  setSelectedContent(id: string) {
+  async setSelectedContent(id: string) {
     // Tapping same chip hides content
     if (this.selectedContentId === id) {
+      const content = this.contents.find((content) => content.id === id)!
       this.contentHost.clear()
       this.selectedContentId = undefined
+      await content.waitForAnimationEnd(this.selectedContentComponent)
       this.contentDisplayedChange.emit(false)
       return
     }
@@ -83,6 +87,8 @@ export class ChippedContentComponent implements OnInit {
       content.component,
     )
     content.setupComponent(contentComponentRef.instance)
+    this.selectedContentComponent =
+      contentComponentRef.instance as Type<unknown>
     return contentComponentRef
   }
 }

--- a/src/app/about/chipped-content/chipped-content.ts
+++ b/src/app/about/chipped-content/chipped-content.ts
@@ -5,21 +5,29 @@ export class ChippedContent<T, U> {
   public readonly displayName: string
   public readonly component: Type<U>
   public readonly setupComponent: (component: U) => void
+  public readonly waitForAnimationEnd: (component: U) => Promise<void>
 
   constructor({
     id,
     displayName,
     component,
     setupComponent,
+    waitForAnimationEnd,
   }: {
     id: T
     displayName: string
     component: Type<U>
     setupComponent: (component: U) => void
+    waitForAnimationEnd?: (component: U) => Promise<void>
   }) {
     this.id = id
     this.displayName = displayName
     this.component = component
     this.setupComponent = setupComponent
+    this.waitForAnimationEnd = waitForAnimationEnd ?? noWaitForAnimationEnd
   }
+}
+
+async function noWaitForAnimationEnd() {
+  return
 }

--- a/src/app/about/experience/experience-item/experience-item-highlights/experience-item-highlights.component.spec.ts
+++ b/src/app/about/experience/experience-item/experience-item-highlights/experience-item-highlights.component.spec.ts
@@ -33,4 +33,13 @@ describe('ExperienceItemHighlightsComponent', () => {
       )
     })
   })
+
+  it('should emit animation done event when animation finishes', () => {
+    let eventEmitted = false
+    component.enterAndLeaveAnimationDone.subscribe(() => {
+      eventEmitted = true
+    })
+    fixture.debugElement.triggerEventHandler('@enterAndLeave.done')
+    expect(eventEmitted).toBeTrue()
+  })
 })

--- a/src/app/about/experience/experience-item/experience-item-highlights/experience-item-highlights.component.ts
+++ b/src/app/about/experience/experience-item/experience-item-highlights/experience-item-highlights.component.ts
@@ -1,4 +1,10 @@
-import { Component, HostBinding, Input } from '@angular/core'
+import {
+  Component,
+  EventEmitter,
+  HostBinding,
+  HostListener,
+  Input,
+} from '@angular/core'
 import { slideDownOnEnterAndSlideUpOnLeave } from '../../../../common/animations'
 
 @Component({
@@ -14,4 +20,10 @@ import { slideDownOnEnterAndSlideUpOnLeave } from '../../../../common/animations
 export class ExperienceItemHighlightsComponent {
   @HostBinding('@enterAndLeave') public enterAndLeaveAnimation = true
   @Input({ required: true }) public highlights!: readonly string[]
+
+  public enterAndLeaveAnimationDone = new EventEmitter<void>()
+  @HostListener('@enterAndLeave.done')
+  protected onEnterAndLeaveAnimationDone() {
+    this.enterAndLeaveAnimationDone.emit()
+  }
 }

--- a/src/app/about/experience/experience-item/experience-item-summary/experience-item-summary.component.spec.ts
+++ b/src/app/about/experience/experience-item/experience-item-summary/experience-item-summary.component.spec.ts
@@ -28,4 +28,13 @@ describe('ExperienceItemSummaryComponent', () => {
       summary,
     )
   })
+
+  it('should emit animation done event when animation finishes', () => {
+    let eventEmitted = false
+    component.enterAndLeaveAnimationDone.subscribe(() => {
+      eventEmitted = true
+    })
+    fixture.debugElement.triggerEventHandler('@enterAndLeave.done')
+    expect(eventEmitted).toBeTrue()
+  })
 })

--- a/src/app/about/experience/experience-item/experience-item-summary/experience-item-summary.component.ts
+++ b/src/app/about/experience/experience-item/experience-item-summary/experience-item-summary.component.ts
@@ -1,4 +1,10 @@
-import { Component, HostBinding, Input } from '@angular/core'
+import {
+  Component,
+  EventEmitter,
+  HostBinding,
+  HostListener,
+  Input,
+} from '@angular/core'
 import { slideDownOnEnterAndSlideUpOnLeave } from '../../../../common/animations'
 
 @Component({
@@ -17,4 +23,10 @@ export class ExperienceItemSummaryComponent {
   @HostBinding('@enterAndLeave') public readonly enterOrLeaveAnimation = true
   @Input({ required: true })
   public summary!: string
+
+  public enterAndLeaveAnimationDone = new EventEmitter<void>()
+  @HostListener('@enterAndLeave.done')
+  protected onEnterAndLeaveAnimationDone() {
+    this.enterAndLeaveAnimationDone.emit()
+  }
 }

--- a/src/app/about/experience/experience-item/experience-item.component.spec.ts
+++ b/src/app/about/experience/experience-item/experience-item.component.spec.ts
@@ -1,4 +1,9 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing'
+import {
+  ComponentFixture,
+  fakeAsync,
+  TestBed,
+  tick,
+} from '@angular/core/testing'
 import {
   Attribute,
   ContentId,
@@ -30,6 +35,7 @@ import { ExperienceItemSummaryComponent } from './experience-item-summary/experi
 import { ChippedContent } from '../../chipped-content/chipped-content'
 import { ExperienceItemHighlightsComponent } from './experience-item-highlights/experience-item-highlights.component'
 import { byComponent } from '../../../../test/helpers/component-query-predicates'
+import { EventEmitter } from '@angular/core'
 
 describe('ExperienceItem', () => {
   let component: ExperienceItemComponent
@@ -232,16 +238,30 @@ describe('ExperienceItem', () => {
       setExperienceItem(fixture, { summary })
     })
 
-    it('should generate its content item', () => {
+    it('should generate its content item', fakeAsync(() => {
       const summaryContent = component.contents.find(
         (content) => content.id === ContentId.Summary,
       ) as ChippedContent<ContentId, ExperienceItemSummaryComponent>
       expect(summaryContent).toBeTruthy()
+
       expect(summaryContent!.component).toEqual(ExperienceItemSummaryComponent)
-      const mockSummaryComponent = {} as ExperienceItemSummaryComponent
+
+      const mockSummaryComponent = {
+        enterAndLeaveAnimationDone: new EventEmitter<void>(),
+      } as ExperienceItemSummaryComponent
       summaryContent!.setupComponent(mockSummaryComponent)
       expect(mockSummaryComponent.summary).toEqual(summary)
-    })
+
+      let endedAnimation = false
+      summaryContent
+        .waitForAnimationEnd(mockSummaryComponent)
+        .then(() => (endedAnimation = true))
+      tick()
+      expect(endedAnimation).toBeFalse()
+      mockSummaryComponent.enterAndLeaveAnimationDone.emit()
+      tick()
+      expect(endedAnimation).toBeTrue()
+    }))
   })
 
   describe('when experience has highlights', () => {
@@ -250,18 +270,32 @@ describe('ExperienceItem', () => {
       setExperienceItem(fixture, { highlights })
     })
 
-    it('should generate its content item', () => {
+    it('should generate its content item', fakeAsync(() => {
       const highlightContent = component.contents.find(
         (content) => content.id === ContentId.Highlights,
       ) as ChippedContent<ContentId, ExperienceItemHighlightsComponent>
       expect(highlightContent).toBeTruthy()
+
       expect(highlightContent!.component).toEqual(
         ExperienceItemHighlightsComponent,
       )
-      const mockHighlightsComponent = {} as ExperienceItemHighlightsComponent
+
+      const mockHighlightsComponent = {
+        enterAndLeaveAnimationDone: new EventEmitter<void>(),
+      } as ExperienceItemHighlightsComponent
       highlightContent!.setupComponent(mockHighlightsComponent)
       expect(mockHighlightsComponent.highlights).toEqual(highlights)
-    })
+
+      let endedAnimation = false
+      highlightContent
+        .waitForAnimationEnd(mockHighlightsComponent)
+        .then(() => (endedAnimation = true))
+      tick()
+      expect(endedAnimation).toBeFalse()
+      mockHighlightsComponent.enterAndLeaveAnimationDone.emit()
+      tick()
+      expect(endedAnimation).toBeTrue()
+    }))
   })
   describe('when content is displayed', () => {
     const summary = 'summary'

--- a/src/app/about/experience/experience-item/experience-item.component.ts
+++ b/src/app/about/experience/experience-item/experience-item.component.ts
@@ -11,6 +11,7 @@ import { SlugGeneratorService } from '../../../common/slug-generator.service'
 import { ChippedContent } from '../../chipped-content/chipped-content'
 import { ExperienceItemSummaryComponent } from './experience-item-summary/experience-item-summary.component'
 import { ExperienceItemHighlightsComponent } from './experience-item-highlights/experience-item-highlights.component'
+import { firstValueFrom } from 'rxjs'
 
 @Component({
   selector: 'app-experience-item',
@@ -40,6 +41,9 @@ export class ExperienceItemComponent {
           setupComponent: (component) => {
             component.summary = this.item.summary
           },
+          waitForAnimationEnd: async (component) => {
+            await firstValueFrom(component.enterAndLeaveAnimationDone)
+          },
         }),
       )
     }
@@ -51,6 +55,9 @@ export class ExperienceItemComponent {
           component: ExperienceItemHighlightsComponent,
           setupComponent: (component) => {
             component.highlights = this.item.highlights
+          },
+          waitForAnimationEnd: async (component) => {
+            await firstValueFrom(component.enterAndLeaveAnimationDone)
           },
         }),
       )


### PR DESCRIPTION
Adds a method to `ChippedContentComponent` to allow animations to finish before emitting the new content displayed event. Which allows to collapse the item in the grid after animation finishes and not before.
