### PR TITLE
test: use component instance over reflected attributes

### DIFF
--- a/src/app/resume-page/chipped-content/chipped-content.component.spec.ts
+++ b/src/app/resume-page/chipped-content/chipped-content.component.spec.ts
@@ -8,13 +8,13 @@ import {
   expectIsNotInLayout,
 } from '@/test/helpers/visibility'
 import { byComponent } from '@/test/helpers/component-query-predicates'
-import { getReflectedAttribute } from '@/test/helpers/get-reflected-attribute'
 import { componentTestSetup } from '@/test/helpers/component-test-setup'
 import { By } from '@angular/platform-browser'
 import { provideNoopAnimations } from '@angular/platform-browser/animations'
 import { tickToFinishAnimation } from '@/test/helpers/tick-to-finish-animation'
 import { MockProvider } from 'ng-mocks'
 import { SCROLL_INTO_VIEW } from '@/common/scroll-into-view'
+import { getComponentInstance } from '@/test/helpers/get-component-instance'
 
 describe('ChippedContentComponent', () => {
   let fixture: ComponentFixture<ChippedContentComponent>
@@ -40,9 +40,9 @@ describe('ChippedContentComponent', () => {
 
     chipElements.forEach((chipElement, index) => {
       const content = CONTENTS[index]
-      expect(getReflectedAttribute(chipElement, 'selected'))
+      expect(getComponentInstance(chipElement, ChipComponent).selected)
         .withContext(`chip ${index} is unselected`)
-        .toBe('false')
+        .toBeFalse()
       expect(chipElement.nativeElement.textContent.trim())
         .withContext(`chip ${index} display name`)
         .toEqual(content.displayName)
@@ -93,9 +93,9 @@ describe('ChippedContentComponent', () => {
     }
 
     it('should mark the chip as selected', () => {
-      expect(getReflectedAttribute(firstChipElement, 'selected')).toBe(
-        true.toString(),
-      )
+      expect(
+        getComponentInstance(firstChipElement, ChipComponent).selected,
+      ).toBe(true)
     })
 
     it('should layout its content', () => {
@@ -118,9 +118,9 @@ describe('ChippedContentComponent', () => {
       }))
 
       it('should mark the chip as unselected', () => {
-        expect(getReflectedAttribute(firstChipElement, 'selected')).toEqual(
-          false.toString(),
-        )
+        expect(
+          getComponentInstance(firstChipElement, ChipComponent).selected,
+        ).toBeFalse()
       })
 
       it('should not layout its content', () => {
@@ -142,12 +142,12 @@ describe('ChippedContentComponent', () => {
       }))
 
       it('should mark the previous chip as unselected and just tapped chip as selected', () => {
-        expect(getReflectedAttribute(firstChipElement, 'selected')).toBe(
-          false.toString(),
-        )
-        expect(getReflectedAttribute(secondChipElement, 'selected')).toBe(
-          true.toString(),
-        )
+        expect(
+          getComponentInstance(firstChipElement, ChipComponent).selected,
+        ).toBeFalse()
+        expect(
+          getComponentInstance(secondChipElement, ChipComponent).selected,
+        ).toBeTrue()
       })
 
       it('should not layout currently active content and layout the new content', () => {

--- a/src/app/resume-page/collapsible-tree/collapsible-tree.component.spec.ts
+++ b/src/app/resume-page/collapsible-tree/collapsible-tree.component.spec.ts
@@ -12,7 +12,6 @@ import {
   ATTRIBUTE_ARIA_EXPANDED,
   ATTRIBUTE_ARIA_HIDDEN,
 } from '@/test/helpers/aria'
-import { getReflectedAttribute } from '@/test/helpers/get-reflected-attribute'
 import { provideNoopAnimations } from '@angular/platform-browser/animations'
 import { expectIsInLayout } from '@/test/helpers/visibility'
 import {
@@ -21,6 +20,7 @@ import {
 } from './collapsible-tree-node'
 import { Component, Input } from '@angular/core'
 import { EmptyComponent } from '@/test/helpers/empty-component'
+import { getComponentInstance } from '@/test/helpers/get-component-instance'
 
 describe('CollapsibleTreeComponent', () => {
   let component: CollapsibleTreeComponent
@@ -126,9 +126,9 @@ describe('CollapsibleTreeComponent', () => {
         )
         expect(itemElement).not.toBeNull()
 
-        expect(getReflectedAttribute(itemElement, 'depth')).toEqual(
-          (DUMMY_DEPTH + 1).toString(),
-        )
+        expect(
+          getComponentInstance(itemElement, CollapsibleTreeComponent).depth,
+        ).toBe(DUMMY_DEPTH + 1)
       }
     })
 

--- a/src/app/resume-page/education-section/education-item/education-item.component.spec.ts
+++ b/src/app/resume-page/education-section/education-item/education-item.component.spec.ts
@@ -23,7 +23,7 @@ import { componentTestSetup } from '@/test/helpers/component-test-setup'
 import { makeEducationItem } from './__tests__/make-education-item'
 import { shouldContainComponent } from '@/test/helpers/component-testers'
 import { ItemFactoryOverrides } from '@/test/helpers/make-item-factory'
-import { getReflectedAttribute } from '@/test/helpers/get-reflected-attribute'
+import { getComponentInstance } from '@/test/helpers/get-component-instance'
 
 describe('EducationItemComponent', () => {
   let component: EducationItemComponent
@@ -60,7 +60,9 @@ describe('EducationItemComponent', () => {
       byComponent(CardHeaderImageComponent),
     )
     expect(imageElement).toBeTruthy()
-    expect(getReflectedAttribute(imageElement, 'src')).toEqual(imageUrl)
+    expect(
+      getComponentInstance(imageElement, CardHeaderImageComponent).src,
+    ).toEqual(imageUrl)
   })
 
   it("should display institution name with link to company's website", () => {

--- a/src/app/resume-page/experience-section/experience-item/experience-item.component.spec.ts
+++ b/src/app/resume-page/experience-section/experience-item/experience-item.component.spec.ts
@@ -22,7 +22,7 @@ import { byComponent } from '@/test/helpers/component-query-predicates'
 import { componentTestSetup } from '@/test/helpers/component-test-setup'
 import { makeExperienceItem } from './__tests__/make-experience-item'
 import { ItemFactoryOverrides } from '@/test/helpers/make-item-factory'
-import { getReflectedAttribute } from '@/test/helpers/get-reflected-attribute'
+import { getComponentInstance } from '@/test/helpers/get-component-instance'
 
 describe('ExperienceItem', () => {
   let component: ExperienceItemComponent
@@ -61,7 +61,9 @@ describe('ExperienceItem', () => {
         byComponent(CardHeaderImageComponent),
       )
       expect(imageElement).toBeTruthy()
-      expect(getReflectedAttribute(imageElement, 'src')).toEqual(imageUrl)
+      expect(
+        getComponentInstance(imageElement, CardHeaderImageComponent).src,
+      ).toBe(imageUrl)
     })
 
     it("should display company name with link to company's website", () => {

--- a/src/app/resume-page/profile-section/profile-picture/profile-picture.component.spec.ts
+++ b/src/app/resume-page/profile-section/profile-picture/profile-picture.component.spec.ts
@@ -4,7 +4,7 @@ import { By } from '@angular/platform-browser'
 import { expectIsNotVisible } from '@/test/helpers/visibility'
 
 import { ProfilePictureComponent } from './profile-picture.component'
-import { getReflectedAttribute } from '@/test/helpers/get-reflected-attribute'
+import { NgOptimizedImage } from '@angular/common'
 
 describe('ProfilePictureComponent', () => {
   let component: ProfilePictureComponent
@@ -24,22 +24,21 @@ describe('ProfilePictureComponent', () => {
   })
 
   it('should display profile picture', () => {
-    const profilePic = fixture.debugElement.query(PROFILE_PIC_MAIN_SELECTOR)
-    expect(profilePic).toBeTruthy()
-    const ngSrcAttribute = getReflectedAttribute(profilePic, 'ng-src')
-    expect(ngSrcAttribute).toBeDefined()
-    expect(ngSrcAttribute).toContain('profile.png')
+    expect(
+      fixture.debugElement
+        .query(PROFILE_PIC_MAIN_SELECTOR)
+        .injector.get(NgOptimizedImage).ngSrc,
+    ).toContain('profile.png')
   })
 
   it('should contain "huh" profile picture, despite hidden', () => {
-    const huhProfilePic = fixture.debugElement.query(PROFILE_PIC_HUH_SELECTOR)
-    expect(huhProfilePic).toBeTruthy()
-    const ngSrcAttribute = getReflectedAttribute(huhProfilePic, 'ng-src')
-    expect(ngSrcAttribute).toBeDefined()
-    expect(ngSrcAttribute).toContain('profile_huh.png')
-    expectIsNotVisible(huhProfilePic.nativeElement)
-    const styles = getComputedStyle(huhProfilePic.nativeElement)
-    expect(styles.opacity).toEqual('0')
+    const profileHuhImgElement = fixture.debugElement.query(
+      PROFILE_PIC_HUH_SELECTOR,
+    )
+    expect(profileHuhImgElement.injector.get(NgOptimizedImage).ngSrc).toContain(
+      'profile_huh.png',
+    )
+    expectIsNotVisible(profileHuhImgElement.nativeElement)
   })
 
   describe('accessible easter egg', () => {

--- a/src/app/resume-page/projects-section/project-item/project-item.component.spec.ts
+++ b/src/app/resume-page/projects-section/project-item/project-item.component.spec.ts
@@ -10,7 +10,6 @@ import { CardComponent } from '../../card/card.component'
 import { CardHeaderImageComponent } from '../../card/card-header/card-header-image/card-header-image.component'
 import { CardHeaderComponent } from '../../card/card-header/card-header.component'
 import { byComponent } from '@/test/helpers/component-query-predicates'
-import { getReflectedAttribute } from '@/test/helpers/get-reflected-attribute'
 import { ProjectItem, Stack } from './project-item'
 import { CardHeaderTextsComponent } from '../../card/card-header/card-header-texts/card-header-texts.component'
 import { CardHeaderTitleComponent } from '../../card/card-header/card-header-title/card-header-title.component'
@@ -28,6 +27,7 @@ import { componentTestSetup } from '@/test/helpers/component-test-setup'
 import { makeProjectItem } from '../__tests__/make-project-item'
 import { ItemFactoryOverrides } from '@/test/helpers/make-item-factory'
 import { shouldContainComponent } from '@/test/helpers/component-testers'
+import { getComponentInstance } from '@/test/helpers/get-component-instance'
 
 describe('ProjectItemComponent', () => {
   let component: ProjectItemComponent
@@ -69,7 +69,9 @@ describe('ProjectItemComponent', () => {
         byComponent(CardHeaderImageComponent),
       )
       expect(imageElement).toBeTruthy()
-      expect(getReflectedAttribute(imageElement, 'src')).toEqual(imageSrc)
+      expect(
+        getComponentInstance(imageElement, CardHeaderImageComponent).src,
+      ).toBe(imageSrc)
     })
   })
 
@@ -145,9 +147,9 @@ describe('ProjectItemComponent', () => {
         byTestId(Attribute.Stack),
       )
       expect(stackAttributeElement).toBeTruthy()
-      expect(getReflectedAttribute(stackAttributeElement, 'symbol')).toEqual(
-        stackContent.materialSymbol,
-      )
+      expect(
+        getComponentInstance(stackAttributeElement, AttributeComponent).symbol,
+      ).toBe(stackContent.materialSymbol)
       expect(stackAttributeElement.nativeElement.textContent.trim()).toEqual(
         stackContent.displayName,
       )

--- a/src/test/helpers/get-component-instance.spec.ts
+++ b/src/test/helpers/get-component-instance.spec.ts
@@ -1,0 +1,50 @@
+import { Component } from '@angular/core'
+import { componentTestSetup } from '@/test/helpers/component-test-setup'
+import { getComponentInstance } from '@/test/helpers/get-component-instance'
+
+@Component({
+  selector: 'app-test-component',
+  template: '',
+  standalone: true,
+})
+export class TestComponent {}
+@Component({
+  selector: 'app-another-test-component',
+  template: '',
+  standalone: true,
+})
+export class AnotherTestComponent {}
+
+describe('GetComponentInstance', () => {
+  describe('when component instance matches component type', () => {
+    it('should return component instance (with type assertion)', () => {
+      const [fixture, component] = componentTestSetup(TestComponent)
+
+      expect(getComponentInstance(fixture.debugElement, TestComponent)).toBe(
+        component,
+      )
+    })
+  })
+
+  describe('when component instance does match component type', () => {
+    it('should throw an informative error', () => {
+      const [fixture] = componentTestSetup(TestComponent)
+
+      let error: Error | undefined
+      try {
+        getComponentInstance(fixture.debugElement, AnotherTestComponent)
+      } catch (caughtError: unknown) {
+        error = caughtError as Error
+      }
+
+      expect(error).toBeDefined()
+      expect(error?.message).toMatch(/unexpected component instance type/i)
+      expect(error?.message)
+        .withContext('should indicate expected type')
+        .toMatch(/E|expected[\s:'"]+EmptyComponent/)
+      expect(error?.message)
+        .withContext('should indicate actual type')
+        .toMatch(/A|actual[\s:'"]+TestComponent/)
+    })
+  })
+})

--- a/src/test/helpers/get-component-instance.ts
+++ b/src/test/helpers/get-component-instance.ts
@@ -1,0 +1,16 @@
+import { DebugElement, Type } from '@angular/core'
+
+export const getComponentInstance = <T>(
+  debugElement: DebugElement,
+  component: Type<T>,
+) => {
+  const componentInstance = debugElement.componentInstance
+  if (!(componentInstance instanceof component)) {
+    const expectedComponentName = component.name
+    const actualComponentName = componentInstance.constructor.name
+    throw new Error(
+      `Unexpected component instance type. Expected: '${expectedComponentName}'. Actual: '${actualComponentName}'`,
+    )
+  }
+  return componentInstance as T
+}

--- a/src/test/helpers/get-reflected-attribute.ts
+++ b/src/test/helpers/get-reflected-attribute.ts
@@ -1,8 +1,0 @@
-import { DebugElement } from '@angular/core'
-
-export function getReflectedAttribute(
-  element: DebugElement,
-  name: string,
-): string | null {
-  return element.attributes[`ng-reflect-${name}`]
-}


### PR DESCRIPTION
As reflected attributes are not a public API. So shouldn't be used
