### PR TITLE
refactor: chipped content to render on click

### DIFF
--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -6,7 +6,6 @@ import {
 import { APP_METADATA_PROVIDERS } from './app.metadata-imports'
 import { routes } from './app.routes'
 import { provideAnimationsAsync } from '@angular/platform-browser/animations/async'
-import { PLATFORM_SERVICE_PROVIDER } from '@/common/platform.service'
 
 export const appConfig: ApplicationConfig = {
   providers: [
@@ -17,6 +16,5 @@ export const appConfig: ApplicationConfig = {
     ),
     provideAnimationsAsync(),
     ...APP_METADATA_PROVIDERS,
-    PLATFORM_SERVICE_PROVIDER,
   ],
 }

--- a/src/app/common/item.ts
+++ b/src/app/common/item.ts
@@ -1,0 +1,1 @@
+export type Item<T, NewObjArg extends object> = { new (obj: NewObjArg): T }

--- a/src/app/common/platform.service.ts
+++ b/src/app/common/platform.service.ts
@@ -1,22 +1,22 @@
 import { isPlatformBrowser } from '@angular/common'
-import { FactoryProvider, InjectionToken, PLATFORM_ID } from '@angular/core'
+import { inject, InjectionToken, PLATFORM_ID } from '@angular/core'
+import { isDevMode } from '@/common/is-dev-mode'
 
-export interface PlatformService {
+export class PlatformService {
   readonly isBrowser: boolean
   readonly isServer: boolean
+
+  constructor(isBrowser: boolean) {
+    this.isBrowser = isBrowser
+    this.isServer = !isBrowser
+  }
 }
 
-// Not using `@Injectable` for performance purposes 🧑‍💻
-class AngularPlatformService {
-  public readonly isBrowser = isPlatformBrowser(this._platformId)
-  public readonly isServer = !this.isBrowser
-
-  constructor(private readonly _platformId: object) {}
-}
-
-export const PLATFORM_SERVICE = new InjectionToken<PlatformService>('PlatServ')
-export const PLATFORM_SERVICE_PROVIDER: FactoryProvider = {
-  provide: PLATFORM_SERVICE,
-  useFactory: (platformId: object) => new AngularPlatformService(platformId),
-  deps: [PLATFORM_ID],
-}
+//👇 Not @Injectable for perf purposes
+export const PLATFORM_SERVICE = new InjectionToken<PlatformService>(
+  isDevMode ? 'PlatformService' : 'PS',
+  {
+    providedIn: 'platform',
+    factory: () => new PlatformService(isPlatformBrowser(inject(PLATFORM_ID))),
+  },
+)

--- a/src/app/common/scroll-into-view.spec.ts
+++ b/src/app/common/scroll-into-view.spec.ts
@@ -1,0 +1,44 @@
+import {
+  _SCROLL_INTO_VIEW_FACTORY,
+  SCROLL_INTO_VIEW,
+} from '@/common/scroll-into-view'
+import { MockProvider } from 'ng-mocks'
+import { PLATFORM_SERVICE, PlatformService } from '@/common/platform.service'
+import {
+  MOCK_BROWSER_PLATFORM_SERVICE,
+  MOCK_SERVER_PLATFORM_SERVICE,
+} from '@/test/helpers/platform-service'
+import { serviceTestSetup } from '@/test/helpers/service-test-setup'
+
+describe('ScrollIntoView', () => {
+  describe('when on browser', () => {
+    const DEFAULT_ARGS: ScrollIntoViewOptions = { block: 'nearest' }
+    it('should call scroll into view function with default args', () => {
+      const sut = makeSut({ platformService: MOCK_BROWSER_PLATFORM_SERVICE })
+      const dummyElement = jasmine.createSpyObj<HTMLElement>(['scrollIntoView'])
+
+      sut(dummyElement)
+
+      expect(dummyElement.scrollIntoView).toHaveBeenCalledOnceWith(DEFAULT_ARGS)
+    })
+  })
+  describe('when on server', () => {
+    it('should do nothing', () => {
+      const sut = makeSut({ platformService: MOCK_SERVER_PLATFORM_SERVICE })
+      const dummyElement = jasmine.createSpyObj<HTMLElement>(['scrollIntoView'])
+
+      sut(dummyElement)
+
+      expect(dummyElement.scrollIntoView).not.toHaveBeenCalled()
+    })
+  })
+})
+
+function makeSut(opts: { platformService: PlatformService }) {
+  return serviceTestSetup(SCROLL_INTO_VIEW, {
+    providers: [
+      MockProvider(PLATFORM_SERVICE, opts.platformService),
+      MockProvider(SCROLL_INTO_VIEW, _SCROLL_INTO_VIEW_FACTORY, 'useFactory'),
+    ],
+  })
+}

--- a/src/app/common/scroll-into-view.ts
+++ b/src/app/common/scroll-into-view.ts
@@ -1,0 +1,20 @@
+import { inject, InjectionToken } from '@angular/core'
+import { isDevMode } from '@/common/is-dev-mode'
+import { PLATFORM_SERVICE } from '@/common/platform.service'
+import { noop } from 'rxjs'
+
+const scrollIntoView: ScrollIntoView = (element: HTMLElement) =>
+  element.scrollIntoView && element.scrollIntoView({ block: 'nearest' })
+export type ScrollIntoView = (element: HTMLElement) => void
+/**
+ * @visibleForTesting
+ */
+export const _SCROLL_INTO_VIEW_FACTORY: () => ScrollIntoView = () =>
+  inject(PLATFORM_SERVICE).isBrowser ? scrollIntoView : noop
+export const SCROLL_INTO_VIEW = new InjectionToken<ScrollIntoView>(
+  isDevMode ? 'ScrollIntoView' : 'SIV',
+  {
+    providedIn: 'platform',
+    factory: _SCROLL_INTO_VIEW_FACTORY,
+  },
+)

--- a/src/app/common/scroll-into-view.ts
+++ b/src/app/common/scroll-into-view.ts
@@ -6,8 +6,17 @@ import { noop } from 'rxjs'
 const scrollIntoView: ScrollIntoView = (element: HTMLElement) =>
   element.scrollIntoView && element.scrollIntoView({ block: 'nearest' })
 export type ScrollIntoView = (element: HTMLElement) => void
+
 /**
  * @visibleForTesting
+ *
+ * Otherwise, don't know how to mock the {@link PlatformService} due to `providedIn: 'platform'`
+ *
+ * Given `TestBed` configures things after platform is already bootstrapped.
+ * At that point, the token is already there with the proper {@link PlatformService}
+ *
+ * As workaround, creating another provider for it when testing using the same factory.
+ * That's why it's exported
  */
 export const _SCROLL_INTO_VIEW_FACTORY: () => ScrollIntoView = () =>
   inject(PLATFORM_SERVICE).isBrowser ? scrollIntoView : noop

--- a/src/app/resume-page/chipped-content/chipped-content.component.html
+++ b/src/app/resume-page/chipped-content/chipped-content.component.html
@@ -1,34 +1,20 @@
-<div class="selectable-chips" [class]="DISPLAY_NONE_IF_NO_SCRIPT_CLASS">
+<div class="chips">
   <app-chip
-    *ngFor="let content of contents"
-    [selected]="_displayedContent === content"
-    (selectedChange)="
-      _displayedContent === content
-        ? (_displayedContent = undefined)
-        : (_displayedContent = content)
-    "
+    *ngFor="let content of contents; let i = index"
+    [selected]="_active && _activeIndex === i"
+    (selectedChange)="onSelect(i)"
   >
     {{ content.displayName }}
   </app-chip>
 </div>
 <div
   class="content"
-  *ngFor="let content of contents"
-  [ngClass]="DISPLAY_BLOCK_IF_NO_SCRIPT_CLASS"
-  [@contentDisplayed]="_displayedContent === content"
-  (@contentDisplayed.done)="
-    _platformService.isBrowser &&
-      contentElement.scrollIntoView({ block: 'nearest' })
-  "
+  [@contentDisplayed]="_active"
+  (@contentDisplayed.done)="_scrollIntoView(contentElement)"
   #contentElement
 >
-  <app-chip
-    [ngClass]="DISPLAY_BLOCK_IF_NO_SCRIPT_CLASS"
-    [style.display]="'none'"
-  >
-    {{ content.displayName }}
-  </app-chip>
   <ng-container
-    *ngComponentOutlet="content.component; inputs: content.inputs"
+    [ngComponentOutlet]="contents[_activeIndex].component"
+    [ngComponentOutletInputs]="contents[_activeIndex].inputs"
   ></ng-container>
 </div>

--- a/src/app/resume-page/chipped-content/chipped-content.component.scss
+++ b/src/app/resume-page/chipped-content/chipped-content.component.scss
@@ -5,16 +5,12 @@
   flex-direction: column;
   gap: margins.$m;
 
-  .selectable-chips {
+  .chips {
     display: flex;
     gap: margins.$s;
   }
 
   .content {
-    app-chip {
-      margin-bottom: margins.$s;
-    }
-
     > ::ng-deep * {
       display: block;
     }

--- a/src/app/resume-page/chipped-content/chipped-content.component.spec.ts
+++ b/src/app/resume-page/chipped-content/chipped-content.component.spec.ts
@@ -190,17 +190,13 @@ const BAR_CONTENT = new ChippedContent({
 const CONTENTS = [FOO_CONTENT, BAR_CONTENT] as const
 const FIRST_CONTENT = CONTENTS[0]
 const SECOND_CONTENT = CONTENTS[1]
-function makeSut(): [
-  ComponentFixture<ChippedContentComponent>,
-  ChippedContentComponent,
-] {
+function makeSut() {
   const [fixture, component] = componentTestSetup(ChippedContentComponent, {
-    imports: [ChippedContentComponent, ChipComponent],
     providers: [
       provideNoopAnimations(),
       MockProvider(SCROLL_INTO_VIEW, jasmine.createSpy()),
     ],
   })
   component.contents = CONTENTS
-  return [fixture, component]
+  return [fixture, component] as const
 }

--- a/src/app/resume-page/chipped-content/chipped-content.component.spec.ts
+++ b/src/app/resume-page/chipped-content/chipped-content.component.spec.ts
@@ -103,8 +103,11 @@ describe('ChippedContentComponent', () => {
     })
 
     it('should scroll content into view', () => {
+      const contentElement = fixture.debugElement.query(CONTENT_PREDICATE)
       const scrollIntoViewSpy = TestBed.inject(SCROLL_INTO_VIEW) as jasmine.Spy
-      expect(scrollIntoViewSpy).toHaveBeenCalledTimes(1)
+      expect(scrollIntoViewSpy).toHaveBeenCalledOnceWith(
+        contentElement.nativeElement,
+      )
     })
 
     describe('when tapping same chip again', () => {

--- a/src/app/resume-page/chipped-content/chipped-content.component.spec.ts
+++ b/src/app/resume-page/chipped-content/chipped-content.component.spec.ts
@@ -1,4 +1,4 @@
-import { ComponentFixture, fakeAsync } from '@angular/core/testing'
+import { ComponentFixture, fakeAsync, TestBed } from '@angular/core/testing'
 import { ChippedContentComponent } from './chipped-content.component'
 import { Component, DebugElement, Input } from '@angular/core'
 import { ChippedContent } from './chipped-content'
@@ -10,16 +10,11 @@ import {
 import { byComponent } from '@/test/helpers/component-query-predicates'
 import { getReflectedAttribute } from '@/test/helpers/get-reflected-attribute'
 import { componentTestSetup } from '@/test/helpers/component-test-setup'
-import {
-  expectIsBlockDisplayedIfNoScript,
-  expectIsNotDisplayedIfNoScript,
-} from '@/test/helpers/no-script'
 import { By } from '@angular/platform-browser'
 import { provideNoopAnimations } from '@angular/platform-browser/animations'
 import { tickToFinishAnimation } from '@/test/helpers/tick-to-finish-animation'
 import { MockProvider } from 'ng-mocks'
-import { PLATFORM_SERVICE } from '@/common/platform.service'
-import { MOCK_BROWSER_PLATFORM_SERVICE } from '@/test/helpers/platform-service'
+import { SCROLL_INTO_VIEW } from '@/common/scroll-into-view'
 
 describe('ChippedContentComponent', () => {
   let fixture: ComponentFixture<ChippedContentComponent>
@@ -35,15 +30,10 @@ describe('ChippedContentComponent', () => {
     expect(component).toBeTruthy()
   })
 
-  const SELECTABLE_CHIPS_CONTAINER_PREDICATE = By.css('.selectable-chips')
   const CONTENT_PREDICATE = By.css('.content')
 
-  it('should render all selectable chips unselected with their display names', () => {
-    const selectableChipsContainerElement = fixture.debugElement.query(
-      SELECTABLE_CHIPS_CONTAINER_PREDICATE,
-    )
-
-    const chipElements = selectableChipsContainerElement.queryAll(
+  it('should render selection chips unselected with their display names', () => {
+    const chipElements = fixture.debugElement.queryAll(
       byComponent(ChipComponent),
     )
     expect(chipElements.length).toEqual(CONTENTS.length)
@@ -59,64 +49,36 @@ describe('ChippedContentComponent', () => {
     })
   })
 
-  it('should render all contents without laying out neither its component or its chip', () => {
-    const contentElements = fixture.debugElement.queryAll(CONTENT_PREDICATE)
-    expect(contentElements.length).toEqual(CONTENTS.length)
+  it('should add but not layout first content', () => {
+    const contentElement = fixture.debugElement.query(CONTENT_PREDICATE)
+    expect(contentElement).toBeDefined()
 
-    contentElements.forEach((contentElement, index) => {
-      const content = CONTENTS[index]
-      const componentElement = contentElement.query(
-        byComponent(content.component),
-      )
-      expect(componentElement).toBeTruthy()
+    const firstComponentElement = contentElement.query(
+      byComponent(FIRST_CONTENT.component),
+    )
+    expect(firstComponentElement).toBeTruthy()
 
-      expect(componentElement.nativeElement.textContent.trim()).toEqual(
-        content.inputs!['data'],
-      )
-
-      const chipElement = contentElement.query(byComponent(ChipComponent))
-      expectIsNotInLayout(chipElement.nativeElement)
-
-      expectIsNotInLayout(contentElement.nativeElement)
-    })
-  })
-
-  describe('when JS is disabled', () => {
-    it('should not display selectable chips', () => {
-      const selectableChipsContainerElement = fixture.debugElement.query(
-        SELECTABLE_CHIPS_CONTAINER_PREDICATE,
-      )
-      expectIsNotDisplayedIfNoScript(selectableChipsContainerElement)
-    })
-
-    it('should display all content', () => {
-      const contentContainers = fixture.debugElement.queryAll(CONTENT_PREDICATE)
-      for (const contentContainer of contentContainers) {
-        expectIsBlockDisplayedIfNoScript(contentContainer)
-      }
-    })
-
-    it('should display non-selectable chips', () => {
-      const contentContainers = fixture.debugElement.queryAll(CONTENT_PREDICATE)
-
-      for (const contentContainer of contentContainers) {
-        const chipElement = contentContainer.query(byComponent(ChipComponent))
-        expectIsBlockDisplayedIfNoScript(chipElement)
-      }
-    })
+    expect(firstComponentElement.nativeElement.textContent.trim()).toEqual(
+      FIRST_CONTENT.inputs!['data'],
+    )
+    expectIsNotInLayout(contentElement.nativeElement)
+    expectIsNotInLayout(firstComponentElement.nativeElement)
   })
 
   describe('when tapping on a chip', () => {
-    let fooChipElement: DebugElement
-    let fooContentElement: DebugElement
+    let firstChipElement: DebugElement
+    let firstContentElement: DebugElement
 
     beforeEach(fakeAsync(() => {
-      fooChipElement = findChipByDisplayName(FOO_CONTENT.displayName)!
-      fooContentElement = fixture.debugElement.query(byComponent(FooComponent))
-      expect(fooChipElement).withContext('foo chip exists').toBeTruthy()
-      expect(fooContentElement).withContext('foo content exists').toBeTruthy()
+      firstChipElement = findChipByDisplayName(FIRST_CONTENT.displayName)!
+      firstContentElement = fixture.debugElement.query(
+        byComponent(FIRST_CONTENT.component),
+      )
 
-      fooChipElement.triggerEventHandler('click')
+      expect(firstChipElement).toBeTruthy()
+      expect(firstContentElement).toBeTruthy()
+
+      firstChipElement.triggerEventHandler('click')
       fixture.detectChanges()
       tickToFinishAnimation()
     }))
@@ -131,55 +93,62 @@ describe('ChippedContentComponent', () => {
     }
 
     it('should mark the chip as selected', () => {
-      expect(getReflectedAttribute(fooChipElement, 'selected')).toBe('true')
+      expect(getReflectedAttribute(firstChipElement, 'selected')).toBe(
+        true.toString(),
+      )
     })
 
-    it('should display its content', () => {
-      expectIsInLayout(fooContentElement.nativeElement)
+    it('should layout its content', () => {
+      expectIsInLayout(firstContentElement.nativeElement)
+    })
+
+    it('should scroll content into view', () => {
+      const scrollIntoViewSpy = TestBed.inject(SCROLL_INTO_VIEW) as jasmine.Spy
+      expect(scrollIntoViewSpy).toHaveBeenCalledTimes(1)
     })
 
     describe('when tapping same chip again', () => {
       beforeEach(fakeAsync(() => {
-        fooChipElement.triggerEventHandler('click')
+        firstChipElement.triggerEventHandler('click')
         fixture.detectChanges()
         tickToFinishAnimation()
       }))
 
       it('should mark the chip as unselected', () => {
-        expect(getReflectedAttribute(fooChipElement, 'selected')).toEqual(
+        expect(getReflectedAttribute(firstChipElement, 'selected')).toEqual(
           false.toString(),
         )
       })
 
-      it('should not display its content', () => {
-        expectIsNotInLayout(fooContentElement.nativeElement)
+      it('should not layout its content', () => {
+        expectIsNotInLayout(firstContentElement.nativeElement)
       })
     })
 
     describe('when tapping another chip', () => {
-      let barChipElement: DebugElement
+      let secondChipElement: DebugElement
 
       beforeEach(fakeAsync(() => {
-        barChipElement = findChipByDisplayName(BAR_CONTENT.displayName)!
-        expect(barChipElement).withContext('bar chip exists').toBeTruthy()
+        secondChipElement = findChipByDisplayName(SECOND_CONTENT.displayName)!
+        expect(secondChipElement).toBeTruthy()
 
-        barChipElement.triggerEventHandler('click')
+        secondChipElement.triggerEventHandler('click')
 
         fixture.detectChanges()
         tickToFinishAnimation()
       }))
 
       it('should mark the previous chip as unselected and just tapped chip as selected', () => {
-        expect(getReflectedAttribute(fooChipElement, 'selected')).toBe(
+        expect(getReflectedAttribute(firstChipElement, 'selected')).toBe(
           false.toString(),
         )
-        expect(getReflectedAttribute(barChipElement, 'selected')).toBe(
+        expect(getReflectedAttribute(secondChipElement, 'selected')).toBe(
           true.toString(),
         )
       })
 
-      it('should hide currently active content and show the new content', () => {
-        expectIsNotInLayout(fooContentElement.nativeElement)
+      it('should not layout currently active content and layout the new content', () => {
+        expectIsNotInLayout(firstContentElement.nativeElement)
 
         const barContentElement = fixture.debugElement.query(
           byComponent(BarComponent),
@@ -216,6 +185,8 @@ const BAR_CONTENT = new ChippedContent({
 })
 
 const CONTENTS = [FOO_CONTENT, BAR_CONTENT] as const
+const FIRST_CONTENT = CONTENTS[0]
+const SECOND_CONTENT = CONTENTS[1]
 function makeSut(): [
   ComponentFixture<ChippedContentComponent>,
   ChippedContentComponent,
@@ -224,7 +195,7 @@ function makeSut(): [
     imports: [ChippedContentComponent, ChipComponent],
     providers: [
       provideNoopAnimations(),
-      MockProvider(PLATFORM_SERVICE, MOCK_BROWSER_PLATFORM_SERVICE),
+      MockProvider(SCROLL_INTO_VIEW, jasmine.createSpy()),
     ],
   })
   component.contents = CONTENTS

--- a/src/app/resume-page/chipped-content/chipped-content.component.ts
+++ b/src/app/resume-page/chipped-content/chipped-content.component.ts
@@ -1,12 +1,8 @@
 import { Component, Inject, Input } from '@angular/core'
 import { ChipComponent } from '../chip/chip.component'
-import { NgClass, NgComponentOutlet, NgFor } from '@angular/common'
+import { NgClass, NgComponentOutlet, NgFor, NgIf } from '@angular/common'
 import { TestIdDirective } from '@/common/test-id.directive'
 import { ChippedContent } from './chipped-content'
-import {
-  DISPLAY_BLOCK_IF_NO_SCRIPT_CLASS,
-  DISPLAY_NONE_IF_NO_SCRIPT_CLASS,
-} from '@/common/no-script'
 import { EMPHASIZED_DURATION_MS, TIMING_FUNCTION } from '@/common/animations'
 import {
   animate,
@@ -16,14 +12,21 @@ import {
   transition,
   trigger,
 } from '@angular/animations'
-import { PLATFORM_SERVICE, PlatformService } from '@/common/platform.service'
+import { SCROLL_INTO_VIEW, ScrollIntoView } from '@/common/scroll-into-view'
 
 @Component({
   selector: 'app-chipped-content',
   templateUrl: './chipped-content.component.html',
   styleUrls: ['./chipped-content.component.scss'],
   standalone: true,
-  imports: [NgFor, ChipComponent, TestIdDirective, NgClass, NgComponentOutlet],
+  imports: [
+    NgFor,
+    ChipComponent,
+    TestIdDirective,
+    NgClass,
+    NgComponentOutlet,
+    NgIf,
+  ],
   animations: [
     trigger('contentDisplayed', [
       state('false', style({ display: 'none' })),
@@ -50,15 +53,18 @@ export class ChippedContentComponent {
   @Input() public contents!: ReadonlyArray<ChippedContent>
 
   constructor(
-    @Inject(PLATFORM_SERVICE) protected _platformService: PlatformService,
+    @Inject(SCROLL_INTO_VIEW) protected _scrollIntoView: ScrollIntoView,
   ) {}
 
-  protected _displayedContent: DisplayedContent
+  protected _active = false
+  protected _activeIndex = 0
 
-  protected readonly DISPLAY_BLOCK_IF_NO_SCRIPT_CLASS =
-    DISPLAY_BLOCK_IF_NO_SCRIPT_CLASS
-  protected readonly DISPLAY_NONE_IF_NO_SCRIPT_CLASS =
-    DISPLAY_NONE_IF_NO_SCRIPT_CLASS
+  onSelect(index: number) {
+    if (this._activeIndex == index) {
+      this._active = !this._active
+      return
+    }
+    this._active = true
+    this._activeIndex = index
+  }
 }
-
-type DisplayedContent = ChippedContent | undefined

--- a/src/app/resume-page/chipped-content/chipped-content.component.ts
+++ b/src/app/resume-page/chipped-content/chipped-content.component.ts
@@ -1,7 +1,6 @@
 import { Component, Inject, Input } from '@angular/core'
 import { ChipComponent } from '../chip/chip.component'
-import { NgClass, NgComponentOutlet, NgFor, NgIf } from '@angular/common'
-import { TestIdDirective } from '@/common/test-id.directive'
+import { NgComponentOutlet, NgFor } from '@angular/common'
 import { ChippedContent } from './chipped-content'
 import { EMPHASIZED_DURATION_MS, TIMING_FUNCTION } from '@/common/animations'
 import {
@@ -19,14 +18,7 @@ import { SCROLL_INTO_VIEW, ScrollIntoView } from '@/common/scroll-into-view'
   templateUrl: './chipped-content.component.html',
   styleUrls: ['./chipped-content.component.scss'],
   standalone: true,
-  imports: [
-    NgFor,
-    ChipComponent,
-    TestIdDirective,
-    NgClass,
-    NgComponentOutlet,
-    NgIf,
-  ],
+  imports: [NgFor, ChipComponent, NgComponentOutlet],
   animations: [
     trigger('contentDisplayed', [
       state('false', style({ display: 'none' })),

--- a/src/app/resume-page/chipped-content/chipped-content.ts
+++ b/src/app/resume-page/chipped-content/chipped-content.ts
@@ -1,9 +1,9 @@
 import { Type } from '@angular/core'
 
-export class ChippedContent {
+export class ChippedContent<T = unknown> {
   public readonly displayName: string
-  public readonly component: Type<unknown>
-  public readonly inputs?: Record<string, unknown>
+  public readonly component: Type<T>
+  public readonly inputs?: Partial<T>
 
   constructor({
     displayName,
@@ -11,8 +11,8 @@ export class ChippedContent {
     inputs,
   }: {
     displayName: string
-    component: Type<unknown>
-    inputs?: Record<string, unknown>
+    component: Type<T>
+    inputs?: Partial<T>
   }) {
     this.displayName = displayName
     this.component = component

--- a/src/app/resume-page/education-section/education-item/__tests__/make-education-item.ts
+++ b/src/app/resume-page/education-section/education-item/__tests__/make-education-item.ts
@@ -1,0 +1,16 @@
+import { Organization } from '../../../organization'
+import { DateRange } from '../../../date-range/date-range'
+import { EducationItem } from '../education-item'
+import { makeItemFactory } from '@/test/helpers/make-item-factory'
+
+export const makeEducationItem = makeItemFactory(EducationItem, {
+  institution: new Organization({
+    name: 'Institution name',
+    imageSrc: 'https://example.org/logo.png',
+    website: new URL('https://example.org'),
+  }),
+  area: 'Area',
+  studyType: 'Study type',
+  score: 'Score',
+  dateRange: new DateRange(new Date('2023-01-01'), new Date('2023-12-31')),
+})

--- a/src/app/resume-page/education-section/education-item/education-item-to-contents.spec.ts
+++ b/src/app/resume-page/education-section/education-item/education-item-to-contents.spec.ts
@@ -1,0 +1,44 @@
+import { makeEducationItem } from './__tests__/make-education-item'
+import { EducationItemCoursesComponent } from './education-item-courses/education-item-courses.component'
+import { TextContentComponent } from '../../chipped-content/text-content/text-content.component'
+import { educationItemToContents } from './education-item-to-contents'
+
+describe('educationItemToContents', () => {
+  describe('when score is present', () => {
+    const score = 'Very good++'
+
+    it('should include score content', () => {
+      const sut = makeSut()
+
+      const contents = sut(makeEducationItem({ score }))
+      const scoreContents = contents.filter(
+        (content) => content.displayName === 'Score',
+      )
+      expect(scoreContents).toHaveSize(1)
+      const scoreContent = scoreContents[0]
+      expect(scoreContent.component).toEqual(TextContentComponent)
+      expect(scoreContent.inputs).toEqual({
+        text: score,
+      } satisfies Partial<TextContentComponent>)
+    })
+  })
+
+  describe('when courses are not empty', () => {
+    const courses = ['Course 1', 'Course 2']
+
+    it('should include courses content', () => {
+      const sut = makeSut()
+
+      const contents = sut(makeEducationItem({ courses }))
+      const coursesContents = contents.filter(
+        (content) => content.displayName === 'Courses',
+      )
+      expect(coursesContents).toHaveSize(1)
+      const courseContent = coursesContents[0]
+      expect(courseContent.component).toEqual(EducationItemCoursesComponent)
+      expect(courseContent.inputs).toEqual({ courses })
+    })
+  })
+})
+
+const makeSut = () => educationItemToContents

--- a/src/app/resume-page/education-section/education-item/education-item-to-contents.spec.ts
+++ b/src/app/resume-page/education-section/education-item/education-item-to-contents.spec.ts
@@ -36,7 +36,9 @@ describe('educationItemToContents', () => {
       expect(coursesContents).toHaveSize(1)
       const courseContent = coursesContents[0]
       expect(courseContent.component).toEqual(EducationItemCoursesComponent)
-      expect(courseContent.inputs).toEqual({ courses })
+      expect(courseContent.inputs).toEqual({
+        courses,
+      } satisfies Partial<EducationItemCoursesComponent>)
     })
   })
 })

--- a/src/app/resume-page/education-section/education-item/education-item-to-contents.ts
+++ b/src/app/resume-page/education-section/education-item/education-item-to-contents.ts
@@ -1,0 +1,30 @@
+import { EducationItem } from './education-item'
+import { ChippedContent } from '../../chipped-content/chipped-content'
+import { EducationItemCoursesComponent } from './education-item-courses/education-item-courses.component'
+import { isNotUndefined } from '@/common/is-not-undefined'
+import { TextContentComponent } from '../../chipped-content/text-content/text-content.component'
+
+export type EducationItemToContents = (
+  item: EducationItem,
+) => ReadonlyArray<ChippedContent>
+export const educationItemToContents: EducationItemToContents = (item) =>
+  [
+    item.score
+      ? new ChippedContent({
+          displayName: 'Score',
+          component: TextContentComponent,
+          inputs: {
+            text: item.score,
+          } satisfies Partial<TextContentComponent>,
+        })
+      : undefined,
+    item.courses.length > 0
+      ? new ChippedContent({
+          displayName: 'Courses',
+          component: EducationItemCoursesComponent,
+          inputs: {
+            courses: item.courses,
+          } satisfies Partial<EducationItemCoursesComponent>,
+        })
+      : undefined,
+  ].filter(isNotUndefined)

--- a/src/app/resume-page/education-section/education-item/education-item-to-contents.ts
+++ b/src/app/resume-page/education-section/education-item/education-item-to-contents.ts
@@ -15,7 +15,7 @@ export const educationItemToContents: EducationItemToContents = (item) =>
           component: TextContentComponent,
           inputs: {
             text: item.score,
-          } satisfies Partial<TextContentComponent>,
+          },
         })
       : undefined,
     item.courses.length > 0
@@ -24,7 +24,7 @@ export const educationItemToContents: EducationItemToContents = (item) =>
           component: EducationItemCoursesComponent,
           inputs: {
             courses: item.courses,
-          } satisfies Partial<EducationItemCoursesComponent>,
+          },
         })
       : undefined,
   ].filter(isNotUndefined)

--- a/src/app/resume-page/education-section/education-item/education-item.component.spec.ts
+++ b/src/app/resume-page/education-section/education-item/education-item.component.spec.ts
@@ -6,8 +6,7 @@ import { Organization } from '../../organization'
 import { By } from '@angular/platform-browser'
 import { NgIf, NgOptimizedImage } from '@angular/common'
 import { DateRangeComponent } from '../../date-range/date-range.component'
-import { DateRange } from '../../date-range/date-range'
-import { MockComponents, MockProvider } from 'ng-mocks'
+import { MockComponents } from 'ng-mocks'
 import { CardComponent } from '../../card/card.component'
 import { CardHeaderImageComponent } from '../../card/card-header/card-header-image/card-header-image.component'
 import { LinkComponent } from '../../link/link.component'
@@ -23,9 +22,9 @@ import { AttributeComponent } from '../../attribute/attribute.component'
 import { byComponent } from '@/test/helpers/component-query-predicates'
 import { ChippedContentComponent } from '../../chipped-content/chipped-content.component'
 import { componentTestSetup } from '@/test/helpers/component-test-setup'
-import { provideNoopAnimations } from '@angular/platform-browser/animations'
-import { PLATFORM_SERVICE } from '@/common/platform.service'
-import { MOCK_BROWSER_PLATFORM_SERVICE } from '@/test/helpers/platform-service'
+import { makeEducationItem } from './__tests__/make-education-item'
+import { shouldContainComponent } from '@/test/helpers/component-testers'
+import { ItemFactoryOverrides } from '@/test/helpers/make-item-factory'
 
 describe('EducationItemComponent', () => {
   let component: EducationItemComponent
@@ -148,51 +147,7 @@ describe('EducationItemComponent', () => {
     })
   })
 
-  it('should add chipped contents component', () => {
-    setEducationItem(fixture)
-
-    expect(
-      fixture.debugElement.query(byComponent(ChippedContentComponent)),
-    ).toBeTruthy()
-  })
-
-  const CONTENT_CONTAINER_PREDICATE = byComponent(ChippedContentComponent)
-
-  describe('when score is present', () => {
-    const score = 'Very good++'
-
-    beforeEach(() => {
-      setEducationItem(fixture, { score })
-    })
-
-    it('should render score content', () => {
-      const contentContainer = fixture.debugElement.query(
-        CONTENT_CONTAINER_PREDICATE,
-      )
-
-      expect(contentContainer.nativeElement.textContent.trim()).toContain(score)
-    })
-  })
-
-  describe('when courses are not empty', () => {
-    const courses = ['Course 1', 'Course 2']
-
-    beforeEach(() => {
-      setEducationItem(fixture, { courses })
-    })
-
-    it('should render courses content', () => {
-      const contentContainer = fixture.debugElement.query(
-        CONTENT_CONTAINER_PREDICATE,
-      )
-
-      courses.forEach((course) => {
-        expect(contentContainer.nativeElement.textContent.trim()).toContain(
-          course,
-        )
-      })
-    })
-  })
+  shouldContainComponent(() => fixture, ChippedContentComponent)
 })
 
 function makeSut() {
@@ -214,31 +169,17 @@ function makeSut() {
         CardHeaderTextsComponent,
         CardHeaderAttributesComponent,
         AttributeComponent,
+        ChippedContentComponent,
       ),
-    ],
-    providers: [
-      provideNoopAnimations(), // to include real chipped content
-      MockProvider(PLATFORM_SERVICE, MOCK_BROWSER_PLATFORM_SERVICE),
     ],
   })
 }
 
 function setEducationItem(
   fixture: ComponentFixture<EducationItemComponent>,
-  newItemArgOverrides?: Partial<ConstructorParameters<typeof EducationItem>[0]>,
+  overrides?: ItemFactoryOverrides<typeof EducationItem>,
 ): void {
-  fixture.componentInstance.item = new EducationItem({
-    institution: new Organization({
-      name: 'Institution name',
-      imageSrc: 'https://example.org/logo.png',
-      website: new URL('https://example.org'),
-    }),
-    area: 'Area',
-    studyType: 'Study type',
-    score: 'Score',
-    dateRange: new DateRange(new Date('2023-01-01'), new Date('2023-12-31')),
-    ...newItemArgOverrides,
-  })
+  fixture.componentInstance.item = makeEducationItem(overrides)
 
   fixture.detectChanges()
 }

--- a/src/app/resume-page/education-section/education-item/education-item.component.spec.ts
+++ b/src/app/resume-page/education-section/education-item/education-item.component.spec.ts
@@ -4,17 +4,15 @@ import { Attribute, EducationItemComponent } from './education-item.component'
 import { EducationItem } from './education-item'
 import { Organization } from '../../organization'
 import { By } from '@angular/platform-browser'
-import { NgIf, NgOptimizedImage } from '@angular/common'
+import { NgIf } from '@angular/common'
 import { DateRangeComponent } from '../../date-range/date-range.component'
 import { MockComponents } from 'ng-mocks'
 import { CardComponent } from '../../card/card.component'
 import { CardHeaderImageComponent } from '../../card/card-header/card-header-image/card-header-image.component'
-import { LinkComponent } from '../../link/link.component'
 import { CardHeaderTitleComponent } from '../../card/card-header/card-header-title/card-header-title.component'
 import { CardHeaderSubtitleComponent } from '../../card/card-header/card-header-subtitle/card-header-subtitle.component'
 import { CardHeaderDetailComponent } from '../../card/card-header/card-header-detail/card-header-detail.component'
 import { byTestId } from '@/test/helpers/test-id'
-import { TestIdDirective } from '@/common/test-id.directive'
 import { CardHeaderComponent } from '../../card/card-header/card-header.component'
 import { CardHeaderTextsComponent } from '../../card/card-header/card-header-texts/card-header-texts.component'
 import { CardHeaderAttributesComponent } from '../../card/card-header/card-header-attributes/card-header-attributes.component'
@@ -25,6 +23,7 @@ import { componentTestSetup } from '@/test/helpers/component-test-setup'
 import { makeEducationItem } from './__tests__/make-education-item'
 import { shouldContainComponent } from '@/test/helpers/component-testers'
 import { ItemFactoryOverrides } from '@/test/helpers/make-item-factory'
+import { getReflectedAttribute } from '@/test/helpers/get-reflected-attribute'
 
 describe('EducationItemComponent', () => {
   let component: EducationItemComponent
@@ -57,9 +56,11 @@ describe('EducationItemComponent', () => {
     expect(anchorElement).toBeTruthy()
     expect(anchorElement.attributes['href']).toEqual(website)
 
-    const imageElement = anchorElement.query(By.css('img'))
+    const imageElement = anchorElement.query(
+      byComponent(CardHeaderImageComponent),
+    )
     expect(imageElement).toBeTruthy()
-    expect(imageElement.attributes['src']).toEqual(imageUrl)
+    expect(getReflectedAttribute(imageElement, 'src')).toEqual(imageUrl)
   })
 
   it("should display institution name with link to company's website", () => {
@@ -155,15 +156,12 @@ function makeSut() {
     imports: [
       EducationItemComponent,
       NgIf,
-      NgOptimizedImage,
-      LinkComponent,
-      CardHeaderImageComponent,
-      CardHeaderTitleComponent,
-      CardHeaderSubtitleComponent,
-      TestIdDirective,
       MockComponents(
         CardComponent,
         DateRangeComponent,
+        CardHeaderImageComponent,
+        CardHeaderTitleComponent,
+        CardHeaderSubtitleComponent,
         CardHeaderDetailComponent,
         CardHeaderComponent,
         CardHeaderTextsComponent,

--- a/src/app/resume-page/education-section/education-item/education-item.component.ts
+++ b/src/app/resume-page/education-section/education-item/education-item.component.ts
@@ -2,7 +2,6 @@ import { Component, Input } from '@angular/core'
 import { EducationItem } from './education-item'
 import { SocialLeaderboard } from '../../../material-symbols'
 import { ChippedContent } from '../../chipped-content/chipped-content'
-import { EducationItemCoursesComponent } from './education-item-courses/education-item-courses.component'
 import { ChippedContentComponent } from '../../chipped-content/chipped-content.component'
 import { AttributeComponent } from '../../attribute/attribute.component'
 import { NgIf } from '@angular/common'
@@ -17,8 +16,7 @@ import { TestIdDirective } from '@/common/test-id.directive'
 import { LinkComponent } from '../../link/link.component'
 import { CardHeaderComponent } from '../../card/card-header/card-header.component'
 import { CardComponent } from '../../card/card.component'
-import { TextContentComponent } from '../../chipped-content/text-content/text-content.component'
-import { isNotUndefined } from '@/common/is-not-undefined'
+import { educationItemToContents } from './education-item-to-contents'
 
 @Component({
   selector: 'app-education-item',
@@ -49,26 +47,7 @@ export class EducationItemComponent {
     } else {
       this._institutionDisplayName = item.institution.name
     }
-    this._contents = [
-      item.score
-        ? new ChippedContent({
-            displayName: 'Score',
-            component: TextContentComponent,
-            inputs: {
-              text: item.score,
-            } satisfies Partial<TextContentComponent>,
-          })
-        : undefined,
-      item.courses.length > 0
-        ? new ChippedContent({
-            displayName: 'Courses',
-            component: EducationItemCoursesComponent,
-            inputs: {
-              courses: item.courses,
-            } satisfies Partial<EducationItemCoursesComponent>,
-          })
-        : undefined,
-    ].filter(isNotUndefined)
+    this._contents = educationItemToContents(item)
   }
 
   protected _item!: EducationItem

--- a/src/app/resume-page/experience-section/experience-item/__tests__/make-experience-item.ts
+++ b/src/app/resume-page/experience-section/experience-item/__tests__/make-experience-item.ts
@@ -1,0 +1,14 @@
+import { ExperienceItem } from '../experience-item'
+import { Organization } from '../../../organization'
+import { DateRange } from '../../../date-range/date-range'
+import { makeItemFactory } from '@/test/helpers/make-item-factory'
+
+export const makeExperienceItem = makeItemFactory(ExperienceItem, {
+  company: new Organization({
+    name: 'Dummy company',
+    imageSrc: 'https://fakeCompany.example.com/logo.jpg',
+  }),
+  summary: 'Dummy summary',
+  position: 'Dummy position',
+  dateRange: new DateRange(new Date('2023-01-01'), new Date('2023-10-10')),
+})

--- a/src/app/resume-page/experience-section/experience-item/experience-item-to-contents.spec.ts
+++ b/src/app/resume-page/experience-section/experience-item/experience-item-to-contents.spec.ts
@@ -30,15 +30,17 @@ describe('experienceItemToContents', () => {
       const sut = makeSut()
 
       const contents = sut(makeExperienceItem({ highlights }))
-      const highlightContents = contents.filter(
+      const highlightsContents = contents.filter(
         (content) => content.displayName === 'Highlights',
       )
-      expect(highlightContents).toHaveSize(1)
-      const highlightContent = highlightContents[0]
-      expect(highlightContent.component).toEqual(
+      expect(highlightsContents).toHaveSize(1)
+      const highlightsContent = highlightsContents[0]
+      expect(highlightsContent.component).toEqual(
         ExperienceItemHighlightsComponent,
       )
-      expect(highlightContent.inputs).toEqual({ highlights })
+      expect(highlightsContent.inputs).toEqual({
+        highlights,
+      } satisfies Partial<ExperienceItemHighlightsComponent>)
     })
   })
 })

--- a/src/app/resume-page/experience-section/experience-item/experience-item-to-contents.spec.ts
+++ b/src/app/resume-page/experience-section/experience-item/experience-item-to-contents.spec.ts
@@ -1,0 +1,46 @@
+import { TextContentComponent } from '../../chipped-content/text-content/text-content.component'
+import { experienceItemToContents } from './experience-item-to-contents'
+import { makeExperienceItem } from './__tests__/make-experience-item'
+import { ExperienceItemHighlightsComponent } from './experience-item-highlights/experience-item-highlights.component'
+
+describe('experienceItemToContents', () => {
+  describe('when summary is present', () => {
+    const summary = 'Did amazing things and rocked 100% of time'
+
+    it('should include summary content', () => {
+      const sut = makeSut()
+
+      const contents = sut(makeExperienceItem({ summary }))
+      const summaryContents = contents.filter(
+        (content) => content.displayName === 'Summary',
+      )
+      expect(summaryContents).toHaveSize(1)
+      const summaryContent = summaryContents[0]
+      expect(summaryContent.component).toEqual(TextContentComponent)
+      expect(summaryContent.inputs).toEqual({
+        text: summary,
+      } satisfies Partial<TextContentComponent>)
+    })
+  })
+
+  describe('when highlights are not empty', () => {
+    const highlights = ['Highlight 1', 'Highlight 2']
+
+    it('should include highlights content', () => {
+      const sut = makeSut()
+
+      const contents = sut(makeExperienceItem({ highlights }))
+      const highlightContents = contents.filter(
+        (content) => content.displayName === 'Highlights',
+      )
+      expect(highlightContents).toHaveSize(1)
+      const highlightContent = highlightContents[0]
+      expect(highlightContent.component).toEqual(
+        ExperienceItemHighlightsComponent,
+      )
+      expect(highlightContent.inputs).toEqual({ highlights })
+    })
+  })
+})
+
+const makeSut = () => experienceItemToContents

--- a/src/app/resume-page/experience-section/experience-item/experience-item-to-contents.ts
+++ b/src/app/resume-page/experience-section/experience-item/experience-item-to-contents.ts
@@ -15,7 +15,7 @@ export const experienceItemToContents: ExperienceItemToContents = (item) =>
           component: TextContentComponent,
           inputs: {
             text: item.summary,
-          } satisfies Partial<TextContentComponent>,
+          },
         })
       : undefined,
     item.highlights.length > 0
@@ -24,7 +24,7 @@ export const experienceItemToContents: ExperienceItemToContents = (item) =>
           component: ExperienceItemHighlightsComponent,
           inputs: {
             highlights: item.highlights,
-          } satisfies Partial<ExperienceItemHighlightsComponent>,
+          },
         })
       : undefined,
   ].filter(isNotUndefined)

--- a/src/app/resume-page/experience-section/experience-item/experience-item-to-contents.ts
+++ b/src/app/resume-page/experience-section/experience-item/experience-item-to-contents.ts
@@ -1,0 +1,30 @@
+import { ExperienceItem } from './experience-item'
+import { ChippedContent } from '../../chipped-content/chipped-content'
+import { isNotUndefined } from '@/common/is-not-undefined'
+import { TextContentComponent } from '../../chipped-content/text-content/text-content.component'
+import { ExperienceItemHighlightsComponent } from './experience-item-highlights/experience-item-highlights.component'
+
+type ExperienceItemToContents = (
+  item: ExperienceItem,
+) => ReadonlyArray<ChippedContent>
+export const experienceItemToContents: ExperienceItemToContents = (item) =>
+  [
+    item.summary
+      ? new ChippedContent({
+          displayName: 'Summary',
+          component: TextContentComponent,
+          inputs: {
+            text: item.summary,
+          } satisfies Partial<TextContentComponent>,
+        })
+      : undefined,
+    item.highlights.length > 0
+      ? new ChippedContent({
+          displayName: 'Highlights',
+          component: ExperienceItemHighlightsComponent,
+          inputs: {
+            highlights: item.highlights,
+          } satisfies Partial<ExperienceItemHighlightsComponent>,
+        })
+      : undefined,
+  ].filter(isNotUndefined)

--- a/src/app/resume-page/experience-section/experience-item/experience-item.component.html
+++ b/src/app/resume-page/experience-section/experience-item/experience-item.component.html
@@ -63,5 +63,5 @@
       </app-attribute>
     </app-card-header-attributes>
   </app-card-header>
-  <app-chipped-content [contents]="contents"></app-chipped-content>
+  <app-chipped-content [contents]="_contents"></app-chipped-content>
 </app-card>

--- a/src/app/resume-page/experience-section/experience-item/experience-item.component.spec.ts
+++ b/src/app/resume-page/experience-section/experience-item/experience-item.component.spec.ts
@@ -4,10 +4,9 @@ import { ExperienceItem } from './experience-item'
 import { NgIf, NgOptimizedImage } from '@angular/common'
 import { By } from '@angular/platform-browser'
 import { Organization } from '../../organization'
-import { DateRange } from '../../date-range/date-range'
 import { shouldContainComponent } from '@/test/helpers/component-testers'
 import { DateRangeComponent } from '../../date-range/date-range.component'
-import { MockComponents, MockProvider } from 'ng-mocks'
+import { MockComponents } from 'ng-mocks'
 import { CardComponent } from '../../card/card.component'
 import { CardHeaderImageComponent } from '../../card/card-header/card-header-image/card-header-image.component'
 import { LinkComponent } from '../../link/link.component'
@@ -24,9 +23,8 @@ import { ChipComponent } from '../../chip/chip.component'
 import { ChippedContentComponent } from '../../chipped-content/chipped-content.component'
 import { byComponent } from '@/test/helpers/component-query-predicates'
 import { componentTestSetup } from '@/test/helpers/component-test-setup'
-import { provideNoopAnimations } from '@angular/platform-browser/animations'
-import { PLATFORM_SERVICE } from '@/common/platform.service'
-import { MOCK_BROWSER_PLATFORM_SERVICE } from '@/test/helpers/platform-service'
+import { makeExperienceItem } from './__tests__/make-experience-item'
+import { ItemFactoryOverrides } from '@/test/helpers/make-item-factory'
 
 describe('ExperienceItem', () => {
   let component: ExperienceItemComponent
@@ -199,44 +197,6 @@ describe('ExperienceItem', () => {
   })
 
   shouldContainComponent(() => fixture, ChippedContentComponent)
-
-  const CONTENT_CONTAINER_PREDICATE = byComponent(ChippedContentComponent)
-
-  describe('when experience has summary', () => {
-    const summary = 'sample summary'
-    beforeEach(() => {
-      setExperienceItem(fixture, { summary })
-    })
-
-    it('should render it', () => {
-      const contentContainerElement = fixture.debugElement.query(
-        CONTENT_CONTAINER_PREDICATE,
-      )
-
-      expect(
-        contentContainerElement.nativeElement.textContent.trim(),
-      ).toContain(summary)
-    })
-  })
-
-  describe('when experience has highlights', () => {
-    const highlights = ['Sample highlight 1', 'Sample highlight 2']
-    beforeEach(() => {
-      setExperienceItem(fixture, { highlights })
-    })
-
-    it('should render them', () => {
-      const contentContainerElement = fixture.debugElement.query(
-        CONTENT_CONTAINER_PREDICATE,
-      )
-
-      highlights.forEach((highlight) => {
-        expect(
-          contentContainerElement.nativeElement.textContent.trim(),
-        ).toContain(highlight)
-      })
-    })
-  })
 })
 function makeSut() {
   return componentTestSetup(ExperienceItemComponent, {
@@ -258,30 +218,16 @@ function makeSut() {
         CardHeaderAttributesComponent,
         AttributeComponent,
         ChipComponent,
+        ChippedContentComponent,
       ),
-    ],
-    providers: [
-      provideNoopAnimations(), // to mount real chipped content component
-      MockProvider(PLATFORM_SERVICE, MOCK_BROWSER_PLATFORM_SERVICE),
     ],
   })
 }
 
 function setExperienceItem(
   fixture: ComponentFixture<ExperienceItemComponent>,
-  newItemArgOverrides?: Partial<
-    ConstructorParameters<typeof ExperienceItem>[0]
-  >,
+  overrides?: ItemFactoryOverrides<typeof ExperienceItem>,
 ) {
-  fixture.componentInstance.item = new ExperienceItem({
-    company: new Organization({
-      name: 'Dummy company',
-      imageSrc: 'https://fakeCompany.example.com/logo.jpg',
-    }),
-    summary: 'Dummy summary',
-    position: 'Dummy position',
-    dateRange: new DateRange(new Date('2023-01-01'), new Date('2023-10-10')),
-    ...newItemArgOverrides,
-  })
+  fixture.componentInstance.item = makeExperienceItem(overrides)
   fixture.detectChanges()
 }

--- a/src/app/resume-page/experience-section/experience-item/experience-item.component.spec.ts
+++ b/src/app/resume-page/experience-section/experience-item/experience-item.component.spec.ts
@@ -1,7 +1,7 @@
 import { ComponentFixture } from '@angular/core/testing'
 import { Attribute, ExperienceItemComponent } from './experience-item.component'
 import { ExperienceItem } from './experience-item'
-import { NgIf, NgOptimizedImage } from '@angular/common'
+import { NgIf } from '@angular/common'
 import { By } from '@angular/platform-browser'
 import { Organization } from '../../organization'
 import { shouldContainComponent } from '@/test/helpers/component-testers'
@@ -9,22 +9,20 @@ import { DateRangeComponent } from '../../date-range/date-range.component'
 import { MockComponents } from 'ng-mocks'
 import { CardComponent } from '../../card/card.component'
 import { CardHeaderImageComponent } from '../../card/card-header/card-header-image/card-header-image.component'
-import { LinkComponent } from '../../link/link.component'
 import { CardHeaderTitleComponent } from '../../card/card-header/card-header-title/card-header-title.component'
 import { CardHeaderSubtitleComponent } from '../../card/card-header/card-header-subtitle/card-header-subtitle.component'
 import { CardHeaderDetailComponent } from '../../card/card-header/card-header-detail/card-header-detail.component'
 import { byTestId } from '@/test/helpers/test-id'
-import { TestIdDirective } from '@/common/test-id.directive'
 import { CardHeaderComponent } from '../../card/card-header/card-header.component'
 import { CardHeaderTextsComponent } from '../../card/card-header/card-header-texts/card-header-texts.component'
 import { CardHeaderAttributesComponent } from '../../card/card-header/card-header-attributes/card-header-attributes.component'
 import { AttributeComponent } from '../../attribute/attribute.component'
-import { ChipComponent } from '../../chip/chip.component'
 import { ChippedContentComponent } from '../../chipped-content/chipped-content.component'
 import { byComponent } from '@/test/helpers/component-query-predicates'
 import { componentTestSetup } from '@/test/helpers/component-test-setup'
 import { makeExperienceItem } from './__tests__/make-experience-item'
 import { ItemFactoryOverrides } from '@/test/helpers/make-item-factory'
+import { getReflectedAttribute } from '@/test/helpers/get-reflected-attribute'
 
 describe('ExperienceItem', () => {
   let component: ExperienceItemComponent
@@ -59,9 +57,11 @@ describe('ExperienceItem', () => {
       expect(anchorElement).toBeTruthy()
       expect(anchorElement.attributes['href']).toEqual(website)
 
-      const imageElement = anchorElement.query(By.css('img'))
+      const imageElement = anchorElement.query(
+        byComponent(CardHeaderImageComponent),
+      )
       expect(imageElement).toBeTruthy()
-      expect(imageElement.attributes['src']).toEqual(imageUrl)
+      expect(getReflectedAttribute(imageElement, 'src')).toEqual(imageUrl)
     })
 
     it("should display company name with link to company's website", () => {
@@ -203,21 +203,17 @@ function makeSut() {
     imports: [
       ExperienceItemComponent,
       NgIf,
-      NgOptimizedImage,
-      LinkComponent,
-      CardHeaderImageComponent,
-      CardHeaderTitleComponent,
-      CardHeaderSubtitleComponent,
-      TestIdDirective,
       MockComponents(
         CardComponent,
         DateRangeComponent,
+        CardHeaderImageComponent,
+        CardHeaderTitleComponent,
+        CardHeaderSubtitleComponent,
         CardHeaderDetailComponent,
         CardHeaderComponent,
         CardHeaderTextsComponent,
         CardHeaderAttributesComponent,
         AttributeComponent,
-        ChipComponent,
         ChippedContentComponent,
       ),
     ],

--- a/src/app/resume-page/experience-section/experience-item/experience-item.component.ts
+++ b/src/app/resume-page/experience-section/experience-item/experience-item.component.ts
@@ -7,7 +7,6 @@ import {
   ToolsLadder,
   Work,
 } from '../../../material-symbols'
-import { ExperienceItemHighlightsComponent } from './experience-item-highlights/experience-item-highlights.component'
 import { ChippedContentComponent } from '../../chipped-content/chipped-content.component'
 import { AttributeComponent } from '../../attribute/attribute.component'
 import { NgIf } from '@angular/common'
@@ -23,8 +22,7 @@ import { LinkComponent } from '../../link/link.component'
 import { CardHeaderComponent } from '../../card/card-header/card-header.component'
 import { CardComponent } from '../../card/card.component'
 import { ChippedContent } from '../../chipped-content/chipped-content'
-import { isNotUndefined } from '@/common/is-not-undefined'
-import { TextContentComponent } from '../../chipped-content/text-content/text-content.component'
+import { experienceItemToContents } from './experience-item-to-contents'
 
 @Component({
   selector: 'app-experience-item',
@@ -50,30 +48,11 @@ import { TextContentComponent } from '../../chipped-content/text-content/text-co
 export class ExperienceItemComponent {
   @Input({ required: true }) public set item(item: ExperienceItem) {
     this._item = item
-    this.contents = [
-      this._item.summary
-        ? new ChippedContent({
-            displayName: 'Summary',
-            component: TextContentComponent,
-            inputs: {
-              text: this._item.summary,
-            } satisfies Partial<TextContentComponent>,
-          })
-        : undefined,
-      this._item.highlights.length > 0
-        ? new ChippedContent({
-            displayName: 'Highlights',
-            component: ExperienceItemHighlightsComponent,
-            inputs: {
-              highlights: this._item.highlights,
-            } satisfies Partial<ExperienceItemHighlightsComponent>,
-          })
-        : undefined,
-    ].filter(isNotUndefined)
+    this._contents = experienceItemToContents(item)
   }
 
   protected _item!: ExperienceItem
-  public contents: ChippedContent[] = []
+  protected _contents: ReadonlyArray<ChippedContent> = []
   protected readonly MaterialSymbol = {
     Badge,
     Work,

--- a/src/app/resume-page/projects-section/project-item/__tests__/make-project-item.ts
+++ b/src/app/resume-page/projects-section/project-item/__tests__/make-project-item.ts
@@ -1,0 +1,9 @@
+import { ProjectItem } from '../project-item'
+import { DateRange } from '../../../date-range/date-range'
+import { makeItemFactory } from '@/test/helpers/make-item-factory'
+
+export const makeProjectItem = makeItemFactory(ProjectItem, {
+  name: 'Sample project item',
+  description: 'Project item',
+  dateRange: new DateRange(new Date('2022-01-01'), new Date('2022-12-31')),
+})

--- a/src/app/resume-page/projects-section/project-item/project-item-to-contents.spec.ts
+++ b/src/app/resume-page/projects-section/project-item/project-item-to-contents.spec.ts
@@ -1,0 +1,52 @@
+import { TextContentComponent } from '../../chipped-content/text-content/text-content.component'
+import { makeProjectItem } from './__tests__/make-project-item'
+import { projectItemToContents } from './project-item-to-contents'
+import { Technology } from './project-item'
+import { ProjectItemTechnologiesComponent } from './project-item-technologies/project-item-technologies.component'
+
+describe('projectItemToContents', () => {
+  describe('when description is present', () => {
+    const description = 'Very cool thing and does awesome things'
+
+    it('should include description content', () => {
+      const sut = makeSut()
+
+      const contents = sut(makeProjectItem({ description }))
+      const descriptionContents = contents.filter(
+        (content) => content.displayName === 'Description',
+      )
+      expect(descriptionContents).toHaveSize(1)
+      const descriptionContent = descriptionContents[0]
+      expect(descriptionContent.component).toEqual(TextContentComponent)
+      expect(descriptionContent.inputs).toEqual({
+        text: description,
+      } satisfies Partial<TextContentComponent>)
+    })
+  })
+
+  describe('when technologies are not empty', () => {
+    const technologies = [
+      { id: 'super-cool-tech' },
+      { id: 'another-super-cool-tech' },
+    ] satisfies ReadonlyArray<Technology>
+
+    it('should include technologies content', () => {
+      const sut = makeSut()
+
+      const contents = sut(makeProjectItem({ technologies }))
+      const technologiesContents = contents.filter(
+        (content) => content.displayName === 'Tech',
+      )
+      expect(technologiesContents).toHaveSize(1)
+      const technologiesContent = technologiesContents[0]
+      expect(technologiesContent.component).toEqual(
+        ProjectItemTechnologiesComponent,
+      )
+      expect(technologiesContent.inputs).toEqual({
+        technologies,
+      } satisfies Partial<ProjectItemTechnologiesComponent>)
+    })
+  })
+})
+
+const makeSut = () => projectItemToContents

--- a/src/app/resume-page/projects-section/project-item/project-item-to-contents.ts
+++ b/src/app/resume-page/projects-section/project-item/project-item-to-contents.ts
@@ -15,7 +15,7 @@ export const projectItemToContents: ProjectItemToContents = (item) =>
           component: TextContentComponent,
           inputs: {
             text: item.description,
-          } satisfies Partial<TextContentComponent>,
+          },
         })
       : undefined,
     item.technologies.length > 0
@@ -24,7 +24,7 @@ export const projectItemToContents: ProjectItemToContents = (item) =>
           component: ProjectItemTechnologiesComponent,
           inputs: {
             technologies: item.technologies,
-          } satisfies Partial<ProjectItemTechnologiesComponent>,
+          },
         })
       : undefined,
   ].filter(isNotUndefined)

--- a/src/app/resume-page/projects-section/project-item/project-item-to-contents.ts
+++ b/src/app/resume-page/projects-section/project-item/project-item-to-contents.ts
@@ -1,0 +1,30 @@
+import { ChippedContent } from '../../chipped-content/chipped-content'
+import { ProjectItem } from './project-item'
+import { TextContentComponent } from '../../chipped-content/text-content/text-content.component'
+import { ProjectItemTechnologiesComponent } from './project-item-technologies/project-item-technologies.component'
+import { isNotUndefined } from '@/common/is-not-undefined'
+
+type ProjectItemToContents = (
+  item: ProjectItem,
+) => ReadonlyArray<ChippedContent>
+export const projectItemToContents: ProjectItemToContents = (item) =>
+  [
+    item.description
+      ? new ChippedContent({
+          displayName: 'Description',
+          component: TextContentComponent,
+          inputs: {
+            text: item.description,
+          } satisfies Partial<TextContentComponent>,
+        })
+      : undefined,
+    item.technologies.length > 0
+      ? new ChippedContent({
+          displayName: 'Tech',
+          component: ProjectItemTechnologiesComponent,
+          inputs: {
+            technologies: item.technologies,
+          } satisfies Partial<ProjectItemTechnologiesComponent>,
+        })
+      : undefined,
+  ].filter(isNotUndefined)

--- a/src/app/resume-page/projects-section/project-item/project-item.component.html
+++ b/src/app/resume-page/projects-section/project-item/project-item.component.html
@@ -34,5 +34,5 @@
       </app-attribute>
     </app-card-header-attributes>
   </app-card-header>
-  <app-chipped-content [contents]="contents"></app-chipped-content>
+  <app-chipped-content [contents]="_contents"></app-chipped-content>
 </app-card>

--- a/src/app/resume-page/projects-section/project-item/project-item.component.spec.ts
+++ b/src/app/resume-page/projects-section/project-item/project-item.component.spec.ts
@@ -16,17 +16,14 @@ import { CardHeaderTextsComponent } from '../../card/card-header/card-header-tex
 import { CardHeaderTitleComponent } from '../../card/card-header/card-header-title/card-header-title.component'
 import { CardHeaderSubtitleComponent } from '../../card/card-header/card-header-subtitle/card-header-subtitle.component'
 import { CardHeaderDetailComponent } from '../../card/card-header/card-header-detail/card-header-detail.component'
-import { LinkComponent } from '../../link/link.component'
 import { DateRangeComponent } from '../../date-range/date-range.component'
 import { byTestId } from '@/test/helpers/test-id'
 import { By } from '@angular/platform-browser'
-import { TestIdDirective } from '@/common/test-id.directive'
 import { DateRange } from '../../date-range/date-range'
 import { CardHeaderAttributesComponent } from '../../card/card-header/card-header-attributes/card-header-attributes.component'
 import { AttributeComponent } from '../../attribute/attribute.component'
 import { ChippedContentComponent } from '../../chipped-content/chipped-content.component'
 import { NgIf } from '@angular/common'
-import { ProjectItemTechnologiesComponent } from './project-item-technologies/project-item-technologies.component'
 import { componentTestSetup } from '@/test/helpers/component-test-setup'
 import { makeProjectItem } from './__tests__/make-project-item'
 import { ItemFactoryOverrides } from '@/test/helpers/make-item-factory'
@@ -165,8 +162,6 @@ function makeSut() {
     imports: [
       ProjectItemComponent,
       NgIf,
-      LinkComponent,
-      TestIdDirective,
       MockComponents(
         CardComponent,
         CardHeaderComponent,
@@ -178,7 +173,6 @@ function makeSut() {
         DateRangeComponent,
         CardHeaderAttributesComponent,
         AttributeComponent,
-        ProjectItemTechnologiesComponent,
         ChippedContentComponent,
       ),
     ],

--- a/src/app/resume-page/projects-section/project-item/project-item.component.spec.ts
+++ b/src/app/resume-page/projects-section/project-item/project-item.component.spec.ts
@@ -5,13 +5,13 @@ import {
   ProjectItemComponent,
   StackContent,
 } from './project-item.component'
-import { MockComponents, MockProvider } from 'ng-mocks'
+import { MockComponents } from 'ng-mocks'
 import { CardComponent } from '../../card/card.component'
 import { CardHeaderImageComponent } from '../../card/card-header/card-header-image/card-header-image.component'
 import { CardHeaderComponent } from '../../card/card-header/card-header.component'
 import { byComponent } from '@/test/helpers/component-query-predicates'
 import { getReflectedAttribute } from '@/test/helpers/get-reflected-attribute'
-import { ProjectItem, Stack, Technology } from './project-item'
+import { ProjectItem, Stack } from './project-item'
 import { CardHeaderTextsComponent } from '../../card/card-header/card-header-texts/card-header-texts.component'
 import { CardHeaderTitleComponent } from '../../card/card-header/card-header-title/card-header-title.component'
 import { CardHeaderSubtitleComponent } from '../../card/card-header/card-header-subtitle/card-header-subtitle.component'
@@ -28,9 +28,9 @@ import { ChippedContentComponent } from '../../chipped-content/chipped-content.c
 import { NgIf } from '@angular/common'
 import { ProjectItemTechnologiesComponent } from './project-item-technologies/project-item-technologies.component'
 import { componentTestSetup } from '@/test/helpers/component-test-setup'
-import { provideNoopAnimations } from '@angular/platform-browser/animations'
-import { PLATFORM_SERVICE } from '@/common/platform.service'
-import { MOCK_BROWSER_PLATFORM_SERVICE } from '@/test/helpers/platform-service'
+import { makeProjectItem } from './__tests__/make-project-item'
+import { ItemFactoryOverrides } from '@/test/helpers/make-item-factory'
+import { shouldContainComponent } from '@/test/helpers/component-testers'
 
 describe('ProjectItemComponent', () => {
   let component: ProjectItemComponent
@@ -157,35 +157,7 @@ describe('ProjectItemComponent', () => {
     })
   })
 
-  it('should render description content', () => {
-    const description = 'It is super cool and does awesome things'
-    setProjectItem(fixture, { description })
-
-    const contentContainer = fixture.debugElement.query(
-      byComponent(ChippedContentComponent),
-    )
-    expect(contentContainer).toBeTruthy()
-    expect(contentContainer.nativeElement.textContent.trim()).toContain(
-      description,
-    )
-  })
-
-  it('should render techs', () => {
-    const technologies = [
-      { id: 'tech-1', version: 'version-1' },
-      { id: 'tech-2', version: 'version-2' },
-    ] satisfies ReadonlyArray<Technology>
-
-    setProjectItem(fixture, { technologies })
-
-    const techContent = component.contents.find(
-      (content) => content.component === ProjectItemTechnologiesComponent,
-    )
-    expect(techContent).toBeTruthy()
-    expect(techContent!.inputs).toEqual({
-      technologies,
-    } satisfies Partial<ProjectItemTechnologiesComponent>)
-  })
+  shouldContainComponent(() => fixture, ChippedContentComponent)
 })
 
 function makeSut() {
@@ -207,26 +179,16 @@ function makeSut() {
         CardHeaderAttributesComponent,
         AttributeComponent,
         ProjectItemTechnologiesComponent,
+        ChippedContentComponent,
       ),
-    ],
-    providers: [
-      provideNoopAnimations(), // to use real chipped content component
-      MockProvider(PLATFORM_SERVICE, MOCK_BROWSER_PLATFORM_SERVICE),
     ],
   })
 }
 
 function setProjectItem(
   fixture: ComponentFixture<ProjectItemComponent>,
-  overrides: Partial<ConstructorParameters<typeof ProjectItem>[0]> = {},
+  overrides?: ItemFactoryOverrides<typeof ProjectItem>,
 ) {
-  fixture.componentInstance.item = new ProjectItem({
-    ...{
-      name: 'Sample project item',
-      description: 'Project item',
-      dateRange: new DateRange(new Date('2022-01-01'), new Date('2022-12-31')),
-    },
-    ...overrides,
-  })
+  fixture.componentInstance.item = makeProjectItem(overrides)
   fixture.detectChanges()
 }

--- a/src/app/resume-page/projects-section/project-item/project-item.component.ts
+++ b/src/app/resume-page/projects-section/project-item/project-item.component.ts
@@ -16,9 +16,7 @@ import { LinkComponent } from '../../link/link.component'
 import { NgIf } from '@angular/common'
 import { CardHeaderComponent } from '../../card/card-header/card-header.component'
 import { CardComponent } from '../../card/card.component'
-import { ProjectItemTechnologiesComponent } from './project-item-technologies/project-item-technologies.component'
-import { isNotUndefined } from '@/common/is-not-undefined'
-import { TextContentComponent } from '../../chipped-content/text-content/text-content.component'
+import { projectItemToContents } from './project-item-to-contents'
 
 @Component({
   selector: 'app-project-item',
@@ -44,33 +42,11 @@ import { TextContentComponent } from '../../chipped-content/text-content/text-co
 export class ProjectItemComponent {
   @Input({ required: true }) public set item(item: ProjectItem) {
     this._item = item
-    this.contents = [
-      item.description
-        ? new ChippedContent({
-            displayName: 'Description',
-            component: TextContentComponent,
-            inputs: {
-              text: item.description,
-            } satisfies Partial<TextContentComponent>,
-          })
-        : undefined,
-      item.technologies.length > 0
-        ? new ChippedContent({
-            displayName: 'Tech',
-            component: ProjectItemTechnologiesComponent,
-            inputs: {
-              technologies: item.technologies,
-            } satisfies Partial<ProjectItemTechnologiesComponent>,
-          })
-        : undefined,
-    ].filter(isNotUndefined)
+    this._contents = projectItemToContents(item)
   }
 
   protected _item!: ProjectItem
-  /**
-   * @visibleForTesting
-   */
-  public contents: ReadonlyArray<ChippedContent> = []
+  protected _contents: ReadonlyArray<ChippedContent> = []
 
   protected readonly StackContent = StackContent
   protected readonly Attribute = Attribute

--- a/src/test/helpers/make-item-factory.ts
+++ b/src/test/helpers/make-item-factory.ts
@@ -1,0 +1,14 @@
+import { Item } from '@/common/item'
+
+export const makeItemFactory =
+  <T, NewObjArg extends object>(
+    klass: Item<T, NewObjArg>,
+    baseArgs: NewObjArg,
+  ) =>
+  (overrides?: Partial<NewObjArg>) =>
+    new klass({ ...baseArgs, ...overrides })
+
+export type ItemFactoryOverrides<
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  T extends abstract new (args: any) => unknown,
+> = Partial<ConstructorParameters<T>[0]>

--- a/src/test/helpers/platform-service.ts
+++ b/src/test/helpers/platform-service.ts
@@ -1,20 +1,5 @@
 import { PlatformService } from '@/common/platform.service'
 
-function makeMockPlatformService({
-  isBrowser,
-}: {
-  isBrowser: boolean
-}): PlatformService {
-  return {
-    isBrowser,
-    isServer: !isBrowser,
-  }
-}
+export const MOCK_SERVER_PLATFORM_SERVICE = new PlatformService(false)
 
-export const MOCK_SERVER_PLATFORM_SERVICE = makeMockPlatformService({
-  isBrowser: false,
-})
-
-export const MOCK_BROWSER_PLATFORM_SERVICE = makeMockPlatformService({
-  isBrowser: true,
-})
+export const MOCK_BROWSER_PLATFORM_SERVICE = new PlatformService(true)

--- a/src/test/helpers/service-test-setup.ts
+++ b/src/test/helpers/service-test-setup.ts
@@ -1,5 +1,5 @@
 import { TestBed } from '@angular/core/testing'
-import { Type } from '@angular/core'
+import { InjectionToken, Type } from '@angular/core'
 
 /**
  * Sets up a basic service test given the service to test
@@ -13,7 +13,7 @@ import { Type } from '@angular/core'
  * ```
  */
 export function serviceTestSetup<T>(
-  service: Type<T>,
+  service: Type<T> | InjectionToken<T>,
   moduleDef: Parameters<TestBed['configureTestingModule']>[0] = {},
 ): T {
   TestBed.configureTestingModule(moduleDef)

--- a/src/test/helpers/visibility.ts
+++ b/src/test/helpers/visibility.ts
@@ -1,7 +1,4 @@
 // TODO: those could be custom matchers
-export function expectIsVisible(element: Element) {
-  expectVisibility(element, true)
-}
 export function expectIsHidden(element: Element) {
   expectVisibility(element, false)
 }
@@ -42,22 +39,9 @@ function expectVisibility(element: Element, visible: boolean) {
 }
 
 export function expectIsInLayout(element: Element) {
-  const { height, width, x, y } = element.getBoundingClientRect()
-  expect({ height, width, x, y })
-    .withContext('is in layout')
-    .not.toEqual(NOT_RENDERED_BOUNDING_BOX)
+  expect(element.checkVisibility()).withContext('is in layout').toBeTrue()
 }
 
 export function expectIsNotInLayout(element: Element) {
-  const { height, width, x, y } = element.getBoundingClientRect()
-  expect({ height, width, x, y })
-    .withContext('is not in layout')
-    .toEqual(NOT_RENDERED_BOUNDING_BOX)
+  expect(element.checkVisibility()).withContext('is not in layout').toBeFalse()
 }
-
-const NOT_RENDERED_BOUNDING_BOX = {
-  height: 0,
-  width: 0,
-  x: 0,
-  y: 0,
-} satisfies Partial<DOMRect>


### PR DESCRIPTION
Dream of having same page with same code working with JavaScript enabled or disabled ends with this PR

The trade-off we're doing here is performance. And the main issue right now is number of DOM nodes is huge.

Why? Because of chipped content component. It renders all contents so that when JavaScript is disabled, they're shown all at once. Noice!

However, clients (browsers) with JavaScript enabled (most) will get loooots of DOM nodes that won't be visible. Hence impacting performance

In order to move forward, setting aside the fully functional without JavaScript feature. Starting with chipped content component. 

> It can be introduced later with a separate layout. This will also simplify things. As for now, any component testing was getting hard as apart from regular behaviour with JS on, the axis of no JS was also there introducing complexity. 
>
> A raw idea could be a `<meta refresh>` inside `<noscript>` in `<head>` that takes the user to a non-JS compatible version of the site. For instance `resume` to `/nojs/resume`. Could do also via query params `?js=disabled` but that would require either a routes file to take into account for prerendering or deploy the server somewhere. 
>
> Performance will be improved too for non JS version. As we can simplify UI for this specific case.
>
> Indeed we could export same component interface and 2 implementations. One for non JS and one for JS enabled. So we can reuse general layout and use different low-level/ atom components for different versions.

Also here:
 - Simplify `PlatformService` code. Use root injector when defining token to avoid manual (can be missed) injection.
 - Improve visibility testers by using `checkVisibility` instead of getting associated box of elements
 - Add util to generate item factories
 - Extract function to scroll into view. This way the function already will do nothing on server (and we don't have to do that every time)
 - Split content generation into separate function. Test that one.