### PR TITLE
feat: add underline to links

### DIFF
--- a/src/app/resume-page/card/card-header/card-header-title/card-header-title.component.scss
+++ b/src/app/resume-page/card/card-header/card-header-title/card-header-title.component.scss
@@ -1,7 +1,3 @@
 :host {
   font-size: 1.15rem;
 }
-
-::ng-deep a {
-  text-decoration: none;
-}

--- a/src/app/resume-page/education-section/education-item/education-item.component.html
+++ b/src/app/resume-page/education-section/education-item/education-item.component.html
@@ -8,13 +8,8 @@
       </app-card-header-image>
     </app-link>
     <app-card-header-texts>
-      <app-card-header-title>
-        <app-link
-          [href]="_item.institution.website?.toString()"
-          appTestId="institution-name"
-        >
-          {{ _institutionDisplayName }}
-        </app-link>
+      <app-card-header-title appTestId="institution-name">
+        {{ _institutionDisplayName }}
       </app-card-header-title>
       <app-card-header-subtitle appTestId="study-type">
         {{ _item.studyType }}

--- a/src/app/resume-page/education-section/education-item/education-item.component.spec.ts
+++ b/src/app/resume-page/education-section/education-item/education-item.component.spec.ts
@@ -75,12 +75,10 @@ describe('EducationItemComponent', () => {
     })
     setEducationItem(fixture, { institution })
 
-    const anchorElement = fixture.debugElement
-      .query(byTestId('institution-name'))
-      .query(By.css('a'))
-    expect(anchorElement).toBeTruthy()
-    expect(anchorElement.attributes['href']).toEqual(website)
-    expect(anchorElement.nativeElement.textContent.trim()).toEqual(name)
+    const titleElement = fixture.debugElement.query(
+      byTestId('institution-name'),
+    )
+    expect(titleElement.nativeElement.textContent.trim()).toEqual(name)
   })
 
   describe('when name is long and there is short name', () => {

--- a/src/app/resume-page/experience-section/experience-item/experience-item.component.html
+++ b/src/app/resume-page/experience-section/experience-item/experience-item.component.html
@@ -8,13 +8,8 @@
       </app-card-header-image>
     </app-link>
     <app-card-header-texts>
-      <app-card-header-title>
-        <app-link
-          [href]="_item.company.website?.toString()"
-          appTestId="company-name"
-        >
-          {{ _item.company.name }}
-        </app-link>
+      <app-card-header-title appTestId="company-name">
+        {{ _item.company.name }}
       </app-card-header-title>
       <app-card-header-subtitle appTestId="position">
         {{ _item.position }}

--- a/src/app/resume-page/experience-section/experience-item/experience-item.component.spec.ts
+++ b/src/app/resume-page/experience-section/experience-item/experience-item.component.spec.ts
@@ -66,7 +66,7 @@ describe('ExperienceItem', () => {
       ).toBe(imageUrl)
     })
 
-    it("should display company name with link to company's website", () => {
+    it('should display company name', () => {
       const name = 'Sample company name'
       const website = 'https://example.org/'
       setExperienceItem(fixture, {
@@ -77,13 +77,8 @@ describe('ExperienceItem', () => {
         }),
       })
 
-      const anchorElement = fixture.debugElement
-        .query(byTestId('company-name'))
-        .query(By.css('a'))
-      expect(anchorElement).toBeTruthy()
-      expect(anchorElement.attributes['href']).toEqual(website)
-
-      expect(anchorElement.nativeElement.textContent.trim()).toEqual(name)
+      const titleElement = fixture.debugElement.query(byTestId('company-name'))
+      expect(titleElement.nativeElement.textContent.trim()).toEqual(name)
     })
   })
   describe('position', () => {

--- a/src/app/resume-page/projects-section/project-item/project-item.component.html
+++ b/src/app/resume-page/projects-section/project-item/project-item.component.html
@@ -12,9 +12,7 @@
     </app-link>
     <app-card-header-texts>
       <app-card-header-title appTestId="name">
-        <app-link [href]="_item.website?.toString()">
-          {{ _item.name }}
-        </app-link>
+        {{ _item.name }}
       </app-card-header-title>
       <app-card-header-subtitle *ngIf="_item.roles.length" appTestId="role">
         <!-- TODO: display all roles, for current case just 1 is enough -->

--- a/src/app/resume-page/projects-section/project-item/project-item.component.spec.ts
+++ b/src/app/resume-page/projects-section/project-item/project-item.component.spec.ts
@@ -81,13 +81,8 @@ describe('ProjectItemComponent', () => {
 
     setProjectItem(fixture, { name, website })
 
-    const anchorElement = fixture.debugElement
-      .query(byTestId('name'))
-      .query(By.css('a'))
-    expect(anchorElement).toBeTruthy()
-    expect(anchorElement.attributes['href']).toEqual(website.toString())
-
-    expect(anchorElement.nativeElement.textContent.trim()).toEqual(name)
+    const titleElement = fixture.debugElement.query(byTestId('name'))
+    expect(titleElement.nativeElement.textContent.trim()).toEqual(name)
   })
 
   describe('when no roles exist', () => {

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -58,14 +58,8 @@ a {
     );
   }
 
-  &:visited {
-    color: var(--sys-color-primary);
-  }
-
-  &:hover {
-    color: var(--sys-color-primary);
-  }
-
+  &:visited,
+  &:hover,
   &:active {
     color: var(--sys-color-primary);
   }


### PR DESCRIPTION
Lighthouse CI started failing on `main` branch. Failure:

```
  ✘  link-in-text-block failure for minScore assertion
       Links rely on color to be distinguishable.
       https://dequeuniversity.com/rules/axe/4.8/link-in-text-block

        expected: >=0.9
           found: 0
      all values: 0, 0, 0
```

Which makes sense, as just color is used for links

So adding underline to distinguish them too. To do so, removing the rule that removed the underline added by default to all links. That by mistake was being applied to all elements, not just card header title elements.

In card header title elements, links with underline don't look nice, so removing them. Adding it to the things to handle later. An idea could be adding an icon next to the title that contains the link
