### PR TITLE
refactor: remove unused attribute IDs generation

### DIFF
--- a/src/app/resume-page/education-section/education-item/education-item.component.ts
+++ b/src/app/resume-page/education-section/education-item/education-item.component.ts
@@ -1,7 +1,6 @@
 import { Component, Input } from '@angular/core'
 import { EducationItem } from './education-item'
 import { SocialLeaderboard } from '../../../material-symbols'
-import { SlugGeneratorService } from '@/common/slug-generator.service'
 import { ChippedContent } from '../../chipped-content/chipped-content'
 import { EducationItemCoursesComponent } from './education-item-courses/education-item-courses.component'
 import { ChippedContentComponent } from '../../chipped-content/chipped-content.component'
@@ -50,9 +49,6 @@ export class EducationItemComponent {
     } else {
       this._institutionDisplayName = item.institution.name
     }
-    this._itemIdPrefix = this.slugGenerator.generate(item.institution.name, {
-      prefix: 'edu-',
-    })
     this._contents = [
       item.score
         ? new ChippedContent({
@@ -78,18 +74,11 @@ export class EducationItemComponent {
   protected _item!: EducationItem
   protected _contents: ReadonlyArray<ChippedContent> = []
   protected _institutionDisplayName?: string
-  protected _itemIdPrefix?: string
 
   protected readonly MaterialSymbol = {
     SocialLeaderboard,
   }
   protected readonly Attribute = Attribute
-
-  constructor(private slugGenerator: SlugGeneratorService) {}
-
-  public getAttributeId(attribute: Attribute) {
-    return `${this._itemIdPrefix}-${attribute}`
-  }
 }
 
 export enum Attribute {

--- a/src/app/resume-page/experience-section/experience-item/experience-item.component.ts
+++ b/src/app/resume-page/experience-section/experience-item/experience-item.component.ts
@@ -7,7 +7,6 @@ import {
   ToolsLadder,
   Work,
 } from '../../../material-symbols'
-import { SlugGeneratorService } from '@/common/slug-generator.service'
 import { ExperienceItemHighlightsComponent } from './experience-item-highlights/experience-item-highlights.component'
 import { ChippedContentComponent } from '../../chipped-content/chipped-content.component'
 import { AttributeComponent } from '../../attribute/attribute.component'
@@ -83,18 +82,6 @@ export class ExperienceItemComponent {
     More,
   }
   protected readonly Attribute = Attribute
-
-  constructor(private slugGenerator: SlugGeneratorService) {}
-
-  public getAttributeId(attributeName: string) {
-    return `${this.itemId}${attributeName}`
-  }
-
-  private get itemId() {
-    return this.slugGenerator.generate(this._item.company.name, {
-      prefix: 'exp-pos-',
-    })
-  }
 }
 
 export enum Attribute {

--- a/src/app/resume-page/projects-section/project-item/project-item.component.ts
+++ b/src/app/resume-page/projects-section/project-item/project-item.component.ts
@@ -1,6 +1,5 @@
 import { Component, Input } from '@angular/core'
 import { ProjectItem, Stack } from './project-item'
-import { SlugGeneratorService } from '@/common/slug-generator.service'
 import { Apps, Dns, FullStackedBarChart } from '../../../material-symbols'
 import { ChippedContent } from '../../chipped-content/chipped-content'
 import { ChippedContentComponent } from '../../chipped-content/chipped-content.component'
@@ -45,7 +44,6 @@ import { TextContentComponent } from '../../chipped-content/text-content/text-co
 export class ProjectItemComponent {
   @Input({ required: true }) public set item(item: ProjectItem) {
     this._item = item
-    this._itemIdPrefix = `project-${this.slugGenerator.generate(item.name)}`
     this.contents = [
       item.description
         ? new ChippedContent({
@@ -73,16 +71,9 @@ export class ProjectItemComponent {
    * @visibleForTesting
    */
   public contents: ReadonlyArray<ChippedContent> = []
-  protected _itemIdPrefix?: string
 
   protected readonly StackContent = StackContent
   protected readonly Attribute = Attribute
-
-  constructor(private slugGenerator: SlugGeneratorService) {}
-
-  public getAttributeId(attribute: Attribute): string {
-    return `${this._itemIdPrefix}-${attribute}`
-  }
 }
 
 export enum Attribute {


### PR DESCRIPTION
A step closer to removing slug generation service. Now all references to it have been removed.
