### PR TITLE
fix: update Font Awesome icons size quirk

### DIFF
--- a/src/sass/_font-awesome.scss
+++ b/src/sass/_font-awesome.scss
@@ -5,7 +5,7 @@
 // size. Which also helps with SSR, given there are less layout shifts. As it appears there from early beginning, not
 // until its size is dynamically set
 @mixin iconsStaticSizeFix {
-  fa-icon > svg {
+  svg.svg-inline--fa {
     /* Otherwise, doesn't display when JavaScript is disabled */
     height: 100%;
   }


### PR DESCRIPTION
The new version sized the `svg`s with more specificity. So icons had different size before and after dynamic styling was applied.

Font Awesome applied a `height` of `1em` using `svg-inline--fa` class, which is more specific than `fa-icon > svg`. To win in specificity, using `svg` element + class
