### PR TITLE
ci: replace slash with dash for CF preview URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,14 @@ won't be in sync.
 
 See https://github.com/npm/cli/issues/7279
 
+### Preview deployments
+
+Can only be triggered by users with write access to the repo (to prevent secrets from being leaked). Same secret is used for production access, so better keep that one safe.
+
+Also, branch names should be short. Otherwise, the `canonicalUrl` may be incorrect, given we try to generate the URL following docs about it in Cloudflare Pages docs. But the exact algorithm to generate the preview URL from branch name is not published. Empirically, it is known that branch names get shorten if they exceed a certain length.
+
+See https://github.com/davidlj95/website/pull/288 for more info.
+
 ## Rendering font subsets
 
 Some fonts included are a subset of a big font file. Before doing anything, please run

--- a/src/environments/environment.pull-request.ts.liquid
+++ b/src/environments/environment.pull-request.ts.liquid
@@ -4,7 +4,7 @@ import { METADATA } from '../app/metadata'
 // For info about how the Cloudflare Pages preview URL is formed:
 // https://developers.cloudflare.com/pages/platform/preview-deployments/
 const CLOUDFLARE_PAGES_DOMAIN = `${METADATA.nickname}.pages.dev`
-const PR_BRANCH_NAME = '{{ prBranchName }}'
+const PR_BRANCH_NAME = '{{ prBranchName |  replace: '/', '-' }}'
 const CLOUDFLARE_PAGES_PREVIEW_BRANCH_ALIAS_URL = new URL(
   `https://${PR_BRANCH_NAME}.${CLOUDFLARE_PAGES_DOMAIN}`,
 )


### PR DESCRIPTION
Otherwise, '/' can't be used in hostname, so results in an incorrect preview URL

Also detected that if branch name is too long it gets cut. In [one case it was cut to 28 chars](https://github.com/davidlj95/website/pull/286) but unsure if 28 is the hard limit or if they remove parts (separated by `-`)
