### PR TITLE
build: rename Lighthouse to Lighthouse CI

### DIFF
--- a/.github/workflows/reusable-performance.yml
+++ b/.github/workflows/reusable-performance.yml
@@ -26,7 +26,7 @@ env:
 
 jobs:
   lhci:
-    name: Lighthouse
+    name: Lighthouse CI
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:

--- a/.idea/runConfigurations/Lighthouse_CI.xml
+++ b/.idea/runConfigurations/Lighthouse_CI.xml
@@ -1,5 +1,5 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="Lighthouse" type="js.build_tools.npm">
+  <configuration default="false" name="Lighthouse CI" type="js.build_tools.npm">
     <package-json value="$PROJECT_DIR$/package.json" />
     <command value="run" />
     <scripts>


### PR DESCRIPTION
Not the same! So useful to specify it's CI where it's CI

TL;DR: Lighthouse analyses & reports about websites metrics. CI ensures those metrics are under an acceptable limit.
