### PR TITLE
build: remove act

### DIFF
--- a/.actrc
+++ b/.actrc
@@ -1,4 +1,0 @@
--P ubuntu-latest=catthehacker/ubuntu:js-latest
--P ubuntu-22.04=catthehacker/ubuntu:js-22.04
--P ubuntu-20.04=catthehacker/ubuntu:js-20.04
--P ubuntu-18.04=catthehacker/ubuntu:js-18.04

--- a/.ci/Makefile
+++ b/.ci/Makefile
@@ -36,12 +36,6 @@ test:
 	pnpm run test --browsers=ChromeHeadless \
 		--no-watch --no-progress --reporters junit,progress --code-coverage
 
-run-main:
-	cd .. && act
-
-reset:
-	docker ps -a --format '{{.Names}}' | grep -e '^act-' | xargs docker rm -f
-
 format-check:
 	cd .. && pnpm run format-check-all
 

--- a/README.md
+++ b/README.md
@@ -175,37 +175,6 @@ cd .ci && make test # for instance
 And see how a command run in the CI/CD behaves locally. Notice your machine's state may differ from the CI/CD machine
 one.
 
-### Running GitHub Actions workflows locally
-
-You can use [`act`](https://github.com/nektos/act) to run GitHub Action workflows in your development machine. If using
-macOS, install it using `brew`:
-
-```shell
-brew install act
-```
-
-Then, use one of the many `run-` targets in the CI/CD `Makefile` to simulate a CI/CD workflow run. For instance:
-
-```shell
-cd .ci && make run-main
-```
-
-Simulates the workflow triggered by a push to `main` branch.
-
-> If you get a message related to Apple M-series chip:
->
-> ```shell
-> WARN  ⚠ You are using Apple M-series chip and you have not specified container architecture, you might encounter issues while running act. If so, try running it with '--container-architecture linux/amd64'. ⚠                      7s
-> ```
->
-> You can add ` --container-architecture linux/amd64` (notice a space when line begins) to your `~/.actrc` file. Create
-> it if it doesn't exist.
-
-> ℹ️ Images are set to [`js-*` ones](https://github.com/catthehacker/docker_images) via the `.actrc` file as medium
-> default ones don't include `pnpm` `:sadparrot:`
-
-## Release
-
 ## Further help
 
 To get more help on the Angular CLI use `ng help` or go check out


### PR DESCRIPTION
Long time no use that tool

And when trying now, everything failed. Logs weren't straightforward.

To avoid maintaining that, removing it for now
