### PR TITLE
ci: trim branch name for CF preview URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ Can only be triggered by users with write access to the repo (to prevent secrets
 
 Also, branch names should be short. Otherwise, the `canonicalUrl` may be incorrect, given we try to generate the URL following docs about it in Cloudflare Pages docs. But the exact algorithm to generate the preview URL from branch name is not published. Empirically, it is known that branch names get shorten if they exceed a certain length.
 
-See https://github.com/davidlj95/website/pull/288 for more info.
+See https://github.com/davidlj95/website/pull/289 for more info.
 
 ## Rendering font subsets
 

--- a/src/environments/environment.pull-request.ts.liquid
+++ b/src/environments/environment.pull-request.ts.liquid
@@ -4,7 +4,7 @@ import { METADATA } from '../app/metadata'
 // For info about how the Cloudflare Pages preview URL is formed:
 // https://developers.cloudflare.com/pages/platform/preview-deployments/
 const CLOUDFLARE_PAGES_DOMAIN = `${METADATA.nickname}.pages.dev`
-const PR_BRANCH_NAME = '{{ prBranchName |  replace: '/', '-' }}'
+const PR_BRANCH_NAME = '{{ prBranchName |  replace: '/', '-' |  truncate: 28, '' }}'
 const CLOUDFLARE_PAGES_PREVIEW_BRANCH_ALIAS_URL = new URL(
   `https://${PR_BRANCH_NAME}.${CLOUDFLARE_PAGES_DOMAIN}`,
 )


### PR DESCRIPTION
After checking out a deploy preview, detected that if branch name is too long it gets cut when generating the preview URL. 

In [one case it was cut to 28 chars](https://github.com/davidlj95/website/pull/286) but unsure if 28 is the hard limit or if they remove parts (separated by `-`)
In [another case it was also cut to 28 chars](https://github.com/davidlj95/website/pull/288) so trying with 28 as magic number for now

Worked for this PR:
https://stacked-ci-shorten-cf-previe.davidlj95.pages.dev

🎉 
