### PR TITLE
refactor: use new scss mixin to define css animations

### DIFF
--- a/src/app/header/header.component.scss
+++ b/src/app/header/header.component.scss
@@ -15,7 +15,7 @@ header {
   @include borders.panel(bottom);
   background-color: var(--app-color-toolbar-background);
 
-  @include animations.motion-host-context {
+  @include animations.define-with-host-context {
     @include animations.multiple-transitions(
       (background-color, border-color),
       animations.$emphasized-style

--- a/src/app/header/light-dark-toggle/light-dark-toggle.component.scss
+++ b/src/app/header/light-dark-toggle/light-dark-toggle.component.scss
@@ -4,24 +4,19 @@
 @use 'sass:selector';
 @use 'animations';
 
-:host {
-  button {
-    color: var(--icon-default);
-    border-style: none;
-    background: transparent;
+button {
+  color: var(--icon-default);
+  border-style: none;
+  background: transparent;
 
-    @include touch-or-pointer.primaryInputCanHover {
-      &:hover {
-        color: var(--icon-default-hover);
-      }
+  @include touch-or-pointer.primaryInputCanHover {
+    &:hover {
+      color: var(--icon-default-hover);
     }
+  }
 
-    @include animations.define {
-      @include animations.single-transition(
-        color,
-        animations.$emphasized-style
-      );
-    }
+  @include animations.define-with-host-context {
+    @include animations.single-transition(color, animations.$emphasized-style);
   }
 
   @include material-symbols.class {

--- a/src/app/header/tab/tab.component.scss
+++ b/src/app/header/tab/tab.component.scss
@@ -27,7 +27,7 @@
     }
   }
 
-  @include animations.define {
+  @include animations.define-with-host-context {
     @include animations.multiple-transitions(
       (border-bottom-color, color),
       animations.$emphasized-style

--- a/src/app/resume-page/attribute/attribute.component.scss
+++ b/src/app/resume-page/attribute/attribute.component.scss
@@ -8,7 +8,7 @@
   cursor: pointer;
   color: var(--ui-text);
 
-  @include animations.define {
+  @include animations.define-with-host-context {
     @include animations.single-transition(color);
   }
 
@@ -19,26 +19,26 @@
       opacity: 1;
     }
   }
+}
 
-  [role='tooltip'] {
-    position: absolute;
-    top: 0;
+[role='tooltip'] {
+  position: absolute;
+  top: 0;
 
-    // 👇 For animation purposes
-    visibility: hidden;
-    right: 150%;
-    opacity: 0;
-    @include animations.define {
-      @include animations.multiple-transitions((right, opacity, visibility));
-    }
-
-    font-size: 1rem;
-    width: max-content;
-    margin: 0 margins.$s;
-    padding: paddings.$s;
-    text-align: right;
-    @include borders.panel;
-    color: var(--ui-text);
-    background-color: var(--sys-color-surface5);
+  // 👇 For animation purposes
+  visibility: hidden;
+  right: 150%;
+  opacity: 0;
+  @include animations.define-with-host-context {
+    @include animations.multiple-transitions((right, opacity, visibility));
   }
+
+  font-size: 1rem;
+  width: max-content;
+  margin: 0 margins.$s;
+  padding: paddings.$s;
+  text-align: right;
+  @include borders.panel;
+  color: var(--ui-text);
+  background-color: var(--sys-color-surface5);
 }

--- a/src/app/resume-page/card/card-header/card-header-detail/card-header-detail.component.scss
+++ b/src/app/resume-page/card/card-header/card-header-detail/card-header-detail.component.scss
@@ -3,7 +3,7 @@
 :host {
   font-size: 1rem;
   color: var(--ui-text);
-  @include animations.define {
+  @include animations.define-with-host-context {
     @include animations.single-transition(color, animations.$emphasized-style);
   }
 }

--- a/src/app/resume-page/card/card-header/card-header-image/card-header-image.component.scss
+++ b/src/app/resume-page/card/card-header/card-header-image/card-header-image.component.scss
@@ -2,16 +2,13 @@
 @use 'card-header-image';
 
 :host {
-  min-width: card-header-image.$size;
+  width: card-header-image.$size;
+}
 
-  img {
-    border-radius: card-header-image.$size;
-    filter: var(--img-filter);
-    @include animations.define {
-      @include animations.single-transition(
-        filter,
-        animations.$emphasized-style
-      );
-    }
+img {
+  border-radius: card-header-image.$size;
+  filter: var(--img-filter);
+  @include animations.define-with-host-context {
+    @include animations.single-transition(filter, animations.$emphasized-style);
   }
 }

--- a/src/app/resume-page/card/card-header/card-header-subtitle/card-header-subtitle.component.scss
+++ b/src/app/resume-page/card/card-header/card-header-subtitle/card-header-subtitle.component.scss
@@ -4,7 +4,7 @@
   font-size: 1.15rem;
   color: var(--ui-text);
 
-  @include animations.define {
+  @include animations.define-with-host-context {
     @include animations.single-transition(color, animations.$emphasized-style);
   }
 }

--- a/src/app/resume-page/card/card.component.scss
+++ b/src/app/resume-page/card/card.component.scss
@@ -11,7 +11,7 @@
   @include borders.panel;
   background-color: var(--sys-color-surface1);
 
-  @include animations.define {
+  @include animations.define-with-host-context {
     @include animations.multiple-transitions(
       (background-color, border-color),
       animations.$emphasized-style

--- a/src/app/resume-page/chip/chip.component.scss
+++ b/src/app/resume-page/chip/chip.component.scss
@@ -11,7 +11,7 @@
   color: var(--sys-color-on-surface);
   border-color: var(--adorner-border-color);
 
-  @include animations.define {
+  @include animations.define-with-host-context {
     @include animations.multiple-transitions(
       (background-color, color, border-color),
       animations.$emphasized-style

--- a/src/app/resume-page/content-chip/content-chip.component.scss
+++ b/src/app/resume-page/content-chip/content-chip.component.scss
@@ -7,7 +7,7 @@
   padding: paddings.$s;
   background-color: var(--sys-color-surface3);
 
-  @include animations.define {
+  @include animations.define-with-host-context {
     @include animations.multiple-transitions(
       (background-color, border-color),
       animations.$emphasized-style

--- a/src/app/resume-page/languages-section/language-item/language-tag/language-tag.component.scss
+++ b/src/app/resume-page/languages-section/language-item/language-tag/language-tag.component.scss
@@ -2,37 +2,35 @@
 @use '../../../card/card-header/card-header-image/card-header-image';
 @use 'sass:math';
 
-:host {
-  a {
-    text-decoration: none;
-    color: var(--sys-color-on-surface);
-    :hover {
-      color: var(--ui-text);
-    }
+a {
+  text-decoration: none;
+  color: var(--sys-color-on-surface);
+  :hover {
+    color: var(--ui-text);
+  }
+}
+
+code {
+  display: block;
+  text-align: center;
+
+  height: card-header-image.$size;
+  width: card-header-image.$size;
+  border-radius: card-header-image.$size;
+  line-height: card-header-image.$size;
+
+  background-color: var(--sys-color-surface5);
+  &:hover {
+    background-color: var(--sys-color-surface2);
   }
 
-  code {
-    display: block;
-    text-align: center;
+  font-weight: bold;
+  font-size: math.div(3 * card-header-image.$size, 8);
 
-    height: card-header-image.$size;
-    width: card-header-image.$size;
-    border-radius: card-header-image.$size;
-    line-height: card-header-image.$size;
-
-    background-color: var(--sys-color-surface5);
-    &:hover {
-      background-color: var(--sys-color-surface2);
-    }
-
-    font-weight: bold;
-    font-size: math.div(3 * card-header-image.$size, 8);
-
-    @include animations.define {
-      @include animations.multiple-transitions(
-        (background-color, color),
-        animations.$emphasized-style
-      );
-    }
+  @include animations.define-with-host-context {
+    @include animations.multiple-transitions(
+      (background-color),
+      animations.$emphasized-style
+    );
   }
 }

--- a/src/app/resume-page/profile-section/profile-contacts/profile-contacts.component.scss
+++ b/src/app/resume-page/profile-section/profile-contacts/profile-contacts.component.scss
@@ -22,7 +22,7 @@
       &:hover {
         color: var(--sys-color-on-surface);
       }
-      @include animations.define {
+      @include animations.define-with-host-context {
         @include animations.single-transition(
           color,
           animations.$emphasized-style

--- a/src/app/resume-page/profile-section/profile-picture/profile-picture.component.scss
+++ b/src/app/resume-page/profile-section/profile-picture/profile-picture.component.scss
@@ -18,7 +18,7 @@ $picture-size: 128px;
     border-color: var(--sys-color-divider);
     filter: var(--img-filter);
 
-    @include animations.define {
+    @include animations.define-with-host-context {
       transition: animations.transition(opacity),
         animations.transition(visibility),
         animations.transition(filter, animations.$emphasized-style),
@@ -52,7 +52,7 @@ $picture-size: 128px;
     padding: paddings.$s;
     border-radius: paddings.$s;
 
-    @include animations.define {
+    @include animations.define-with-host-context {
       @include animations.multiple-transitions((opacity, visibility));
     }
 

--- a/src/app/resume-page/section-title/section-title.component.scss
+++ b/src/app/resume-page/section-title/section-title.component.scss
@@ -16,7 +16,7 @@
   background-color: var(--app-color-toolbar-background);
   color: var(--ui-text);
 
-  @include animations.define {
+  @include animations.define-with-host-context {
     @include animations.multiple-transitions(
       (color, background-color, border-color),
       animations.$emphasized-style

--- a/src/sass/_animations.scss
+++ b/src/sass/_animations.scss
@@ -50,7 +50,8 @@ $emphasized-style: (
   @return $property map.get($style, duration) map.get($style, timing-function);
 }
 
-@mixin motion-host-context() {
+$_reduced-motion-selector: 'html:not([data-reduced-motion])';
+@mixin define-with-host-context() {
   @at-root {
     // 👇 Angular adds [_nghost-ng-g4rb4g3] when using :host-context(selector) twice to:
     //      - Match selector in host: `selector:host`
@@ -66,7 +67,7 @@ $emphasized-style: (
     //    https://github.com/angular/angular/issues/51954
     //    But the point of applying `:host-context(html)` was not successfully explained
     //    It's appearing in production builds. Taking note to create an issue about this.
-    #{selector.nest(':host-context(html:not([data-reduced-motion]))', &)} {
+    #{selector.nest(':host-context(#{$_reduced-motion-selector})', &)} {
       @media (prefers-reduced-motion: no-preference) {
         @content;
       }
@@ -75,9 +76,11 @@ $emphasized-style: (
 }
 
 @mixin define {
-  @at-root #{selector.nest('html:not([data-reduced-motion])', &)} {
-    @media (prefers-reduced-motion: no-preference) {
-      @content;
+  @at-root {
+    #{selector.nest($_reduced-motion-selector, &)} {
+      @media (prefers-reduced-motion: no-preference) {
+        @content;
+      }
     }
   }
 }


### PR DESCRIPTION
In order to progressivelly allow defining children of host components without `:host` everywhere
