### PR TITLE
perf: reduce release info for now

### DIFF
--- a/scripts/src/generate-release-file.mts
+++ b/scripts/src/generate-release-file.mts
@@ -271,8 +271,10 @@ type FakeResultObject = ResultObject & { fake: true }
 const RELEASE_FILE = join(getRepositoryRootDir(), 'release.json')
 
 async function writeToReleaseFile(result: object) {
+  const { nextRelease, fake, preview } = result as FakeResultObject &
+    PreviewResultObject
   Log.info("Writing to file '%s'", RELEASE_FILE)
-  writeFileSync(RELEASE_FILE, objectToJson(result))
+  writeFileSync(RELEASE_FILE, objectToJson({ nextRelease, fake, preview }))
 }
 
 if (isMain(import.meta.url)) {

--- a/src/app/common/injection-tokens.ts
+++ b/src/app/common/injection-tokens.ts
@@ -1,11 +1,6 @@
 import { InjectionToken } from '@angular/core'
-import RELEASE_OBJECT from '../../../release.json'
 import { environment, Environment } from '../../environments'
 import { METADATA as METADATA_OBJECT, Metadata } from '../metadata'
-import {
-  ReleaseInfo,
-  ReleaseInfoSummary,
-} from '../release-info/semantic-release'
 
 /* istanbul ignore next */
 export const ENVIRONMENT = new InjectionToken<Environment>(
@@ -21,18 +16,3 @@ export const METADATA = new InjectionToken<Metadata>('Metadata object', {
 export const WINDOW = new InjectionToken<Window>('Global window object', {
   factory: () => window,
 })
-export const RELEASE = new InjectionToken<ReleaseInfoSummary>(
-  'Release object',
-  {
-    // Have to manually cast as strings are not checked against the union type
-    // https://github.com/microsoft/TypeScript/issues/26552
-    // Adding just picked properties because full object may increase a lot the bundle size.
-    // Also, if we want to generate this file on older commits, like tagged ones, this may need to be mocked
-    factory: () =>
-      ({
-        nextRelease: RELEASE_OBJECT.nextRelease,
-        fake: (RELEASE_OBJECT as ReleaseInfo).fake,
-        preview: (RELEASE_OBJECT as ReleaseInfo).preview,
-      }) as ReleaseInfoSummary,
-  },
-)

--- a/src/app/release-info/release-info.component.html
+++ b/src/app/release-info/release-info.component.html
@@ -1,1 +1,1 @@
-<pre>{{ releaseAsJsonString }}</pre>
+<pre>{{ _jsonString }}</pre>

--- a/src/app/release-info/release-info.component.ts
+++ b/src/app/release-info/release-info.component.ts
@@ -1,5 +1,5 @@
-import { Component, Inject } from '@angular/core'
-import { RELEASE } from '@/common/injection-tokens'
+import { Component } from '@angular/core'
+import RELEASE_JSON from '../../../release.json'
 import { ReleaseInfoSummary } from './semantic-release'
 
 @Component({
@@ -9,16 +9,10 @@ import { ReleaseInfoSummary } from './semantic-release'
   standalone: true,
 })
 export class ReleaseInfoComponent {
-  constructor(@Inject(RELEASE) private release: ReleaseInfoSummary) {}
-
-  protected get releaseAsJsonString() {
-    const nextRelease = this.release.nextRelease
-    const summary = {
-      ...nextRelease,
-      notes: undefined,
-      preview: this.release.preview,
-      fake: this.release.fake,
-    }
-    return JSON.stringify(summary, null, 2)
-  }
+  protected _jsonString = JSON.stringify({
+    ...RELEASE_JSON.nextRelease,
+    notes: undefined,
+    preview: (RELEASE_JSON as ReleaseInfoSummary).preview,
+    fake: (RELEASE_JSON as ReleaseInfoSummary).fake,
+  })
 }


### PR DESCRIPTION
Was taking from 2kB to 80kBs depending on release info size

Moves injection token to the feature directory
