### PR TITLE
perf: test resume page with Lighthouse

### DIFF
--- a/.lighthouserc.yaml
+++ b/.lighthouserc.yaml
@@ -2,7 +2,7 @@ ci:
   upload:
     target: temporary-public-storage
     url:
-      - 'http://localhost/'
+      - 'http://localhost/resume'
   collect:
     staticDistDir: dist/@davidlj95/website/browser
   assert:


### PR DESCRIPTION
Fixes recent failures for Lighthouse

It was complaining about LCP for main image.

```text
  ✘  prioritize-lcp-image failure for minScore assertion
       Preload Largest Contentful Paint image
       https://web.dev/optimize-lcp/#optimize-when-the-resource-is-discovered

        expected: >=0.9
           found: 0.87
      all values: 0.87, 0.87, 0.87
```

https://github.com/davidlj95/website/actions/runs/8928153795/job/24523099864?pr=426

 Despite that image having properly set the `fetchpriority` to `high` and `loading` eager with `NgOptimizedImage`

After trying to set the `fetchpriority` to `low` for the alternative, easter-egg picture, kept failing.

Then found out that Lighthouse was actually testing `/` so is taking into account the redirection into the load time. Which makes sense. But given at some point that will disappear, removing it to ensure resume page is OK without taking into account temporary redirection.
