### PR TITLE
ci(performance): run bundlewatch in main

### DIFF
--- a/.github/workflows/reusable-performance.yml
+++ b/.github/workflows/reusable-performance.yml
@@ -59,7 +59,6 @@ jobs:
     name: Bundlewatch
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    if: github.event_name == 'pull_request'
     steps:
       - name: Checkout
         uses: actions/checkout@1d96c772d19495a3b5c517cd2bc0cb401ea0529f # v4


### PR DESCRIPTION
Otherwise results of bundle size analysis won't be stored hence can't be compared later in PRs
