### PR TITLE
refactor: improve tabs overflowing mechanism

### DIFF
--- a/src/app/header/navigation-tabs/navigation-tabs.component.scss
+++ b/src/app/header/navigation-tabs/navigation-tabs.component.scss
@@ -1,13 +1,14 @@
 @use 'borders';
+@use 'header';
 
 :host {
   display: block;
-  overflow: hidden;
+  font-size: 1.25rem;
+}
 
-  app-tab {
-    font-size: 1.25rem;
-    // 👇 Bottom border over panel border
-    position: relative;
-    bottom: -#{borders.$panel-width};
-  }
+app-tabs {
+  height: header.$height;
+}
+app-tab {
+  height: 100%;
 }

--- a/src/app/header/tab/tab.component.scss
+++ b/src/app/header/tab/tab.component.scss
@@ -1,21 +1,19 @@
 @use 'paddings';
 @use 'animations';
-@use 'header';
 @use 'touch-or-pointer';
 
 :host {
-  $bottom-border-width: 2px;
-  cursor: pointer;
-  float: left;
-  padding: 0 paddings.$l;
-  height: calc(#{header.$height} - $bottom-border-width);
   display: flex;
-  flex-grow: 1;
-  justify-content: center;
   align-items: center;
-  border-bottom-width: $bottom-border-width;
+
+  padding: paddings.$xs paddings.$l;
+
+  cursor: pointer;
+
+  border-bottom-width: 2px;
   border-bottom-color: transparent;
   border-bottom-style: solid;
+
   color: var(--ui-text);
 
   &[aria-selected='true'] {

--- a/src/app/header/tabs/tabs.component.scss
+++ b/src/app/header/tabs/tabs.component.scss
@@ -1,3 +1,11 @@
+@use 'header';
+
 :host {
-  display: block;
+  display: flex;
+  flex-wrap: wrap;
+  overflow: hidden;
+}
+
+app-tab {
+  flex-grow: 0;
 }


### PR DESCRIPTION
Improves implementation of tabs overflowing mechanism & integration with header:
 - Use flexbox instead of old & boring flow layout
 - Decouple tab component from header & add padding for cases where height is unset
   - Force tab group height to header's height to hide second line of tabs (if any) 
   - Force tab height to header's height including panel border to paint over it 
 - Remove unneeded properties (`justify-content` on tab component