### PR TITLE
feat: use async animations

### DIFF
--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -5,7 +5,7 @@ import {
 } from '@angular/router'
 import { APP_METADATA_PROVIDERS } from './app.metadata-imports'
 import { routes } from './app.routes'
-import { provideAnimations } from '@angular/platform-browser/animations'
+import { provideAnimationsAsync } from '@angular/platform-browser/animations/async'
 
 export const appConfig: ApplicationConfig = {
   providers: [
@@ -14,7 +14,7 @@ export const appConfig: ApplicationConfig = {
       // 👇 Needed for SSR
       withEnabledBlockingInitialNavigation(),
     ),
-    provideAnimations(),
+    provideAnimationsAsync(),
     ...APP_METADATA_PROVIDERS,
   ],
 }


### PR DESCRIPTION
So that they're lazy-loaded! We don't have initial animations at bootstrap, so it's fine :)

A new chunk has appeared containing animations. So we save 16kB of transfer size for first paint.

```
Lazy chunk files              | Names                      |  Raw size | Estimated transfer size
360.5ed29ad77b8fb07f.js       | angular-animations-browser |  62.53 kB |                16.49 kB
```

More info about it:
 - https://angular.dev/guide/animations#enabling-the-animations-module
 - https://riegler.fr/blog/2023-10-04-animations-async
 - https://dzhavat.github.io/2024/01/08/lazy-load-animations-in-angular.html
