### PR TITLE
ci: use lighthouseci as run script

### DIFF
--- a/.github/workflows/reusable-performance.yml
+++ b/.github/workflows/reusable-performance.yml
@@ -47,7 +47,7 @@ jobs:
           # Needed for status checks to appear on PR
           # https://github.com/GoogleChrome/lighthouse-ci/issues/859#issuecomment-1574205125
           LHCI_BUILD_CONTEXT__CURRENT_HASH: ${{ github.event.pull_request.head.sha || github.sha }}
-        run: pnpm run lighthouse
+        run: pnpm run lighthouseci
       - name: Report results (as status check)
         if: github.ref == 'refs/heads/main'
         # noinspection SpellCheckingInspection

--- a/.idea/runConfigurations/Lighthouse.xml
+++ b/.idea/runConfigurations/Lighthouse.xml
@@ -3,7 +3,7 @@
     <package-json value="$PROJECT_DIR$/package.json" />
     <command value="run" />
     <scripts>
-      <script value="lighthouse" />
+      <script value="lighthouseci" />
     </scripts>
     <node-interpreter value="project" />
     <envs />

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "format:check": "prettier --check",
     "format:check-all": "pnpm run format-check .",
     "scripts:tsc": "cd scripts && tsc",
-    "lighthouse": "lhci autorun",
+    "lighthouseci": "lhci autorun",
     "bundlewatch": "bundlewatch --config .bundlewatch.config.json",
     "//1": "👇 Something weird in source maps after switching to ESBuild",
     "analyze-all-bundles": "pnpm dlx source-map-explorer dist/@davidlj95/website/browser/*.js --no-border-checks",


### PR DESCRIPTION
Otherwise, if installing Lighthouse, one couldn't run it by `pnpm lighthouse` as that would trigger Lighthouse CI
