### PR TITLE
refactor: use platform service in chipped content comp

### DIFF
--- a/src/app/resume-page/chipped-content/chipped-content.component.ts
+++ b/src/app/resume-page/chipped-content/chipped-content.component.ts
@@ -7,19 +7,19 @@ import {
   Input,
   OnInit,
   Output,
-  PLATFORM_ID,
   Type,
   ViewChild,
   ViewContainerRef,
 } from '@angular/core'
 import { ChippedContent } from './chipped-content'
 import { ChipComponent } from '../chip/chip.component'
-import { isPlatformBrowser, NgClass, NgFor } from '@angular/common'
+import { NgClass, NgFor } from '@angular/common'
 import { TestIdDirective } from '@common/test-id.directive'
 import {
   DISPLAY_BLOCK_IF_NO_SCRIPT_CLASS,
   DISPLAY_NONE_IF_NO_SCRIPT_CLASS,
 } from '@common/no-script'
+import { PLATFORM_SERVICE, PlatformService } from '@common/platform.service'
 
 @Component({
   selector: 'app-chipped-content',
@@ -38,17 +38,17 @@ export class ChippedContentComponent implements OnInit {
   private HIDDEN_CLASS = 'hidden'
   public selectedContentId?: string
   private selectedContentComponent?: Type<unknown>
-  private readonly isRenderingOnBrowser: boolean
   @Output() contentDisplayedChange = new EventEmitter<boolean>()
   protected readonly DISPLAY_NONE_IF_NO_SCRIPT_CLASS =
     DISPLAY_NONE_IF_NO_SCRIPT_CLASS
 
-  constructor(@Inject(PLATFORM_ID) platformId: object) {
-    this.isRenderingOnBrowser = isPlatformBrowser(platformId)
-  }
+  constructor(
+    @Inject(PLATFORM_SERVICE)
+    protected readonly _platformService: PlatformService,
+  ) {}
 
   ngOnInit(): void {
-    if (this.isRenderingOnBrowser) {
+    if (this._platformService.isBrowser) {
       return
     }
     this.contentHost.clear()


### PR DESCRIPTION
To avoid depending on copy/pasting Angular's `PLATFORM_X` constants when testing.
