### PR TITLE
ci: use base / head SHAs for commitlint

### DIFF
--- a/.github/workflows/reusable-lint.yml
+++ b/.github/workflows/reusable-lint.yml
@@ -54,6 +54,6 @@ jobs:
         if: github.event_name == 'pull_request'
         run: |
           pnpm commitlint \
-            --from ${{ github.event.pull_request.head.sha }}~${{ github.event.pull_request.commits }} \
+            --from ${{ github.event.pull_request.base.sha }} \
             --to ${{ github.event.pull_request.head.sha }} \
             --verbose


### PR DESCRIPTION
Somehow number of commits wasn't correct here:
https://github.com/davidlj95/website/actions/runs/8398100183/job/23002473972?pr=325

Using event's base / head SHAs then
