### PR TITLE
fix: remove fixed date from gifts page "Last Update" link

### DIFF
--- a/src/app/gifts-page/gifts-page.component.html
+++ b/src/app/gifts-page/gifts-page.component.html
@@ -22,8 +22,7 @@
   </ul>
   <p>
     It's updated from time to time. You can checkout
-    <a
-      href="https://www.giftster.com/gift/hz6ij/#:~:text=purchase-,Last%20update,-May%2014%2C%202024"
+    <a href="https://www.giftster.com/gift/hz6ij/#:~:text=Last%20update"
       >last time it was updated at the bottom of the page</a
     >
   </p>


### PR DESCRIPTION
Otherwise link won't work gifts page gets updated :P 
