### PR TITLE
refactor: split default metadata values

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -7,7 +7,8 @@ import { environment } from '../environments'
 import { NgxMetaRouteData } from '@davidlj95/ngx-meta/routing'
 import { GlobalMetadata } from '@davidlj95/ngx-meta/core'
 import { StandardMetadata } from '@davidlj95/ngx-meta/standard'
-import { JsonLdMetadata } from '@davidlj95/ngx-meta/json-ld'
+import { OpenGraphMetadata } from '@davidlj95/ngx-meta/open-graph'
+import { TwitterCardMetadata } from '@davidlj95/ngx-meta/twitter-card'
 
 // Metadata to add when '/' route is ready
 // jsonLd: {
@@ -23,21 +24,51 @@ import { JsonLdMetadata } from '@davidlj95/ngx-meta/json-ld'
 //   url: environment.canonicalUrl.toString(),
 // },
 const resumePath = 'resume'
-const resumePageData: NgxMetaRouteData<GlobalMetadata & JsonLdMetadata> = {
+const resumePageData: NgxMetaRouteData<
+  GlobalMetadata & StandardMetadata & OpenGraphMetadata
+> = {
   meta: {
     title: `${METADATA.siteName} | Resume`,
     canonicalUrl: new URL(resumePath, environment.canonicalUrl),
+    description: METADATA.description,
+    image: {
+      url: new URL('assets/img/og.jpg', environment.canonicalUrl),
+      alt: `A portrait of ${METADATA.realName}. Slightly smiling and wearing geek-ish glasses`,
+    },
+    standard: {
+      keywords: [
+        METADATA.nickname,
+        'website',
+        METADATA.realName,
+        'portfolio',
+        'cv',
+        'resume',
+        'projects',
+        'info',
+        'contact',
+      ],
+    },
+    openGraph: {
+      image: {
+        width: 875,
+        height: 875,
+      },
+    },
   },
 }
 
-const notFoundPageData: NgxMetaRouteData<GlobalMetadata & StandardMetadata> = {
+const notFoundPageData: NgxMetaRouteData<
+  GlobalMetadata & StandardMetadata & TwitterCardMetadata
+> = {
   meta: {
     title: `${METADATA.siteName} | Not Found`,
     description: 'Page could not be found',
-    canonicalUrl: null,
-    image: null,
     standard: {
-      keywords: null,
+      author: null,
+    },
+    twitterCard: {
+      creator: { username: null },
+      site: { username: null },
     },
   },
 }

--- a/src/app/app.metadata-defaults.ts
+++ b/src/app/app.metadata-defaults.ts
@@ -1,0 +1,40 @@
+import { METADATA } from './metadata'
+import {
+  OPEN_GRAPH_TYPE_WEBSITE,
+  OpenGraphMetadata,
+} from '@davidlj95/ngx-meta/open-graph'
+import {
+  TWITTER_CARD_TYPE_SUMMARY,
+  TwitterCardMetadata,
+} from '@davidlj95/ngx-meta/twitter-card'
+import { GlobalMetadata } from '@davidlj95/ngx-meta/core'
+import { StandardMetadata } from '@davidlj95/ngx-meta/standard'
+
+export const METADATA_DEFAULTS = {
+  title: METADATA.siteName,
+  locale: 'en',
+  applicationName: METADATA.siteName,
+  standard: {
+    author: METADATA.nickname,
+    generator: true,
+  },
+  openGraph: {
+    type: OPEN_GRAPH_TYPE_WEBSITE,
+  },
+  twitterCard: {
+    card: TWITTER_CARD_TYPE_SUMMARY,
+    creator: { username: METADATA.twitterUsername },
+    site: {
+      username: METADATA.twitterUsername,
+    },
+  },
+  // TODO: Add them into `@davidlj95/ngx-meta`
+  // https://github.com/davidlj95/ngx/discussions/422
+  //extra: [
+  //  { property: 'fb:admins', content: METADATA.nickname },
+  //  { name: 'facebook-domain-verification', content: '1299426610587748' },
+  //],
+} satisfies GlobalMetadata &
+  StandardMetadata &
+  OpenGraphMetadata &
+  TwitterCardMetadata

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -3,7 +3,6 @@ import { NgModule } from '@angular/core'
 import { BrowserModule } from '@angular/platform-browser'
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations'
 import { FontAwesomeModule } from '@fortawesome/angular-fontawesome'
-import { environment } from '../environments'
 
 import { ResumePageComponent } from './resume-page/resume-page.component'
 import { ProfileContactSocialIconsComponent } from './resume-page/profile-section/profile-contact-social-icons/profile-contact-social-icons.component'
@@ -13,7 +12,6 @@ import { ProfilePictureComponent } from './resume-page/profile-section/profile-p
 import { AppRoutingModule } from './app-routing.module'
 import { AppComponent } from './app.component'
 import { HeaderComponent } from './header/header.component'
-import { METADATA } from './metadata'
 import { NavigationTabsComponent } from './navigation-tabs/navigation-tabs.component'
 import { NoScriptComponent } from './no-script/no-script.component'
 import { ReleaseInfoComponent } from './release-info/release-info.component'
@@ -46,76 +44,16 @@ import { EducationItemCoursesComponent } from './resume-page/education-section/e
 import { ProjectsSectionComponent } from './resume-page/projects-section/projects-section.component'
 import { ProjectItemComponent } from './resume-page/projects-section/project-item/project-item.component'
 import { ProjectItemDescriptionComponent } from './resume-page/projects-section/project-item/project-item-description/project-item-description.component'
-import { GlobalMetadata, NgxMetaCoreModule } from '@davidlj95/ngx-meta/core'
+import { NgxMetaCoreModule } from '@davidlj95/ngx-meta/core'
 import { NgxMetaRoutingModule } from '@davidlj95/ngx-meta/routing'
-import {
-  NgxMetaStandardModule,
-  StandardMetadata,
-} from '@davidlj95/ngx-meta/standard'
-import {
-  NgxMetaOpenGraphModule,
-  OPEN_GRAPH_TYPE_WEBSITE,
-  OpenGraphMetadata,
-} from '@davidlj95/ngx-meta/open-graph'
-import {
-  NgxMetaTwitterCardModule,
-  TWITTER_CARD_TYPE_SUMMARY,
-  TwitterCardMetadata,
-} from '@davidlj95/ngx-meta/twitter-card'
+import { NgxMetaStandardModule } from '@davidlj95/ngx-meta/standard'
+import { NgxMetaOpenGraphModule } from '@davidlj95/ngx-meta/open-graph'
+import { NgxMetaTwitterCardModule } from '@davidlj95/ngx-meta/twitter-card'
+import { METADATA_DEFAULTS } from './app.metadata-defaults'
 
 export const APP_MODULE_METADATA_IMPORTS = [
   NgxMetaCoreModule.forRoot({
-    defaults: {
-      title: METADATA.siteName,
-      description: METADATA.description,
-      image: {
-        url: new URL('assets/img/og.jpg', environment.canonicalUrl),
-        alt: `A portrait of ${METADATA.realName}. Slightly smiling and wearing geek-ish glasses`,
-      },
-      locale: 'en',
-      // TODO: @davidlj95/ngx-meta tries to merge default canonical URL + route canonical URL
-      //       With spread operator. Result: messed up canonical URL and `[object Object]` in your URLs :')
-      // canonicalUrl: environment.canonicalUrl,
-      applicationName: METADATA.siteName,
-      standard: {
-        author: METADATA.nickname,
-        keywords: [
-          METADATA.nickname,
-          'website',
-          METADATA.realName,
-          'portfolio',
-          'cv',
-          'resume',
-          'projects',
-          'info',
-          'contact',
-        ],
-        generator: true,
-      },
-      openGraph: {
-        type: OPEN_GRAPH_TYPE_WEBSITE,
-        image: {
-          width: 875,
-          height: 875,
-        },
-      },
-      twitterCard: {
-        card: TWITTER_CARD_TYPE_SUMMARY,
-        creator: { username: METADATA.twitterUsername },
-        site: {
-          username: METADATA.twitterUsername,
-        },
-      },
-      // TODO: Add them into `@davidlj95/ngx-meta`
-      // https://github.com/davidlj95/ngx/discussions/422
-      //extra: [
-      //  { property: 'fb:admins', content: METADATA.nickname },
-      //  { name: 'facebook-domain-verification', content: '1299426610587748' },
-      //],
-    } satisfies GlobalMetadata &
-      StandardMetadata &
-      OpenGraphMetadata &
-      TwitterCardMetadata,
+    defaults: METADATA_DEFAULTS,
   }),
   NgxMetaRoutingModule.forRoot(),
   NgxMetaStandardModule,


### PR DESCRIPTION
Some defaults won't make sense when multiple pages are there:
 - Keywords
 - Description
 - Image

Re-arrange tests to test default metadata is there / route metadata can be set as desired