### PR TITLE
refactor: add root attribute scss helpers + renames

### DIFF
--- a/src/app/header/header.component.scss
+++ b/src/app/header/header.component.scss
@@ -15,7 +15,7 @@ header {
   @include borders.panel(bottom);
   background-color: var(--app-color-toolbar-background);
 
-  @include animations.define-with-host-context {
+  @include animations.when-motion-host-context {
     @include animations.multiple-transitions(
       (background-color, border-color),
       animations.$emphasized-style

--- a/src/app/header/light-dark-toggle/light-dark-toggle.component.scss
+++ b/src/app/header/light-dark-toggle/light-dark-toggle.component.scss
@@ -15,7 +15,7 @@ button {
     }
   }
 
-  @include animations.define-with-host-context {
+  @include animations.when-motion-host-context {
     @include animations.single-transition(color, animations.$emphasized-style);
   }
 

--- a/src/app/header/tab/tab.component.scss
+++ b/src/app/header/tab/tab.component.scss
@@ -27,7 +27,7 @@
     }
   }
 
-  @include animations.define-with-host-context {
+  @include animations.when-motion-host-context {
     @include animations.multiple-transitions(
       (border-bottom-color, color),
       animations.$emphasized-style

--- a/src/app/resume-page/attribute/attribute.component.scss
+++ b/src/app/resume-page/attribute/attribute.component.scss
@@ -8,7 +8,7 @@
   cursor: pointer;
   color: var(--ui-text);
 
-  @include animations.define-with-host-context {
+  @include animations.when-motion-host-context {
     @include animations.single-transition(color);
   }
 
@@ -29,8 +29,11 @@
   visibility: hidden;
   right: 150%;
   opacity: 0;
-  @include animations.define-with-host-context {
-    @include animations.multiple-transitions((right, opacity, visibility));
+  @include animations.when-motion-host-context {
+    @include animations.multiple-transitions(
+      (right, opacity, visibility, background-color, color, border-color),
+      animations.$emphasized-style
+    );
   }
 
   font-size: 1rem;

--- a/src/app/resume-page/card/card-header/card-header-detail/card-header-detail.component.scss
+++ b/src/app/resume-page/card/card-header/card-header-detail/card-header-detail.component.scss
@@ -3,7 +3,7 @@
 :host {
   font-size: 1rem;
   color: var(--ui-text);
-  @include animations.define-with-host-context {
+  @include animations.when-motion-host-context {
     @include animations.single-transition(color, animations.$emphasized-style);
   }
 }

--- a/src/app/resume-page/card/card-header/card-header-image/card-header-image.component.scss
+++ b/src/app/resume-page/card/card-header/card-header-image/card-header-image.component.scss
@@ -8,7 +8,7 @@
 img {
   border-radius: card-header-image.$size;
   filter: var(--img-filter);
-  @include animations.define-with-host-context {
+  @include animations.when-motion-host-context {
     @include animations.single-transition(filter, animations.$emphasized-style);
   }
 }

--- a/src/app/resume-page/card/card-header/card-header-subtitle/card-header-subtitle.component.scss
+++ b/src/app/resume-page/card/card-header/card-header-subtitle/card-header-subtitle.component.scss
@@ -4,7 +4,7 @@
   font-size: 1.15rem;
   color: var(--ui-text);
 
-  @include animations.define-with-host-context {
+  @include animations.when-motion-host-context {
     @include animations.single-transition(color, animations.$emphasized-style);
   }
 }

--- a/src/app/resume-page/card/card.component.scss
+++ b/src/app/resume-page/card/card.component.scss
@@ -11,7 +11,7 @@
   @include borders.panel;
   background-color: var(--sys-color-surface1);
 
-  @include animations.define-with-host-context {
+  @include animations.when-motion-host-context {
     @include animations.multiple-transitions(
       (background-color, border-color),
       animations.$emphasized-style

--- a/src/app/resume-page/chip/chip.component.scss
+++ b/src/app/resume-page/chip/chip.component.scss
@@ -11,7 +11,7 @@
   color: var(--sys-color-on-surface);
   border-color: var(--adorner-border-color);
 
-  @include animations.define-with-host-context {
+  @include animations.when-motion-host-context {
     @include animations.multiple-transitions(
       (background-color, color, border-color),
       animations.$emphasized-style

--- a/src/app/resume-page/content-chip/content-chip.component.scss
+++ b/src/app/resume-page/content-chip/content-chip.component.scss
@@ -7,7 +7,7 @@
   padding: paddings.$s;
   background-color: var(--sys-color-surface3);
 
-  @include animations.define-with-host-context {
+  @include animations.when-motion-host-context {
     @include animations.multiple-transitions(
       (background-color, border-color),
       animations.$emphasized-style

--- a/src/app/resume-page/languages-section/language-item/language-tag/language-tag.component.scss
+++ b/src/app/resume-page/languages-section/language-item/language-tag/language-tag.component.scss
@@ -27,7 +27,7 @@ code {
   font-weight: bold;
   font-size: math.div(3 * card-header-image.$size, 8);
 
-  @include animations.define-with-host-context {
+  @include animations.when-motion-host-context {
     @include animations.multiple-transitions(
       (background-color),
       animations.$emphasized-style

--- a/src/app/resume-page/profile-section/profile-contacts/profile-contacts.component.scss
+++ b/src/app/resume-page/profile-section/profile-contacts/profile-contacts.component.scss
@@ -22,7 +22,7 @@ li {
     &:hover {
       color: var(--sys-color-on-surface);
     }
-    @include animations.define-with-host-context {
+    @include animations.when-motion-host-context {
       @include animations.single-transition(
         color,
         animations.$emphasized-style

--- a/src/app/resume-page/profile-section/profile-picture/profile-picture.component.scss
+++ b/src/app/resume-page/profile-section/profile-picture/profile-picture.component.scss
@@ -44,7 +44,7 @@ img {
   border-color: var(--sys-color-divider);
   filter: var(--img-filter);
 
-  @include animations.define-with-host-context {
+  @include animations.when-motion-host-context {
     transition: animations.transition(opacity),
       animations.transition(visibility),
       animations.transition(filter, animations.$emphasized-style),
@@ -78,7 +78,7 @@ img {
   padding: paddings.$s;
   border-radius: paddings.$s;
 
-  @include animations.define-with-host-context {
+  @include animations.when-motion-host-context {
     @include animations.multiple-transitions((opacity, visibility));
   }
 

--- a/src/app/resume-page/section-title/section-title.component.scss
+++ b/src/app/resume-page/section-title/section-title.component.scss
@@ -16,7 +16,7 @@
   background-color: var(--app-color-toolbar-background);
   color: var(--ui-text);
 
-  @include animations.define-with-host-context {
+  @include animations.when-motion-host-context {
     @include animations.multiple-transitions(
       (color, background-color, border-color),
       animations.$emphasized-style

--- a/src/app/sports-page/sports-page.component.scss
+++ b/src/app/sports-page/sports-page.component.scss
@@ -11,10 +11,10 @@
 @include texts.page;
 
 img.sports-equation {
-  @include theming.host-context-dark-mode-only {
+  @include theming.when-dark-mode-host-context {
     filter: invert(1);
   }
-  @include animations.define-with-host-context {
+  @include animations.when-motion-host-context {
     @include animations.single-transition(filter, animations.$emphasized-style);
   }
 }

--- a/src/sass/_animations.scss
+++ b/src/sass/_animations.scss
@@ -1,6 +1,7 @@
 @use 'sass:list';
 @use 'sass:map';
 @use 'sass:selector';
+@use 'helpers/root-attribute';
 
 // https://m3.material.io/styles/motion
 // To be in sync with animations.ts
@@ -50,37 +51,25 @@ $emphasized-style: (
   @return $property map.get($style, duration) map.get($style, timing-function);
 }
 
-$_reduced-motion-selector: 'html:not([data-reduced-motion])';
-@mixin define-with-host-context() {
-  @at-root {
-    // 👇 Angular adds [_nghost-ng-g4rb4g3] when using :host-context(selector) twice to:
-    //      - Match selector in host: `selector:host`
-    //      - Match selector in any host's ancestor: `selector :host`
-    //    In this case, given selector is `html`, `html:host` makes no sense as we know the component
-    //    will never be `<html>`
-    //
-    //    Example output:
-    //      html:not([data-reduced-motion])[_nghost-ng-g4rb4g3] selector[_ngcontent-ng-cp00p],
-    //      html:not([data-reduced-motion]) [_nghost-ng-g4rb4g3] selector[_ngcontent-ng-cp00p],
-    //
-    //    First one could be omitted. There is an issue that slightly talks about it in Angular repo:
-    //    https://github.com/angular/angular/issues/51954
-    //    But the point of applying `:host-context(html)` was not successfully explained
-    //    It's appearing in production builds. Taking note to create an issue about this.
-    #{selector.nest(':host-context(#{$_reduced-motion-selector})', &)} {
-      @media (prefers-reduced-motion: no-preference) {
-        @content;
-      }
+$_reduced-motion-attribute-selector: '[data-reduced-motion]';
+$_no-reduced-motion-selector: ':not(#{$_reduced-motion-attribute-selector})';
+@mixin when-motion-host-context() {
+  @include root-attribute.host-context($_no-reduced-motion-selector) {
+    @include no-reduced-motion-preference {
+      @content;
+    }
+  }
+}
+@mixin when-motion() {
+  @include root-attribute.context($_no-reduced-motion-selector) {
+    @include no-reduced-motion-preference {
+      @content;
     }
   }
 }
 
-@mixin define {
-  @at-root {
-    #{selector.nest($_reduced-motion-selector, &)} {
-      @media (prefers-reduced-motion: no-preference) {
-        @content;
-      }
-    }
+@mixin no-reduced-motion-preference() {
+  @media (prefers-reduced-motion: no-preference) {
+    @content;
   }
 }

--- a/src/sass/_theming.scss
+++ b/src/sass/_theming.scss
@@ -1,7 +1,7 @@
 @use 'themes/constants';
 @use 'sass:selector';
+@use 'helpers/root-attribute';
 @import 'helpers/scss-to-css-vars';
-@import 'helpers/define-global-host-context';
 
 @mixin define-theme($theme) {
   @each $scheme in map-get($theme, schemes) {
@@ -50,11 +50,11 @@
 
 $_no-color-scheme-attribute-selector: ':not([data-color-scheme])';
 $_dark-mode-attribute-selector: '[data-color-scheme="dark"]';
-@mixin host-context-dark-mode-only {
-  @include define-global-host-context($_dark-mode-attribute-selector) {
+@mixin when-dark-mode-host-context {
+  @include root-attribute.host-context($_dark-mode-attribute-selector) {
     @content;
   }
-  @include define-global-host-context($_no-color-scheme-attribute-selector) {
+  @include root-attribute.host-context($_no-color-scheme-attribute-selector) {
     @media (prefers-color-scheme: dark) {
       @content;
     }

--- a/src/sass/helpers/_root-attribute.scss
+++ b/src/sass/helpers/_root-attribute.scss
@@ -1,8 +1,8 @@
 @use 'sass:selector';
 @use 'sass:string';
 
-@mixin define-global-host-context($attributeSelector) {
-  $selector: assert-is-attribute-selector($attributeSelector);
+$_root-selector: 'html'; // could use :root 🤷
+@mixin host-context($attributeSelector) {
   @at-root {
     // 👇 Angular adds [_nghost-ng-g4rb4g3] when using :host-context(selector) twice to:
     //      - Match selector in host: `selector:host`
@@ -18,13 +18,28 @@
     //    https://github.com/angular/angular/issues/51954
     //    But the point of applying `:host-context(html)` was not successfully explained
     //    It's appearing in production builds. Taking note to create an issue about this.
-    #{selector.nest(':host-context(html#{$selector})', &)} {
+    #{selector.nest(':host-context(#{_root-attribute-selector($attributeSelector)})', &)} {
       @content;
     }
   }
 }
 
-@function assert-is-attribute-selector($selector) {
+@mixin context($attributeSelector) {
+  @at-root {
+    #{selector.nest(_root-attribute-selector($attributeSelector), &)} {
+      @content;
+    }
+  }
+}
+
+@function _root-attribute-selector($attributeSelector) {
+  @return selector.append(
+    $_root-selector,
+    _assert-is-attribute-selector($attributeSelector)
+  );
+}
+
+@function _assert-is-attribute-selector($selector) {
   $openingBrace: string.index($selector, '[');
   $closingBrace: string.index($selector, ']');
 

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -28,7 +28,7 @@ body {
   // Do not allow scroll "bounce" effect
   overscroll-behavior: none;
 
-  @include animations.define {
+  @include animations.when-motion {
     @include animations.multiple-transitions(
       (color, background-color),
       animations.$emphasized-style
@@ -51,7 +51,7 @@ a {
   text-decoration-line: underline;
   text-decoration-thickness: 1px;
 
-  @include animations.define {
+  @include animations.when-motion {
     @include animations.multiple-transitions(
       (color, text-decoration-color),
       animations.$emphasized-style


### PR DESCRIPTION
Adds helpers to detect root element attributes in order to act accordingly. Root element attribute: `html[data-color-scheme]` for instance.

Both for use with global styles (there are some animations in body) and in component styles with `:host-context`

Replaces animations initial `defines-with-host-context` for generic one

Rename `define-` with `when-`: more semantic
