### PR TITLE
refactor: separate toolbar from header

### DIFF
--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -10,8 +10,7 @@
   .after-header {
     position: absolute;
     top: header.$height;
-    $headerHeight: header.$height;
-    min-height: calc(100% - $headerHeight);
+    min-height: calc(100% - #{header.$height});
     width: 100%;
   }
 }

--- a/src/app/header/header.component.html
+++ b/src/app/header/header.component.html
@@ -1,5 +1,3 @@
-<div class="bar">
-  <div role="toolbar">
-    <app-light-dark-toggle></app-light-dark-toggle>
-  </div>
-</div>
+<app-toolbar>
+  <app-light-dark-toggle></app-light-dark-toggle>
+</app-toolbar>

--- a/src/app/header/header.component.scss
+++ b/src/app/header/header.component.scss
@@ -5,9 +5,13 @@
 
 :host {
   position: fixed;
-  width: 100%;
-  @include borders.panel(bottom);
   z-index: z-index.$header;
+  height: header.$height;
+  width: 100%;
+
+  display: flex;
+  justify-content: flex-end;
+  @include borders.panel(bottom);
   background-color: var(--app-color-toolbar-background);
 
   @include animations.define {
@@ -15,19 +19,5 @@
       (background-color, border-color),
       animations.$emphasized-style
     );
-  }
-
-  .bar {
-    display: flex;
-    padding: header.$vertical-padding;
-    flex-direction: row;
-    justify-content: flex-end;
-    $icons-height: header.$icons-height;
-    $vertical-padding-height: header.$vertical-padding-height;
-    min-height: calc($icons-height + $vertical-padding-height);
-
-    [role='toolbar'] {
-      height: header.$icons-height;
-    }
   }
 }

--- a/src/app/header/header.component.ts
+++ b/src/app/header/header.component.ts
@@ -1,12 +1,13 @@
 import { Component } from '@angular/core'
 import { LightDarkToggleComponent } from './light-dark-toggle/light-dark-toggle.component'
 import { NgClass } from '@angular/common'
+import { ToolbarComponent } from './toolbar/toolbar.component'
 
 @Component({
   selector: 'app-header',
   templateUrl: './header.component.html',
   styleUrls: ['./header.component.scss'],
   standalone: true,
-  imports: [NgClass, LightDarkToggleComponent],
+  imports: [NgClass, LightDarkToggleComponent, ToolbarComponent],
 })
 export class HeaderComponent {}

--- a/src/app/header/toolbar/toolbar.component.scss
+++ b/src/app/header/toolbar/toolbar.component.scss
@@ -1,0 +1,5 @@
+@use 'header';
+
+:host {
+  padding: header.$vertical-padding;
+}

--- a/src/app/header/toolbar/toolbar.component.spec.ts
+++ b/src/app/header/toolbar/toolbar.component.spec.ts
@@ -1,0 +1,18 @@
+import { ComponentFixture } from '@angular/core/testing'
+
+import { ToolbarComponent } from './toolbar.component'
+import { componentTestSetup } from '@/test/helpers/component-test-setup'
+import { shouldProjectContent } from '@/test/helpers/component-testers'
+
+describe('ToolbarComponent', () => {
+  let component: ToolbarComponent
+  let fixture: ComponentFixture<ToolbarComponent>
+
+  it('should create', () => {
+    ;[fixture, component] = componentTestSetup(ToolbarComponent)
+    fixture.detectChanges()
+    expect(component).toBeTruthy()
+  })
+
+  shouldProjectContent(ToolbarComponent)
+})

--- a/src/app/header/toolbar/toolbar.component.ts
+++ b/src/app/header/toolbar/toolbar.component.ts
@@ -1,0 +1,13 @@
+import { Component } from '@angular/core'
+
+@Component({
+  selector: 'app-toolbar',
+  standalone: true,
+  imports: [],
+  template: '<ng-content></ng-content>',
+  styleUrl: './toolbar.component.scss',
+  host: {
+    role: 'toolbar',
+  },
+})
+export class ToolbarComponent {}


### PR DESCRIPTION
In order to allow for the navigation tabs to come
