### PR TITLE
refactor: attribute component to generate IDs

### DIFF
--- a/src/app/resume-page/attribute/attribute.component.html
+++ b/src/app/resume-page/attribute/attribute.component.html
@@ -1,4 +1,4 @@
-<span [attr.aria-describedby]="tooltipId" tabindex="0" appMaterialSymbol>
+<span [attr.aria-describedby]="_id" tabindex="0" appMaterialSymbol>
   {{ symbol }}
 </span>
-<div [id]="tooltipId" role="tooltip"><ng-content></ng-content></div>
+<div [attr.id]="_id" role="tooltip"><ng-content></ng-content></div>

--- a/src/app/resume-page/attribute/attribute.component.spec.ts
+++ b/src/app/resume-page/attribute/attribute.component.spec.ts
@@ -1,32 +1,22 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing'
-
-import { AttributeComponent } from './attribute.component'
+import { ATTRIBUTE_ID_PREFIX, AttributeComponent } from './attribute.component'
 import { MATERIAL_SYMBOLS_SELECTOR } from '@/test/helpers/material-symbols'
 import { By } from '@angular/platform-browser'
 import { shouldProjectContent } from '@/test/helpers/component-testers'
+import { componentTestSetup } from '@/test/helpers/component-test-setup'
 
 describe('AttributeComponent', () => {
   const symbol = 'some symbol'
-  const id = 'some-attribute-id'
 
-  function makeSut(): [
-    ComponentFixture<AttributeComponent>,
-    AttributeComponent,
-  ] {
-    TestBed.configureTestingModule({})
-    const fixture = TestBed.createComponent(AttributeComponent)
-    const component = fixture.componentInstance
-
+  function makeSut() {
+    const [fixture, component] = componentTestSetup(AttributeComponent)
     component.symbol = symbol
-    component.id = id
-
     fixture.detectChanges()
-
-    return [fixture, component]
+    return [fixture, component] as const
   }
 
   it('should create', () => {
-    const [component] = makeSut()
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const [_, component] = makeSut()
 
     expect(component).toBeTruthy()
   })
@@ -42,16 +32,16 @@ describe('AttributeComponent', () => {
   it('should be ARIA accessible: icon is described by tooltip', () => {
     const [fixture] = makeSut()
 
-    const tooltipId = `${id}-tooltip`
-    const iconElement = fixture.debugElement.query(MATERIAL_SYMBOLS_SELECTOR)
-    expect(iconElement).toBeTruthy()
-    expect(iconElement.attributes['aria-describedby']).toEqual(tooltipId)
-
     const tooltipElement = fixture.debugElement.query(
       By.css("[role='tooltip']"),
     )
     expect(tooltipElement).toBeTruthy()
-    expect(tooltipElement.attributes['id']).toEqual(tooltipId)
+    const tooltipId = tooltipElement.attributes['id']
+    expect(tooltipId).toMatch(`^${ATTRIBUTE_ID_PREFIX}`)
+
+    const iconElement = fixture.debugElement.query(MATERIAL_SYMBOLS_SELECTOR)
+    expect(iconElement).toBeTruthy()
+    expect(iconElement.attributes['aria-describedby']).toEqual(tooltipId)
   })
 
   it('should be ARIA accessible: icon is included in tab sequence', () => {

--- a/src/app/resume-page/attribute/attribute.component.ts
+++ b/src/app/resume-page/attribute/attribute.component.ts
@@ -1,6 +1,14 @@
 import { Component, Input } from '@angular/core'
 import { MaterialSymbolDirective } from '@/common/material-symbol.directive'
 
+/**
+ * Pattern for unique id generation
+ * https://github.com/angular/components/blob/17.3.0/src/cdk/a11y/aria-describer/aria-describer.ts#L47-L48
+ * @visibleForTesting
+ */
+export const ATTRIBUTE_ID_PREFIX = `app-attr-`
+let nextId = 0
+
 @Component({
   selector: 'app-attribute',
   templateUrl: './attribute.component.html',
@@ -11,8 +19,5 @@ import { MaterialSymbolDirective } from '@/common/material-symbol.directive'
 export class AttributeComponent {
   @Input({ required: true }) symbol!: string
   @Input({ required: true }) id!: string
-
-  public get tooltipId() {
-    return `${this.id}-tooltip`
-  }
+  protected _id: string = `${ATTRIBUTE_ID_PREFIX}${nextId++}`
 }


### PR DESCRIPTION
This way we'll no longer need to create those using `SlugGeneratorService`

So we'll be able to remove it and shave off some bytes in bundle size

There's no need anyway for ARIA ids to be slugs
