### PR TITLE
refactor: move scheme classes to component

### DIFF
--- a/src/app/header/light-dark-toggle/light-dark-toggle.component.html
+++ b/src/app/header/light-dark-toggle/light-dark-toggle.component.html
@@ -1,12 +1,11 @@
 <button
   (click)="colorSchemeService.toggleDarkLight()"
-  aria-label="Color scheme toggle (dark or light)"
-  id="dark-light-scheme-toggle"
+  aria-label="Dark or light mode toggle"
 >
   <span class="light-only" appMaterialSymbol>{{
-    MaterialSymbol.DarkTheme
+    MaterialSymbol.DarkMode
   }}</span>
   <span class="dark-only" appMaterialSymbol>{{
-    MaterialSymbol.LightTheme
+    MaterialSymbol.LightMode
   }}</span>
 </button>

--- a/src/app/header/light-dark-toggle/light-dark-toggle.component.scss
+++ b/src/app/header/light-dark-toggle/light-dark-toggle.component.scss
@@ -1,6 +1,7 @@
 @use 'header';
 @use 'touch-or-pointer';
 @use 'material-symbols';
+@use 'sass:selector';
 
 :host {
   button {
@@ -24,5 +25,40 @@
       $grade: 0,
       $size: header.$icons-height
     );
+  }
+}
+
+@mixin light-only {
+  ::ng-deep.light-only {
+    display: initial;
+  }
+
+  ::ng-deep.dark-only {
+    display: none;
+  }
+}
+
+::ng-deep html,
+::ng-deep html[data-color-scheme='light'] {
+  @include light-only;
+}
+
+@mixin dark-only {
+  ::ng-deep.light-only {
+    display: none;
+  }
+
+  ::ng-deep.dark-only {
+    display: initial;
+  }
+}
+
+::ng-deep html[data-color-scheme='dark'] {
+  @include dark-only;
+}
+
+@media (prefers-color-scheme: dark) {
+  ::ng-deep html {
+    @include dark-only;
   }
 }

--- a/src/app/header/light-dark-toggle/light-dark-toggle.component.spec.ts
+++ b/src/app/header/light-dark-toggle/light-dark-toggle.component.spec.ts
@@ -1,10 +1,18 @@
 import { ComponentFixture } from '@angular/core/testing'
 
 import { LightDarkToggleComponent } from './light-dark-toggle.component'
-import { ColorSchemeService } from './color-scheme.service'
+import { ColorSchemeService, Scheme } from './color-scheme.service'
 import { By } from '@angular/platform-browser'
 import { componentTestSetup } from '@/test/helpers/component-test-setup'
 import { MockProvider } from 'ng-mocks'
