### PR TITLE
ci: skip deploy preview if secret N/A

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -33,7 +33,6 @@ jobs:
     name: Deploy preview
     needs: [build, lint, test, performance]
     uses: ./.github/workflows/reusable-deploy-cloudflare-pages.yml
-    if: ${{ secrets.CLOUDFLARE_API_TOKEN != '' }}
     with:
       build-artifact-name: build
     secrets:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -33,11 +33,7 @@ jobs:
     name: Deploy preview
     needs: [build, lint, test, performance]
     uses: ./.github/workflows/reusable-deploy-cloudflare-pages.yml
-    # Cannot run on PRs from forked repos right now.
-    # https://developers.cloudflare.com/pages/platform/known-issues/
-    # Quote to avoid YAML issues with "!" at the beginning
-    # https://github.com/actions/runner/issues/753
-    if: '! github.event.pull_request.head.repo.fork'
+    if: ${{ secrets.CLOUDFLARE_API_TOKEN != '' }}
     with:
       build-artifact-name: build
     secrets:

--- a/.github/workflows/reusable-deploy-cloudflare-pages.yml
+++ b/.github/workflows/reusable-deploy-cloudflare-pages.yml
@@ -23,7 +23,12 @@ concurrency:
 jobs:
   deploy:
     name: Deploy to Cloudflare Pages
-    if: secrets.cloudflare-api-token != ''
+    # Secrets can't be referenced in `if`s. Unless this workaround is used
+    # https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions#:~:text=Secrets%20cannot%20be%20directly%20referenced%20in%20if%3A%20conditionals
+    # That's the reason it's here and can't be in caller workflow. `env` isn't allowed there
+    env:
+      CLOUDFLARE-API-TOKEN: ${{ secrets.cloudflare-api-token }}
+    if: env.CLOUDFLARE_API_TOKEN != ''
     runs-on: ubuntu-latest
     steps:
       - name: Download built app

--- a/.github/workflows/reusable-deploy-cloudflare-pages.yml
+++ b/.github/workflows/reusable-deploy-cloudflare-pages.yml
@@ -23,12 +23,7 @@ concurrency:
 jobs:
   deploy:
     name: Deploy to Cloudflare Pages
-    # Secrets can't be referenced in `if`s. Unless this workaround is used
-    # https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions#:~:text=Secrets%20cannot%20be%20directly%20referenced%20in%20if%3A%20conditionals
-    # That's the reason it's here and can't be in caller workflow. `env` isn't allowed there
-    env:
-      CLOUDFLARE-API-TOKEN: ${{ secrets.cloudflare-api-token }}
-    if: env.CLOUDFLARE_API_TOKEN != ''
+
     runs-on: ubuntu-latest
     steps:
       - name: Download built app
@@ -60,9 +55,16 @@ jobs:
                 throw error
               }
             }
+            console.log(response)
             return response !== undefined
       - name: Publish
-        if: "! (github.event_name == 'pull_request' && steps.ref-exists.outputs.result == 'false')"
+        # Secrets can't be referenced in `if`s. Unless this workaround is used
+        # https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions#:~:text=Secrets%20cannot%20be%20directly%20referenced%20in%20if%3A%20conditionals
+        # Env isn't available in job `if`s, so workaround must be done here
+        # https://docs.github.com/en/actions/learn-github-actions/contexts#context-availability
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.cloudflare-api-token }}
+        if: env.CLOUDFLARE_API_TOKEN != '' && (steps.ref-exists.outputs.result || github.event_name != 'pull_request')
         uses: cloudflare/pages-action@f0a1cd58cd66095dee69bfa18fa5efd1dde93bca # 1
         with:
           accountId: ${{ secrets.cloudflare-account-id }}

--- a/.github/workflows/reusable-deploy-cloudflare-pages.yml
+++ b/.github/workflows/reusable-deploy-cloudflare-pages.yml
@@ -23,6 +23,7 @@ concurrency:
 jobs:
   deploy:
     name: Deploy to Cloudflare Pages
+    if: secrets.cloudflare-api-token != ''
     runs-on: ubuntu-latest
     steps:
       - name: Download built app


### PR DESCRIPTION
Dependabot PRs were failing because deploy preview step didn't have access to secrets.

This is a safety mechanism to prevent dependency updates containing malicious code from having access to secrets. Same happens for PR from forks. They don't have access to secrets to avoid PRs from unknown devs access secrets and use them maliciously.

As quick fix, skipping deploy preview step if secret is not available for any reason like the ones above.

Fixes #258 + allows public contributions
