### PR TITLE
build: remove NPM publish

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -3,7 +3,6 @@
   "plugins": [
     "@semantic-release/commit-analyzer",
     "@semantic-release/release-notes-generator",
-    "@semantic-release/npm",
     "@semantic-release/github"
   ],
   "preset": "conventionalcommits",


### PR DESCRIPTION
It was there just to see how it worked. Now that I have the `@davidlj95/ngx-meta` library, it's enough maintaining one NPM token around. So removing NPM to avoid renewing the NPM token set in the repo secrets.

Other actions taken after PR gets merged:
 - Remove NPM token from repo secrets
 - Remove package from NPMJS. Including `website-v2` one
 - Remove NPM token from NPMJS