+import { forceColorScheme } from '@/test/helpers/color-scheme'
+import { forceReducedMotion } from '@/test/helpers/motion'
+import { DarkMode, LightMode } from '../../material-symbols'
+import {
+  expectIsInLayout,
+  expectIsNotInLayout,
+} from '@/test/helpers/visibility'
+import { findMaterialSymbolByText } from '@/test/helpers/material-symbols'
 
 describe('LightDarkToggleComponent', () => {
   let component: LightDarkToggleComponent
@@ -13,6 +21,50 @@ describe('LightDarkToggleComponent', () => {
   it('should create', () => {
     ;[fixture, component] = makeSut()
     expect(component).toBeTruthy()
+  })
+
+  describe('when light scheme is set', () => {
+    beforeEach(() => {
+      ;[fixture, component] = makeSut()
+      fixture.detectChanges()
+    })
+
+    forceColorScheme(Scheme.Light)
+    forceReducedMotion()
+
+    it('should not display light mode icon', () => {
+      expectIsNotInLayout(
+        findMaterialSymbolByText(fixture.debugElement, LightMode).nativeElement,
+      )
+    })
+
+    it('should display dark mode icon', () => {
+      expectIsInLayout(
+        findMaterialSymbolByText(fixture.debugElement, DarkMode).nativeElement,
+      )
+    })
+  })
+
+  describe('when dark scheme is set', () => {
+    beforeEach(() => {
+      ;[fixture, component] = makeSut()
+      fixture.detectChanges()
+    })
+
+    forceColorScheme(Scheme.Dark)
+    forceReducedMotion()
+
+    it('should display light mode icon', () => {
+      expectIsInLayout(
+        findMaterialSymbolByText(fixture.debugElement, LightMode).nativeElement,
+      )
+    })
+
+    it('should not display dark mode icon', () => {
+      expectIsNotInLayout(
+        findMaterialSymbolByText(fixture.debugElement, DarkMode).nativeElement,
+      )
+    })
   })
 
   describe('when pressing scheme switcher icon', () => {

--- a/src/app/header/light-dark-toggle/light-dark-toggle.component.ts
+++ b/src/app/header/light-dark-toggle/light-dark-toggle.component.ts
@@ -1,6 +1,6 @@
 import { Component } from '@angular/core'
 import { MaterialSymbolDirective } from '@/common/material-symbol.directive'
-import { DarkTheme, LightTheme } from '../../material-symbols'
+import { DarkMode, LightMode } from '../../material-symbols'
 import { ColorSchemeService } from './color-scheme.service'
 
 @Component({
@@ -12,8 +12,8 @@ import { ColorSchemeService } from './color-scheme.service'
 })
 export class LightDarkToggleComponent {
   protected readonly MaterialSymbol = {
-    DarkTheme,
-    LightTheme,
+    DarkMode,
+    LightMode,
   }
 
   constructor(protected readonly colorSchemeService: ColorSchemeService) {}

--- a/src/app/material-symbols.ts
+++ b/src/app/material-symbols.ts
@@ -1,5 +1,5 @@
-export const DarkTheme = '\ue51c'
-export const LightTheme = '\ue518'
+export const DarkMode = '\ue51c'
+export const LightMode = '\ue518'
 export const Warning = '\ue002'
 export const Email = '\ue158'
 export const Call = '\ue0b0'

--- a/src/sass/_theming.scss
+++ b/src/sass/_theming.scss
@@ -1,43 +1,6 @@
 @use 'themes/constants';
 @import 'helpers/scss-to-css-vars';
 
-/**
- * Adds utility CSS classes to display or hide elements depending on the active color scheme
- */
-@mixin display-hide-classes {
-  html,
-  html[data-color-scheme='light'] {
-    .light-only {
-      display: initial;
-    }
-
-    .dark-only {
-      display: none;
-    }
-  }
-  html[data-color-scheme='dark'] {
-    .light-only {
-      display: none;
-    }
-
-    .dark-only {
-      display: initial;
-    }
-  }
-
-  @media (prefers-color-scheme: dark) {
-    html {
-      .light-only {
-        display: none;
-      }
-
-      .dark-only {
-        display: initial;
-      }
-    }
-  }
-}
-
 @mixin define-theme($theme) {
   @each $scheme in map-get($theme, schemes) {
     // When more themes are added, here we can do different if theme is not the default

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1,5 +1,1 @@
-@use 'theming';
-
 @import 'app/root';
-
-@include theming.display-hide-classes();

--- a/src/test/color-scheme.spec.ts
+++ b/src/test/color-scheme.spec.ts
@@ -1,33 +1,26 @@
-import { DOCUMENT } from '@angular/common'
-import { TestBed } from '@angular/core/testing'
 import {
   ColorSchemeService,
   Scheme,
 } from '../app/header/light-dark-toggle/color-scheme.service'
 import { serviceTestSetup } from '@/test/helpers/service-test-setup'
+import { forceReducedMotion } from '@/test/helpers/motion'
+import { forceColorScheme } from '@/test/helpers/color-scheme'
 
 describe('App color scheme', () => {
   let bodyElement: HTMLElement
-  let colorSchemeService: ColorSchemeService
   const LIGHT_MIN_LUMINANCE = 0.75
   const DARK_MAX_LUMINANCE = 0.25
-  const NO_MOTION_ATTRIBUTE = 'data-reduced-motion'
 
   beforeEach(async () => {
-    colorSchemeService = serviceTestSetup(ColorSchemeService)
-    const document = TestBed.inject(DOCUMENT)
-    document.documentElement.setAttribute(NO_MOTION_ATTRIBUTE, '')
+    serviceTestSetup(ColorSchemeService)
     bodyElement = document.body
   })
-  afterEach(() => {
-    document.documentElement.removeAttribute(NO_MOTION_ATTRIBUTE)
-    colorSchemeService.setSystem()
-  })
+  forceReducedMotion()
 
   describe('when light color scheme is set', () => {
-    it('body should have a light background color (high luminance), whilst text color should be a dark one (low luminance)', async () => {
-      colorSchemeService.setManual(Scheme.Light)
+    forceColorScheme(Scheme.Light)
 
+    it('body should have a light background color (high luminance), whilst text color should be a dark one (low luminance)', async () => {
       const bodyBackgroundColor = getRgbFromCssRgbColor(
         getComputedStyle(bodyElement).backgroundColor,
       )
@@ -42,9 +35,9 @@ describe('App color scheme', () => {
     })
   })
   describe('when dark color scheme is set', () => {
-    it('body should have a dark background color (low luminance), whilst text color should be a light one (high luminance)', async () => {
-      colorSchemeService.setManual(Scheme.Dark)
+    forceColorScheme(Scheme.Dark)
 
+    it('body should have a dark background color (low luminance), whilst text color should be a light one (high luminance)', async () => {
       const bodyBackgroundColor = getRgbFromCssRgbColor(
         getComputedStyle(bodyElement).backgroundColor,
       )

--- a/src/test/helpers/color-scheme.ts
+++ b/src/test/helpers/color-scheme.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing'
+import {
+  ColorSchemeService,
+  Scheme,
+} from '../../app/header/light-dark-toggle/color-scheme.service'
+
+export const forceColorScheme = (scheme: Scheme) => {
+  let colorSchemeService: ColorSchemeService | undefined
+  beforeEach(() => {
+    colorSchemeService = TestBed.inject(ColorSchemeService)
+    colorSchemeService.setManual(scheme)
+  })
+  afterEach(() => {
+    colorSchemeService?.setSystem()
+  })
+}

--- a/src/test/helpers/material-symbols.ts
+++ b/src/test/helpers/material-symbols.ts
@@ -1,4 +1,21 @@
 import { By } from '@angular/platform-browser'
 import { MATERIAL_SYMBOLS_CLASS } from '@/common/material-symbol.directive'
+import { DebugElement } from '@angular/core'
 
 export const MATERIAL_SYMBOLS_SELECTOR = By.css(`.${MATERIAL_SYMBOLS_CLASS}`)
+export const findMaterialSymbolByText = (
+  debugElement: DebugElement,
+  text: string,
+) => {
+  const icon = debugElement
+    .queryAll(MATERIAL_SYMBOLS_SELECTOR)
+    .find(
+      (debugElement) => debugElement.nativeElement.textContent.trim() == text,
+    )
+  expect(icon)
+    .withContext(
+      `icon with unicode escape \\u${text.charCodeAt(0).toString(16)} exists`,
+    )
+    .not.toBeUndefined()
+  return icon!
+}

--- a/src/test/helpers/motion.ts
+++ b/src/test/helpers/motion.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing'
+import { DOCUMENT } from '@angular/common'
+
+const NO_MOTION_ATTRIBUTE = 'data-reduced-motion'
+
+export const forceReducedMotion = () => {
+  let html: HTMLElement | undefined
+
+  beforeEach(() => {
+    html = TestBed.inject(DOCUMENT).documentElement
+    html.setAttribute(NO_MOTION_ATTRIBUTE, '')
+  })
+  afterEach(() => {
+    html?.removeAttribute(NO_MOTION_ATTRIBUTE)
+  })
+}


### PR DESCRIPTION
To avoid having that SCSS as part of general theming

- Add util to force reduced motion
- Add util to find material symbol by text
- Add util to force color scheme
- Ensure dark / light icon is proper one depending on active color scheme
- Change material symbol icon names to match official names
