### PR TITLE
ci(build): invalidate Angular cache every week

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -35,13 +35,17 @@ jobs:
           lfs: true
       - name: Setup
         uses: ./.github/actions/setup
+      - name: Generate info for Angular cache key
+        run: echo "week-of-year=$(date --utc '+%V')" >> $GITHUB_ENV
       - name: Cache Angular build
         uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4
         env:
           cache-name: angular-cache
         with:
           path: .angular/cache
-          key: ${{ env.cache-name }}-${{ inputs.ref != '' && inputs.ref || github.ref }}
+          # 👇 Update cache once a week. Best effort approach
+          #    Otherwise it would never be invalidated
+          key: ${{ env.cache-name }}-${{ env.week-of-year }}
           restore-keys: |
             ${{ env.cache-name }}
       - name: Prebuild tasks


### PR DESCRIPTION
Otherwise, it is never invalidated. For instance, cache `main` branch has been there for ages since `github.ref` is always `refs/heads/main`. And if key doesn't change, cache is not updated after the workflow ends successfully. PRs grab that cache when being opened for first time, so it propagates the issue there too. However a new cache will be created for the PR scope, so at least next runs of the PR will use a proper cache.

Removing ref from cache key. This is indirectly done for security purposes by the action itself.  
