### PR TITLE
refactor: use flexbox for main page elements

### DIFF
--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -11,4 +11,18 @@
   top: header.$height;
   min-height: calc(100% - #{header.$height});
   width: 100%;
+
+  display: flex;
+}
+
+main {
+  // 👇 For children to grow to max height
+  display: flex;
+  width: 100%;
+  ::ng-deep > * {
+    width: 100%;
+  }
+}
+router-outlet {
+  display: none;
 }

--- a/src/app/calendar-page/calendar-page.component.scss
+++ b/src/app/calendar-page/calendar-page.component.scss
@@ -2,8 +2,7 @@
 @use 'paddings';
 
 :host {
-  @include page.full-size;
-  padding-top: paddings.$l;
+  padding-top: page.$padding;
 
   display: flex;
   flex-direction: column;

--- a/src/app/not-found-page/not-found-page.component.scss
+++ b/src/app/not-found-page/not-found-page.component.scss
@@ -5,17 +5,19 @@
 @use 'paddings';
 
 :host {
-  @include page.full-size;
   display: flex;
+  flex-direction: column;
+
   justify-content: center;
   align-items: center;
-  flex-direction: column;
+
   gap: margins.$m;
-  padding: paddings.$m;
+  padding: page.$padding;
 }
 
 .icon {
   font-size: 96px;
+  line-height: 1;
 }
 
 main,

--- a/src/sass/_page.scss
+++ b/src/sass/_page.scss
@@ -1,9 +1,3 @@
 @use 'paddings';
 
-@mixin full-size {
-  position: absolute;
-  width: 100%;
-  min-height: 100%;
-}
-
 $padding: paddings.$l;


### PR DESCRIPTION
To avoid absolute positionings. Flexbox is more powerful.

Plus set the not found emoji to take same height as font size via line height
