### PR TITLE
ci: run deploy preview right after build

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -31,7 +31,7 @@ jobs:
       LHCI_GITHUB_APP_TOKEN: ${{ secrets.LHCI_GITHUB_APP_TOKEN }}
   deploy-preview:
     name: Deploy preview
-    needs: [build, lint, test, performance]
+    needs: [build]
     uses: ./.github/workflows/reusable-deploy-cloudflare-pages.yml
     with:
       build-artifact-name: build


### PR DESCRIPTION
No need to wait for performance step

It was done to just preview when everything is OK. But can be useful to preview even if something fails for quick feedback.

We gain valuable secs/mins here
