### PR TITLE
refactor: env canonical URL to app base URL

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -14,7 +14,7 @@ export const routes: Routes = [
   //   },
   //   name: METADATA.siteName,
   //   headline: METADATA.description,
-  //   url: environment.canonicalUrl.toString(),
+  //   url: environment.appBaseUrl.toString(),
   // },
   ...resumePageRoutes,
   ...notFoundPageRoutes,

--- a/src/app/common/app-base-url.ts
+++ b/src/app/common/app-base-url.ts
@@ -1,0 +1,10 @@
+import { InjectionToken } from '@angular/core'
+import { isDevMode } from '@/common/is-dev-mode'
+import { environment } from '../../environments'
+
+export const APP_BASE_URL = new InjectionToken<URL>(
+  isDevMode ? 'App base URL' : 'ABU',
+  {
+    factory: () => environment.appBaseUrl,
+  },
+)

--- a/src/app/common/injection-tokens.ts
+++ b/src/app/common/injection-tokens.ts
@@ -1,18 +1,17 @@
 import { InjectionToken } from '@angular/core'
-import { environment, Environment } from '../../environments'
 import { METADATA as METADATA_OBJECT, Metadata } from '../metadata'
+import { isDevMode } from '@/common/is-dev-mode'
 
 /* istanbul ignore next */
-export const ENVIRONMENT = new InjectionToken<Environment>(
-  'Environment config',
+export const METADATA = new InjectionToken<Metadata>(
+  isDevMode ? 'Metadata object' : 'Mo',
   {
-    factory: () => environment,
+    factory: () => METADATA_OBJECT,
   },
 )
-/* istanbul ignore next */
-export const METADATA = new InjectionToken<Metadata>('Metadata object', {
-  factory: () => METADATA_OBJECT,
-})
-export const WINDOW = new InjectionToken<Window>('Global window object', {
-  factory: () => window,
-})
+export const WINDOW = new InjectionToken<Window>(
+  isDevMode ? 'Global window object' : 'Gwo',
+  {
+    factory: () => window,
+  },
+)

--- a/src/app/not-found-page/not-found-page.component.spec.ts
+++ b/src/app/not-found-page/not-found-page.component.spec.ts
@@ -1,34 +1,29 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing'
+import { ComponentFixture } from '@angular/core/testing'
 
 import {
   NotFoundPageComponent,
   WAYBACK_MACHINE_URL_PREFIX,
 } from './not-found-page.component'
-import { Environment } from '../../environments'
 import { Router } from '@angular/router'
 import { MockProvider } from 'ng-mocks'
-import { ENVIRONMENT } from '@/common/injection-tokens'
+import { APP_BASE_URL } from '@/common/app-base-url'
+import { componentTestSetup } from '@/test/helpers/component-test-setup'
 
 describe('NotFoundPageComponent', () => {
   let component: NotFoundPageComponent
   let fixture: ComponentFixture<NotFoundPageComponent>
-  const fakeEnvUrlNoTrailingSlash: string = 'https://example.com'
-  const fakeEnv: Pick<Environment, 'canonicalUrl'> = {
-    canonicalUrl: new URL(fakeEnvUrlNoTrailingSlash),
-  }
-  const fakeRouter: Pick<Router, 'url'> = {
+  const dummyAppUrlNoTrailingSlash: string = 'https://example.com'
+  const dummyRouter: Pick<Router, 'url'> = {
     url: '/foo',
   }
 
   beforeEach(() => {
-    TestBed.configureTestingModule({
+    ;[fixture, component] = componentTestSetup(NotFoundPageComponent, {
       providers: [
-        MockProvider(ENVIRONMENT, fakeEnv),
-        MockProvider(Router, fakeRouter),
+        MockProvider(APP_BASE_URL, new URL(dummyAppUrlNoTrailingSlash)),
+        MockProvider(Router, dummyRouter),
       ],
     })
-    fixture = TestBed.createComponent(NotFoundPageComponent)
-    component = fixture.componentInstance
     fixture.detectChanges()
   })
 
@@ -41,8 +36,8 @@ describe('NotFoundPageComponent', () => {
       expect(component.currentUrlInWaybackMachine).toEqual(
         new URL(
           WAYBACK_MACHINE_URL_PREFIX.toString() +
-            fakeEnvUrlNoTrailingSlash +
-            fakeRouter.url,
+            dummyAppUrlNoTrailingSlash +
+            dummyRouter.url,
         ),
       )
     })

--- a/src/app/not-found-page/not-found-page.component.ts
+++ b/src/app/not-found-page/not-found-page.component.ts
@@ -1,9 +1,8 @@
 import { Component, Inject } from '@angular/core'
 import { Lightbulb } from '../material-symbols'
 import { Router } from '@angular/router'
-import { Environment } from '../../environments'
-import { ENVIRONMENT } from '@/common/injection-tokens'
 import { MaterialSymbolDirective } from '@/common/material-symbol.directive'
+import { APP_BASE_URL } from '@/common/app-base-url'
 
 @Component({
   selector: 'app-not-found-page',
@@ -18,8 +17,8 @@ export class NotFoundPageComponent {
     Lightbulb,
   }
 
-  constructor(@Inject(ENVIRONMENT) environment: Environment, router: Router) {
-    const currentUrl = new URL(router.url, environment.canonicalUrl)
+  constructor(@Inject(APP_BASE_URL) appBaseUrl: URL, router: Router) {
+    const currentUrl = new URL(router.url, appBaseUrl)
     this.currentUrlInWaybackMachine = new URL(
       `${WAYBACK_MACHINE_URL_PREFIX}${currentUrl}`,
     )

--- a/src/app/resume-page/routes.ts
+++ b/src/app/resume-page/routes.ts
@@ -12,10 +12,10 @@ export const routes: Routes = [
     data: {
       meta: {
         title: `${METADATA.siteName} | Resume`,
-        canonicalUrl: new URL(RESUME_PATH, environment.canonicalUrl),
+        canonicalUrl: new URL(RESUME_PATH, environment.appBaseUrl),
         description: METADATA.description,
         image: {
-          url: new URL('assets/img/og.jpg', environment.canonicalUrl),
+          url: new URL('assets/img/og.jpg', environment.appBaseUrl),
           alt: `A portrait of ${METADATA.realName}. Slightly smiling and wearing geek-ish glasses`,
         },
         standard: {

--- a/src/environments/environment-interface.ts
+++ b/src/environments/environment-interface.ts
@@ -1,4 +1,4 @@
 export interface Environment {
   production: boolean
-  canonicalUrl: URL
+  appBaseUrl: URL
 }

--- a/src/environments/environment.development.ts
+++ b/src/environments/environment.development.ts
@@ -2,8 +2,8 @@ import { Environment } from './environment-interface'
 
 export const environment: Environment = {
   production: false,
-  // ⚠️ When running locally production SSR version, server will run at http://localhost:4000 by default
-  //    However, given was built with production profile, canonical URL will be production's one.
+  // ⚠️ When locally serving production SSR, server will run at http://localhost:4000 by default
+  //    However, given was built with production profile, app base URL will be production's one.
   //    Nothing too bad happens right now given it's used just for SEO metadata. But to bear in mind.
-  canonicalUrl: new URL('http://localhost:4200'),
+  appBaseUrl: new URL('http://localhost:4200'),
 }

--- a/src/environments/environment.pull-request.ts.liquid
+++ b/src/environments/environment.pull-request.ts.liquid
@@ -10,5 +10,5 @@ const CLOUDFLARE_PAGES_PREVIEW_BRANCH_ALIAS_URL = new URL(
 )
 export const environment: Environment = {
   production: false,
-  canonicalUrl: CLOUDFLARE_PAGES_PREVIEW_BRANCH_ALIAS_URL,
+  appBaseUrl: CLOUDFLARE_PAGES_PREVIEW_BRANCH_ALIAS_URL,
 }

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -3,5 +3,5 @@ import { Environment } from './environment-interface'
 
 export const environment: Environment = {
   production: true,
-  canonicalUrl: new URL(`https://${METADATA.domainName}`),
+  appBaseUrl: new URL(`https://${METADATA.domainName}`),
 }


### PR DESCRIPTION
More appropriate. A canonical URL is the URL to identify a resource, it may have aliases. App base URL indicates better that is the base URL where app will be served

Removed `ENVIRONMENT` injection token in favour of specific app base URL token cause the _I_ of _SOLID_
