### PR TITLE
build: use latest npm version

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -10,14 +10,6 @@ runs:
       with:
         cache: 'pnpm'
         node-version-file: '.node-version'
-    # Why this? https://github.com/npm/cli/issues/7279
-    # Why this way? https://github.com/actions/setup-node/issues/213
-    - name: Install latest npm
-      shell: bash
-      run: |
-        npm install -g npm@latest &&
-        npm --version &&
-        npm list -g --depth 0
     - name: Install dependencies
       shell: bash
       run: cd .ci && make install

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -10,6 +10,14 @@ runs:
       with:
         cache: 'pnpm'
         node-version-file: '.node-version'
+    # Why this? https://github.com/npm/cli/issues/7279
+    # Why this way? https://github.com/actions/setup-node/issues/213
+    - name: Install latest npm
+      shell: bash
+      run: |
+        npm install -g npm@latest &&
+        npm --version &&
+        npm list -g --depth 0
     - name: Install dependencies
       shell: bash
       run: cd .ci && make install

--- a/.github/workflows/reusable-release.yml
+++ b/.github/workflows/reusable-release.yml
@@ -33,6 +33,14 @@ jobs:
           fetch-depth: 0
       - name: Setup
         uses: ./.github/actions/setup
+      # Why this? https://github.com/npm/cli/issues/7279
+      # Why this way? https://github.com/actions/setup-node/issues/213
+      # Why only here? Because only the npm audit signatures command is affected
+      - name: Install latest npm
+        run: |
+          npm install -g npm@latest &&
+          npm --version &&
+          npm list -g --depth 0
       - name: Verify the integrity of provenance attestations and registry signatures for installed dependencies
         run: npm audit signatures
       - name: Release

--- a/README.md
+++ b/README.md
@@ -146,6 +146,10 @@ won't be in sync.
 
 ## Quirks
 
+### Use latest `npm` version to audit signatures
+
+See https://github.com/npm/cli/issues/7279
+
 ## Rendering font subsets
 
 Some fonts included are a subset of a big font file. Before doing anything, please run

--- a/package.json
+++ b/package.json
@@ -121,11 +121,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "pnpm": {
-    "overrides": {
-      "@semantic-release/npm": "11.0.2",
-      "ts-api-utils": "1.2.1"
-    }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,10 +4,6 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
-overrides:
-  '@semantic-release/npm': 11.0.2
-  ts-api-utils: 1.2.1
-
 dependencies:
   '@angular/animations':
     specifier: 16.2.12


### PR DESCRIPTION
In order to fix https://github.com/npm/cli/issues/7279

Reverts temporary workaround: 3cfab4af8e6ef75348d9d19091f60f8cc2901472
