### PR TITLE
feat: improve sticky section titles

### DIFF
--- a/src/app/resume-page/resume-page.component.scss
+++ b/src/app/resume-page/resume-page.component.scss
@@ -8,7 +8,3 @@
   display: flex;
   flex-direction: column;
 }
-
-::ng-deep app-profile-section app-section-title {
-  border-top-style: none !important;
-}

--- a/src/app/resume-page/section-title/section-title.component.scss
+++ b/src/app/resume-page/section-title/section-title.component.scss
@@ -7,7 +7,8 @@
 :host {
   display: block;
   position: sticky;
-  top: calc(#{header.$height} - #{header.$border-height});
+  top: header.$height;
+  transform: translateY(-#{borders.$panel-width});
   z-index: z-index.$headers;
   width: 100%;
   padding: paddings.$s paddings.$l;


### PR DESCRIPTION
First section title looked like being shifted up 1px (panel border width) when scrolling down. 

Reason is lack of border for first section title. This is to avoid two border panes to touch: section title top & header bottom. Rest of section titles borders were hidden by positioning them under the header bar. But that's only when `sticky` gets in. Which starts when scrolling down. Hence the effect.

So first section title has 1px with background colour instead of border to avoid duplicate borders. But then, when stickyness enters, the section title gets shifted 1px up (mechanism to hide rest of border collisions) and that's noticed.

By using `translateY` transformation to put the section title's top panel's border under the header, the position is the same for all items and there's no shift. Plus we get a quirky hack to modify first section title element
