### PR TITLE
refactor: add local image service

### DIFF
--- a/src/app/about/education/education-item/education-item.component.html
+++ b/src/app/about/education/education-item/education-item.component.html
@@ -2,7 +2,7 @@
   <app-card-header>
     <app-link [href]="item.institution.website?.toString()" appTestId="image">
       <app-card-header-image
-        [src]="item.institution.image.toString()"
+        [src]="item.institution.imageSrc"
         [alt]="item.institution.name + ' logo'"
       >
       </app-card-header-image>

--- a/src/app/about/education/education-item/education-item.component.spec.ts
+++ b/src/app/about/education/education-item/education-item.component.spec.ts
@@ -77,7 +77,7 @@ describe('EducationItemComponent', () => {
     const website = 'https://example.org/'
     const institution = new Organization({
       name: 'Some cool name',
-      image: new URL(imageUrl),
+      imageSrc: imageUrl,
       website: new URL(website),
     })
     setEducationItem(fixture, { institution })
@@ -99,7 +99,7 @@ describe('EducationItemComponent', () => {
     const website = 'https://example.org/'
     const institution = new Organization({
       name,
-      image: new URL('https://example.org/logo.png'),
+      imageSrc: 'https://example.org/logo.png',
       website: new URL(website),
     })
     setEducationItem(fixture, { institution })
@@ -119,7 +119,7 @@ describe('EducationItemComponent', () => {
       setEducationItem(fixture, {
         institution: new Organization({
           name,
-          image: new URL('https://example.org'),
+          imageSrc: 'https://example.org',
           shortName,
         }),
       })
@@ -261,7 +261,7 @@ function setEducationItem(
   fixture.componentInstance.item = new EducationItem({
     institution: new Organization({
       name: 'Institution name',
-      image: new URL('https://example.org/logo.png'),
+      imageSrc: 'https://example.org/logo.png',
       website: new URL('https://example.org'),
     }),
     area: 'Area',

--- a/src/app/about/education/json-resume-education-item-adapter.service.spec.ts
+++ b/src/app/about/education/json-resume-education-item-adapter.service.spec.ts
@@ -78,7 +78,9 @@ describe('JsonResumeEducationItemAdapterService', () => {
       it('should map the image', () => {
         const image = 'https://example.org/logo.png'
 
-        const item = makeSut().adapt(makeJsonResumeEducationItem({ image }))
+        const item = makeSut({ mapJsonResumeImages: false }).adapt(
+          makeJsonResumeEducationItem({ image }),
+        )
 
         expect(item.institution.imageSrc).toEqual(image)
       })

--- a/src/app/about/education/json-resume-education-item-adapter.service.spec.ts
+++ b/src/app/about/education/json-resume-education-item-adapter.service.spec.ts
@@ -53,6 +53,7 @@ describe('JsonResumeEducationItemAdapterService', () => {
       expect(item.dateRange.start).toEqual(new Date(startDate))
       expect(item.dateRange.end).toEqual(new Date(endDate))
     })
+
     describe('when no end date', () => {
       it('should map no end date exists too', () => {
         const endDate = undefined

--- a/src/app/about/education/json-resume-education-item-adapter.service.spec.ts
+++ b/src/app/about/education/json-resume-education-item-adapter.service.spec.ts
@@ -47,8 +47,8 @@ describe('JsonResumeEducationItemAdapterService', () => {
         expect(educationItem.institution.website).toEqual(
           new URL(fakeJsonResumeEducationItem.url),
         )
-        expect(educationItem.institution.image).toEqual(
-          new URL(fakeJsonResumeEducationItem.image),
+        expect(educationItem.institution.imageSrc).toEqual(
+          fakeJsonResumeEducationItem.image,
         )
         expect(educationItem.institution.shortName).toEqual(
           fakeJsonResumeEducationItem.shortName,
@@ -137,7 +137,7 @@ describe('JsonResumeEducationItemAdapterService', () => {
           const expectedImageFileName = 'fin'
           const educationItem = sut.adapt(fakeJsonResumeEducationItem)
 
-          expect(educationItem.institution.image.toString()).toEqual(
+          expect(educationItem.institution.imageSrc).toEqual(
             fakeCanonicalUrl.toString() +
               sut.EDUCATION_IMAGES_PATH +
               expectedImageFileName +
@@ -155,7 +155,7 @@ describe('JsonResumeEducationItemAdapterService', () => {
           const expectedImageFileName = 'fake-institution-name'
           const educationItem = sut.adapt(fakeJsonResumeEducationItem)
 
-          expect(educationItem.institution.image.toString()).toEqual(
+          expect(educationItem.institution.imageSrc).toEqual(
             fakeCanonicalUrl.toString() +
               sut.EDUCATION_IMAGES_PATH +
               expectedImageFileName +

--- a/src/app/about/education/json-resume-education-item-adapter.service.spec.ts
+++ b/src/app/about/education/json-resume-education-item-adapter.service.spec.ts
@@ -10,135 +10,98 @@ import {
 
 describe('JsonResumeEducationItemAdapterService', () => {
   it('should be created', () => {
-    TestBed.configureTestingModule({})
-    expect(TestBed.inject(JsonResumeEducationItemAdapterService)).toBeTruthy()
+    expect(makeSut()).toBeTruthy()
   })
 
   describe('#adapt', () => {
-    const sampleJsonResumeEducationItem = resume.education[0]
+    it('should map the institution name, website and short name', () => {
+      const institution = 'Fake institution name'
+      const url = 'https://example.org/'
+      const shortName = 'FIN'
 
-    describe('when images mapping is disabled', () => {
-      let sut: JsonResumeEducationItemAdapterService
+      const item = makeSut().adapt(
+        makeJsonResumeEducationItem({ institution, url, shortName }),
+      )
 
-      beforeEach(() => {
-        const fakeEnvironment: Pick<Environment, 'mapJsonResumeImages'> = {
-          mapJsonResumeImages: false,
-        }
-        TestBed.configureTestingModule({
-          providers: [MockProvider(ENVIRONMENT, fakeEnvironment)],
-        })
-        sut = TestBed.inject(JsonResumeEducationItemAdapterService)
-      })
+      expect(item.institution.name).toEqual(institution)
+      expect(item.institution.website).toEqual(new URL(url))
+      expect(item.institution.shortName).toEqual(shortName)
+    })
 
-      it('should map the institution name, shortName, image and website', () => {
-        const fakeJsonResumeEducationItem: JsonResumeEducationItem = {
-          ...sampleJsonResumeEducationItem,
-          institution: 'Fake institution name',
-          image: 'https://example.org/logo.png',
-          url: 'https://example.org/',
-          shortName: 'FIN',
-        }
+    it('should map the area, study type and score', () => {
+      const area = 'Fake area'
+      const studyType = 'Fake study type'
+      const score = 'Fake score'
 
-        const educationItem = sut.adapt(fakeJsonResumeEducationItem)
+      const item = makeSut().adapt(
+        makeJsonResumeEducationItem({ area, studyType, score }),
+      )
 
-        expect(educationItem.institution.name).toEqual(
-          fakeJsonResumeEducationItem.institution,
-        )
-        expect(educationItem.institution.website).toEqual(
-          new URL(fakeJsonResumeEducationItem.url),
-        )
-        expect(educationItem.institution.imageSrc).toEqual(
-          fakeJsonResumeEducationItem.image,
-        )
-        expect(educationItem.institution.shortName).toEqual(
-          fakeJsonResumeEducationItem.shortName,
-        )
-      })
+      expect(item.area).toEqual(area)
+      expect(item.studyType).toEqual(studyType)
+      expect(item.score).toEqual(score)
+    })
 
-      it('should map the area, study type and score', () => {
-        const fakeJsonResumeEducationItem: JsonResumeEducationItem = {
-          ...sampleJsonResumeEducationItem,
-          area: 'Fake area',
-          studyType: 'Fake study type',
-          score: 'Fake score',
-        } as JsonResumeEducationItem
+    it('should map the date range', () => {
+      const startDate = '2022-12-31'
+      const endDate = '2024-01-01'
 
-        const educationItem = sut.adapt(fakeJsonResumeEducationItem)
+      const item = makeSut().adapt(
+        makeJsonResumeEducationItem({ startDate, endDate }),
+      )
 
-        expect(educationItem.area).toEqual(fakeJsonResumeEducationItem.area)
-        expect(educationItem.studyType).toEqual(
-          fakeJsonResumeEducationItem.studyType,
-        )
-        expect(educationItem.score).toEqual(fakeJsonResumeEducationItem.score)
-      })
-      it('should map the date range', () => {
-        const fakeStartDate = '2022-12-31'
-        const fakeEndDate = '2024-01-01'
-        const fakeJsonResumeEducationItem: JsonResumeEducationItem = {
-          ...sampleJsonResumeEducationItem,
-          startDate: fakeStartDate,
-          endDate: fakeEndDate,
-        } as JsonResumeEducationItem
+      expect(item.dateRange.start).toEqual(new Date(startDate))
+      expect(item.dateRange.end).toEqual(new Date(endDate))
+    })
+    describe('when no end date', () => {
+      it('should map no end date exists too', () => {
+        const endDate = undefined
 
-        const educationItem = sut.adapt(fakeJsonResumeEducationItem)
+        const item = makeSut().adapt(makeJsonResumeEducationItem({ endDate }))
 
-        expect(educationItem.dateRange.start).toEqual(new Date(fakeStartDate))
-        expect(educationItem.dateRange.end).toEqual(new Date(fakeEndDate))
-      })
-      describe('when no end date', () => {
-        it('should map no end date exists too', () => {
-          const fakeJsonResumeEducationItem: JsonResumeEducationItem = {
-            ...sampleJsonResumeEducationItem,
-            endDate: undefined,
-          } as unknown as JsonResumeEducationItem
-
-          const educationItem = sut.adapt(fakeJsonResumeEducationItem)
-
-          expect(educationItem.dateRange.end).toBeUndefined()
-        })
-      })
-      // Non standard fields
-      it('should map the cum laude field', () => {
-        const fakeJsonResumeEducationItem: JsonResumeEducationItem = {
-          ...sampleJsonResumeEducationItem,
-          cumLaude: true,
-        } as JsonResumeEducationItem
-
-        const educationItem = sut.adapt(fakeJsonResumeEducationItem)
-
-        expect(educationItem.cumLaude).toBeTrue()
+        expect(item.dateRange.end).toBeUndefined()
       })
     })
+
+    // Non standard fields
+    it('should map the cum laude field', () => {
+      const item = makeSut().adapt(
+        makeJsonResumeEducationItem({ cumLaude: true }),
+      )
+
+      expect(item.cumLaude).toBeTrue()
+    })
+
+    describe('when image mapping is disabled', () => {
+      it('should map the image', () => {
+        const image = 'https://example.org/logo.png'
+
+        const item = makeSut().adapt(makeJsonResumeEducationItem({ image }))
+
+        expect(item.institution.imageSrc).toEqual(image)
+      })
+    })
+
     describe('when images mapping is enabled', () => {
-      const fakeCanonicalUrl = new URL('https://example.org/canonical/')
+      const canonicalUrl = new URL('https://example.org/canonical/')
       let sut: JsonResumeEducationItemAdapterService
 
       beforeEach(() => {
-        const fakeEnvironment: Pick<
-          Environment,
-          'canonicalUrl' | 'mapJsonResumeImages'
-        > = {
-          canonicalUrl: fakeCanonicalUrl,
-          mapJsonResumeImages: true,
-        }
-        TestBed.configureTestingModule({
-          providers: [MockProvider(ENVIRONMENT, fakeEnvironment)],
-        })
-        sut = TestBed.inject(JsonResumeEducationItemAdapterService)
+        sut = makeSut({ mapJsonResumeImages: true, canonicalUrl })
       })
 
       describe('when short name is available', () => {
         it('should map the company image into a custom URL using canonical URL, assets path and slug from short name', () => {
-          const fakeJsonResumeEducationItem: JsonResumeEducationItem = {
-            ...sampleJsonResumeEducationItem,
-            institution: 'Fake ínstìtútión name',
-            shortName: 'FIN',
-          }
+          const institution = 'Fake ínstìtútión name'
+          const shortName = 'FIN'
           const expectedImageFileName = 'fin'
-          const educationItem = sut.adapt(fakeJsonResumeEducationItem)
 
-          expect(educationItem.institution.imageSrc).toEqual(
-            fakeCanonicalUrl.toString() +
+          const item = sut.adapt(
+            makeJsonResumeEducationItem({ institution, shortName }),
+          )
+
+          expect(item.institution.imageSrc).toEqual(
+            canonicalUrl.toString() +
               sut.EDUCATION_IMAGES_PATH +
               expectedImageFileName +
               sut.IMAGE_EXTENSION,
@@ -147,16 +110,16 @@ describe('JsonResumeEducationItemAdapterService', () => {
       })
       describe('when short name is not available', () => {
         it('should map the company image into a custom URL using canonical URL, assets path and slug from name', () => {
-          const fakeJsonResumeEducationItem: JsonResumeEducationItem = {
-            ...sampleJsonResumeEducationItem,
-            shortName: undefined,
-            institution: 'Fake ínstìtútión name',
-          } as unknown as JsonResumeEducationItem
+          const institution = 'Fake ínstìtútión name'
+          const shortName = undefined
           const expectedImageFileName = 'fake-institution-name'
-          const educationItem = sut.adapt(fakeJsonResumeEducationItem)
 
-          expect(educationItem.institution.imageSrc).toEqual(
-            fakeCanonicalUrl.toString() +
+          const item = sut.adapt(
+            makeJsonResumeEducationItem({ institution, shortName }),
+          )
+
+          expect(item.institution.imageSrc).toEqual(
+            canonicalUrl.toString() +
               sut.EDUCATION_IMAGES_PATH +
               expectedImageFileName +
               sut.IMAGE_EXTENSION,
@@ -166,3 +129,30 @@ describe('JsonResumeEducationItemAdapterService', () => {
     })
   })
 })
+
+function makeSut(opts?: {
+  mapJsonResumeImages: boolean
+  canonicalUrl?: URL
+}): JsonResumeEducationItemAdapterService {
+  let providers: unknown[] | undefined
+  if (opts) {
+    const environment: Partial<Environment> = {
+      mapJsonResumeImages: opts.mapJsonResumeImages,
+      canonicalUrl: opts.canonicalUrl,
+    }
+    providers = [MockProvider(ENVIRONMENT, environment)]
+  }
+  TestBed.configureTestingModule({ providers })
+  return TestBed.inject(JsonResumeEducationItemAdapterService)
+}
+
+const sampleJsonResumeEducationItem = resume.education[0]
+
+function makeJsonResumeEducationItem(
+  overrides?: Partial<JsonResumeEducationItem>,
+): JsonResumeEducationItem {
+  return {
+    ...sampleJsonResumeEducationItem,
+    ...overrides,
+  } as JsonResumeEducationItem
+}

--- a/src/app/about/education/json-resume-education-item-adapter.service.ts
+++ b/src/app/about/education/json-resume-education-item-adapter.service.ts
@@ -31,9 +31,11 @@ export class JsonResumeEducationItemAdapterService {
       institution: new Organization({
         name: item.institution,
         website: new URL(item.url),
-        image: this.mapJsonResumeImages
-          ? this.imageUrlFromInstitutionName(item.shortName ?? item.institution)
-          : new URL(item.image),
+        imageSrc: this.mapJsonResumeImages
+          ? this.imagePathFromInstitutionName(
+              item.shortName ?? item.institution,
+            )
+          : item.image,
         shortName: item.shortName,
       }),
       area: item.area,
@@ -48,13 +50,13 @@ export class JsonResumeEducationItemAdapterService {
     })
   }
 
-  private imageUrlFromInstitutionName(institutionName: string): URL {
+  private imagePathFromInstitutionName(institutionName: string): string {
     return new URL(
       this.EDUCATION_IMAGES_PATH +
         this.slugGenerator.generate(institutionName) +
         this.IMAGE_EXTENSION,
       this.canonicalURL,
-    )
+    ).toString()
   }
 }
 

--- a/src/app/about/education/json-resume-education-item-adapter.service.ts
+++ b/src/app/about/education/json-resume-education-item-adapter.service.ts
@@ -2,27 +2,21 @@ import { Inject, Injectable } from '@angular/core'
 import resume from '../../../../assets/resume.json'
 import { ENVIRONMENT } from '../../common/injection-tokens'
 import { Environment } from '../../../environments'
-import { SlugGeneratorService } from '../../common/slug-generator.service'
 import { EducationItem } from './education-item/education-item'
 import { Organization } from '../organization'
 import { DateRange } from '../date-range/date-range'
+import { LocalImageService } from '../local-image.service'
 
 @Injectable({
   providedIn: 'root',
 })
 export class JsonResumeEducationItemAdapterService {
-  public readonly EDUCATION_IMAGES_PATH = 'assets/education/'
-  public readonly IMAGE_EXTENSION = '.png'
-  private readonly canonicalURL: URL
-  private readonly mapJsonResumeImages: boolean
+  public readonly ASSETS_SUBDIRECTORY = 'education'
 
   constructor(
-    @Inject(ENVIRONMENT) environment: Environment,
-    private slugGenerator: SlugGeneratorService,
-  ) {
-    this.canonicalURL = environment.canonicalUrl
-    this.mapJsonResumeImages = environment.mapJsonResumeImages
-  }
+    @Inject(ENVIRONMENT) private environment: Environment,
+    private localImageService: LocalImageService,
+  ) {}
 
   // 👇 JSON Schema of "education"
   // https://github.com/jsonresume/resume-schema/blob/v1.0.0/schema.json#L192-L237
@@ -31,10 +25,11 @@ export class JsonResumeEducationItemAdapterService {
       institution: new Organization({
         name: item.institution,
         website: new URL(item.url),
-        imageSrc: this.mapJsonResumeImages
-          ? this.imagePathFromInstitutionName(
-              item.shortName ?? item.institution,
-            )
+        imageSrc: this.environment.mapJsonResumeImages
+          ? this.localImageService.generatePath({
+              name: item.shortName ?? item.institution,
+              subdirectory: this.ASSETS_SUBDIRECTORY,
+            })
           : item.image,
         shortName: item.shortName,
       }),
@@ -48,15 +43,6 @@ export class JsonResumeEducationItemAdapterService {
       courses: item.courses,
       cumLaude: !!item.cumLaude,
     })
-  }
-
-  private imagePathFromInstitutionName(institutionName: string): string {
-    return new URL(
-      this.EDUCATION_IMAGES_PATH +
-        this.slugGenerator.generate(institutionName) +
-        this.IMAGE_EXTENSION,
-      this.canonicalURL,
-    ).toString()
   }
 }
 

--- a/src/app/about/experience/experience-item/experience-item.component.html
+++ b/src/app/about/experience/experience-item/experience-item.component.html
@@ -2,7 +2,7 @@
   <app-card-header>
     <app-link [href]="item.company.website?.toString()" appTestId="image">
       <app-card-header-image
-        [src]="item.company.image.toString()"
+        [src]="item.company.imageSrc"
         [alt]="item.company.name + ' logo'"
       >
       </app-card-header-image>

--- a/src/app/about/experience/experience-item/experience-item.component.spec.ts
+++ b/src/app/about/experience/experience-item/experience-item.component.spec.ts
@@ -81,7 +81,7 @@ describe('ExperienceItem', () => {
       setExperienceItem(fixture, {
         company: new Organization({
           name: 'Company name',
-          image: new URL(imageUrl),
+          imageSrc: imageUrl,
           website: new URL(website),
         }),
       })
@@ -104,7 +104,7 @@ describe('ExperienceItem', () => {
       setExperienceItem(fixture, {
         company: new Organization({
           name,
-          image: new URL('https://example.org/logo.png'),
+          imageSrc: 'https://example.org/logo.png',
           website: new URL(website),
         }),
       })
@@ -346,7 +346,7 @@ function setExperienceItem(
   fixture.componentInstance.item = new ExperienceItem({
     company: new Organization({
       name: 'Fake company',
-      image: new URL('https://fakeCompany.example.com/logo.jpg'),
+      imageSrc: 'https://fakeCompany.example.com/logo.jpg',
     }),
     summary: 'Fake summary',
     position: 'Fake position',

--- a/src/app/about/experience/json-resume-experience-item-adapter.service.spec.ts
+++ b/src/app/about/experience/json-resume-experience-item-adapter.service.spec.ts
@@ -44,8 +44,8 @@ describe('JsonResumeExperienceItemAdapterService', () => {
         expect(experienceItem.company.website).toEqual(
           new URL(jsonResumeWorkItem.url),
         )
-        expect(experienceItem.company.image).toEqual(
-          new URL(jsonResumeWorkItem.image),
+        expect(experienceItem.company.imageSrc).toEqual(
+          jsonResumeWorkItem.image,
         )
       })
 
@@ -131,7 +131,7 @@ describe('JsonResumeExperienceItemAdapterService', () => {
         const expectedImageFileName = 'company-name'
         const experienceItem = sut.adapt(jsonResumeWorkItem)
 
-        expect(experienceItem.company.image.toString()).toEqual(
+        expect(experienceItem.company.imageSrc).toEqual(
           canonicalUrl.toString() +
             sut.COMPANIES_IMAGE_ASSETS_PATH +
             expectedImageFileName +

--- a/src/app/about/experience/json-resume-experience-item-adapter.service.ts
+++ b/src/app/about/experience/json-resume-experience-item-adapter.service.ts
@@ -3,26 +3,20 @@ import resume from '../../../../assets/resume.json'
 import { ExperienceItem } from './experience-item/experience-item'
 import { ENVIRONMENT } from '../../common/injection-tokens'
 import { Environment } from '../../../environments'
-import { SlugGeneratorService } from '../../common/slug-generator.service'
 import { Organization } from '../organization'
 import { DateRange } from '../date-range/date-range'
+import { LocalImageService } from '../local-image.service'
 
 @Injectable({
   providedIn: 'root',
 })
 export class JsonResumeExperienceItemAdapterService {
-  public readonly COMPANIES_IMAGE_ASSETS_PATH = 'assets/companies/'
-  public readonly IMAGE_EXTENSION = '.png'
-  private readonly canonicalURL: URL
-  private readonly mapJsonResumeImages: boolean
+  public readonly ASSETS_SUBDIRECTORY = 'companies'
 
   constructor(
-    @Inject(ENVIRONMENT) environment: Environment,
-    private slugGenerator: SlugGeneratorService,
-  ) {
-    this.canonicalURL = environment.canonicalUrl
-    this.mapJsonResumeImages = environment.mapJsonResumeImages
-  }
+    @Inject(ENVIRONMENT) private environment: Environment,
+    private localImageService: LocalImageService,
+  ) {}
 
   // 👇 JSON Resume Schema of "work"
   // https://github.com/jsonresume/resume-schema/blob/v1.0.0/schema.json#L100-L149
@@ -31,10 +25,11 @@ export class JsonResumeExperienceItemAdapterService {
     return new ExperienceItem({
       company: new Organization({
         name: item.name,
-        // Point to assets in this repo using canonical URL from env, so we can change the image and preview it.
-        // Links in resume.json work anyway
-        imageSrc: this.mapJsonResumeImages
-          ? this.imageSrcFromCompanyName(item.name)
+        imageSrc: this.environment.mapJsonResumeImages
+          ? this.localImageService.generatePath({
+              name: item.name,
+              subdirectory: this.ASSETS_SUBDIRECTORY,
+            })
           : item.image,
         website: new URL(item.url),
       }),
@@ -50,15 +45,6 @@ export class JsonResumeExperienceItemAdapterService {
       promotions: item.promotions,
       morePositions: item.morePositions,
     })
-  }
-
-  private imageSrcFromCompanyName(companyName: string): string {
-    return new URL(
-      this.COMPANIES_IMAGE_ASSETS_PATH +
-        this.slugGenerator.generate(companyName) +
-        this.IMAGE_EXTENSION,
-      this.canonicalURL,
-    ).toString()
   }
 }
 

--- a/src/app/about/experience/json-resume-experience-item-adapter.service.ts
+++ b/src/app/about/experience/json-resume-experience-item-adapter.service.ts
@@ -33,9 +33,9 @@ export class JsonResumeExperienceItemAdapterService {
         name: item.name,
         // Point to assets in this repo using canonical URL from env, so we can change the image and preview it.
         // Links in resume.json work anyway
-        image: this.mapJsonResumeImages
-          ? this.imageUrlFromCompanyName(item.name)
-          : new URL(item.image),
+        imageSrc: this.mapJsonResumeImages
+          ? this.imageSrcFromCompanyName(item.name)
+          : item.image,
         website: new URL(item.url),
       }),
       position: item.position,
@@ -52,13 +52,13 @@ export class JsonResumeExperienceItemAdapterService {
     })
   }
 
-  private imageUrlFromCompanyName(companyName: string): URL {
+  private imageSrcFromCompanyName(companyName: string): string {
     return new URL(
       this.COMPANIES_IMAGE_ASSETS_PATH +
         this.slugGenerator.generate(companyName) +
         this.IMAGE_EXTENSION,
       this.canonicalURL,
-    )
+    ).toString()
   }
 }
 

--- a/src/app/about/local-image.service.spec.ts
+++ b/src/app/about/local-image.service.spec.ts
@@ -1,0 +1,86 @@
+import { TestBed } from '@angular/core/testing'
+
+import { LocalImageService } from './local-image.service'
+import { SlugGeneratorService } from '../common/slug-generator.service'
+
+describe('LocalImageService', () => {
+  it('should be created', () => {
+    expect(makeSut()).toBeTruthy()
+  })
+  describe('#getPath', () => {
+    const dummyArgs: Parameters<LocalImageService['getPath']>[0] = {
+      name: 'Cool image',
+    }
+
+    it('should start by assets directory', () => {
+      const sut = makeSut()
+
+      const path = sut.getPath(dummyArgs)
+
+      expect(path.startsWith(sut.ASSETS_PATH)).toBeTruthy()
+    })
+
+    it('should include given subdirectory', () => {
+      const subdirectory = 'foo'
+
+      const path = makeSut().getPath({ ...dummyArgs, subdirectory })
+
+      expect(path).toEqual(jasmine.stringContaining(subdirectory))
+    })
+
+    it('should include slugged name as image filename', () => {
+      const name = '"Fòó Bär%='
+      const sluggedName = 'foo-bar'
+      const sut = makeSut()
+      const slugGenerator = TestBed.inject(SlugGeneratorService)
+      spyOn(slugGenerator, 'generate').and.returnValue(sluggedName)
+
+      const path = sut.getPath({ name })
+
+      expect(path).toEqual(jasmine.stringContaining(sluggedName))
+      expect(slugGenerator.generate).toHaveBeenCalledWith(name)
+    })
+
+    it('should finish with default extension', () => {
+      const sut = makeSut()
+
+      const path = sut.getPath(dummyArgs)
+
+      expect(path.endsWith(sut.DEFAULT_EXTENSION)).toBeTrue()
+    })
+
+    it('should correctly get path for a sample name without subdirectory', () => {
+      const name = 'Cool image'
+      const sluggedName = 'cool-image'
+      const sut = makeSut()
+      const slugGenerator = TestBed.inject(SlugGeneratorService)
+      spyOn(slugGenerator, 'generate').and.returnValue(sluggedName)
+
+      const path = sut.getPath({ ...dummyArgs, name })
+
+      expect(path).toEqual(
+        `${sut.ASSETS_PATH}/${sluggedName}${sut.DEFAULT_EXTENSION}`,
+      )
+    })
+
+    it('should correctly get path for a sample name with a sample subdirectory', () => {
+      const name = 'Cool image'
+      const subdirectory = 'logos'
+      const sluggedName = 'cool-image'
+      const sut = makeSut()
+      const slugGenerator = TestBed.inject(SlugGeneratorService)
+      spyOn(slugGenerator, 'generate').and.returnValue(sluggedName)
+
+      const path = sut.getPath({ ...dummyArgs, name, subdirectory })
+
+      expect(path).toEqual(
+        `${sut.ASSETS_PATH}/${subdirectory}/${sluggedName}${sut.DEFAULT_EXTENSION}`,
+      )
+    })
+  })
+})
+
+function makeSut(): LocalImageService {
+  TestBed.configureTestingModule({})
+  return TestBed.inject(LocalImageService)
+}

--- a/src/app/about/local-image.service.spec.ts
+++ b/src/app/about/local-image.service.spec.ts
@@ -7,15 +7,15 @@ describe('LocalImageService', () => {
   it('should be created', () => {
     expect(makeSut()).toBeTruthy()
   })
-  describe('#getPath', () => {
-    const dummyArgs: Parameters<LocalImageService['getPath']>[0] = {
+  describe('#generatePath', () => {
+    const dummyArgs: Parameters<LocalImageService['generatePath']>[0] = {
       name: 'Cool image',
     }
 
     it('should start by assets directory', () => {
       const sut = makeSut()
 
-      const path = sut.getPath(dummyArgs)
+      const path = sut.generatePath(dummyArgs)
 
       expect(path.startsWith(sut.ASSETS_PATH)).toBeTruthy()
     })
@@ -23,7 +23,7 @@ describe('LocalImageService', () => {
     it('should include given subdirectory', () => {
       const subdirectory = 'foo'
 
-      const path = makeSut().getPath({ ...dummyArgs, subdirectory })
+      const path = makeSut().generatePath({ ...dummyArgs, subdirectory })
 
       expect(path).toEqual(jasmine.stringContaining(subdirectory))
     })
@@ -35,7 +35,7 @@ describe('LocalImageService', () => {
       const slugGenerator = TestBed.inject(SlugGeneratorService)
       spyOn(slugGenerator, 'generate').and.returnValue(sluggedName)
 
-      const path = sut.getPath({ name })
+      const path = sut.generatePath({ name })
 
       expect(path).toEqual(jasmine.stringContaining(sluggedName))
       expect(slugGenerator.generate).toHaveBeenCalledWith(name)
@@ -44,7 +44,7 @@ describe('LocalImageService', () => {
     it('should finish with default extension', () => {
       const sut = makeSut()
 
-      const path = sut.getPath(dummyArgs)
+      const path = sut.generatePath(dummyArgs)
 
       expect(path.endsWith(sut.DEFAULT_EXTENSION)).toBeTrue()
     })
@@ -56,7 +56,7 @@ describe('LocalImageService', () => {
       const slugGenerator = TestBed.inject(SlugGeneratorService)
       spyOn(slugGenerator, 'generate').and.returnValue(sluggedName)
 
-      const path = sut.getPath({ ...dummyArgs, name })
+      const path = sut.generatePath({ ...dummyArgs, name })
 
       expect(path).toEqual(
         `${sut.ASSETS_PATH}/${sluggedName}${sut.DEFAULT_EXTENSION}`,
@@ -71,7 +71,7 @@ describe('LocalImageService', () => {
       const slugGenerator = TestBed.inject(SlugGeneratorService)
       spyOn(slugGenerator, 'generate').and.returnValue(sluggedName)
 
-      const path = sut.getPath({ ...dummyArgs, name, subdirectory })
+      const path = sut.generatePath({ ...dummyArgs, name, subdirectory })
 
       expect(path).toEqual(
         `${sut.ASSETS_PATH}/${subdirectory}/${sluggedName}${sut.DEFAULT_EXTENSION}`,

--- a/src/app/about/local-image.service.ts
+++ b/src/app/about/local-image.service.ts
@@ -10,7 +10,7 @@ export class LocalImageService {
 
   constructor(private slugGenerator: SlugGeneratorService) {}
 
-  public getPath({
+  public generatePath({
     name,
     subdirectory,
   }: {

--- a/src/app/about/local-image.service.ts
+++ b/src/app/about/local-image.service.ts
@@ -1,0 +1,27 @@
+import { Injectable } from '@angular/core'
+import { SlugGeneratorService } from '../common/slug-generator.service'
+
+@Injectable({
+  providedIn: 'root',
+})
+export class LocalImageService {
+  public readonly ASSETS_PATH = 'assets'
+  public readonly DEFAULT_EXTENSION = '.png'
+
+  constructor(private slugGenerator: SlugGeneratorService) {}
+
+  public getPath({
+    name,
+    subdirectory,
+  }: {
+    name: string
+    subdirectory?: string
+  }): string {
+    const pathElements = [
+      this.ASSETS_PATH,
+      subdirectory,
+      `${this.slugGenerator.generate(name)}${this.DEFAULT_EXTENSION}`,
+    ].filter((pathElement) => !!pathElement)
+    return pathElements.join('/')
+  }
+}

--- a/src/app/about/organization.ts
+++ b/src/app/about/organization.ts
@@ -1,23 +1,23 @@
 export class Organization {
   public readonly name: string
   public readonly website?: URL
-  public readonly image: URL
+  public readonly imageSrc: string
   public readonly shortName?: string
 
   constructor({
     name,
     website,
-    image,
+    imageSrc,
     shortName,
   }: {
     name: string
     website?: URL
-    image: URL
+    imageSrc: string
     shortName?: string
   }) {
     this.name = name
     this.website = website
-    this.image = image
+    this.imageSrc = imageSrc
     this.shortName = shortName
   }
 }

--- a/src/environments/environment.pull-request.ts.liquid
+++ b/src/environments/environment.pull-request.ts.liquid
@@ -10,6 +10,6 @@ const CLOUDFLARE_PAGES_PREVIEW_BRANCH_ALIAS_URL = new URL(
 )
 export const environment: Environment = {
   production: false,
-  mapJsonResumeImages: false,
+  mapJsonResumeImages: true,
   canonicalUrl: CLOUDFLARE_PAGES_PREVIEW_BRANCH_ALIAS_URL,
 }

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -3,6 +3,6 @@ import { Environment } from './environment-interface'
 
 export const environment: Environment = {
   production: true,
-  mapJsonResumeImages: false,
+  mapJsonResumeImages: true,
   canonicalUrl: new URL(`https://${METADATA.domainName}`),
 }


### PR DESCRIPTION
Adds service to generate paths to local images based on names. Also, changes image to be an URL to allow relative paths. So we don't need to rely on canonical URL which is not always true. And use relative paths when generating local images.

Improves also education and experience item adapters:
- Create and use `makeSut()` instead of `beforeEach()` for greater flexibility
- Create and use `makeXItem()` to reduce spread operators around
- Rename `xItem` to just `item`
- Position non-standard field tests at the end

Closes #120
