### PR TITLE
refactor: toolbar icon into button directive

### DIFF
--- a/src/app/header/light-dark-toggle/light-dark-toggle.component.html
+++ b/src/app/header/light-dark-toggle/light-dark-toggle.component.html
@@ -1,14 +1,14 @@
-<app-toolbar-icon
+<button
+  app-toolbar-button
   [icon]="MaterialSymbol.DarkMode"
   (click)="colorSchemeService.toggleDarkLight()"
-  ariaLabel="Switch to dark mode"
+  aria-label="Switch to dark mode"
   class="light-only"
-  role="status"
-></app-toolbar-icon>
-<app-toolbar-icon
+></button>
+<button
+  app-toolbar-button
   [icon]="MaterialSymbol.LightMode"
   (click)="colorSchemeService.toggleDarkLight()"
-  ariaLabel="Switch to light mode"
+  aria-label="Switch to light mode"
   class="dark-only"
-  role="status"
-></app-toolbar-icon>
+></button>

--- a/src/app/header/light-dark-toggle/light-dark-toggle.component.spec.ts
+++ b/src/app/header/light-dark-toggle/light-dark-toggle.component.spec.ts
@@ -13,7 +13,7 @@ import {
 } from '@/test/helpers/visibility'
 import { findMaterialSymbolByText } from '@/test/helpers/material-symbols'
 import { byComponent } from '@/test/helpers/component-query-predicates'
-import { ToolbarIconComponent } from '../toolbar-icon/toolbar-icon.component'
+import { ToolbarButtonComponent } from '../toolbar-button/toolbar-button.component'
 
 describe('LightDarkToggleComponent', () => {
   let component: LightDarkToggleComponent
@@ -76,7 +76,7 @@ describe('LightDarkToggleComponent', () => {
       ;[fixture, component] = makeSut({ colorSchemeService })
 
       fixture.debugElement
-        .query(byComponent(ToolbarIconComponent))
+        .query(byComponent(ToolbarButtonComponent))
         .triggerEventHandler('click')
 
       expect(colorSchemeService.toggleDarkLight).toHaveBeenCalled()

--- a/src/app/header/light-dark-toggle/light-dark-toggle.component.ts
+++ b/src/app/header/light-dark-toggle/light-dark-toggle.component.ts
@@ -2,12 +2,12 @@ import { Component } from '@angular/core'
 import { MaterialSymbolDirective } from '@/common/material-symbol.directive'
 import { DarkMode, LightMode } from '../../material-symbols'
 import { ColorSchemeService } from './color-scheme.service'
-import { ToolbarIconComponent } from '../toolbar-icon/toolbar-icon.component'
+import { ToolbarButtonComponent } from '../toolbar-button/toolbar-button.component'
 
 @Component({
   selector: 'app-light-dark-toggle',
   standalone: true,
-  imports: [MaterialSymbolDirective, ToolbarIconComponent],
+  imports: [MaterialSymbolDirective, ToolbarButtonComponent],
   templateUrl: './light-dark-toggle.component.html',
   styleUrl: './light-dark-toggle.component.scss',
 })

--- a/src/app/header/navigation-tabs/navigation-tabs.component.ts
+++ b/src/app/header/navigation-tabs/navigation-tabs.component.ts
@@ -10,7 +10,7 @@ import {
 import { TabComponent } from '../tab/tab.component'
 import { TabsComponent } from '../tabs/tabs.component'
 import { RouterLink, RouterLinkActive } from '@angular/router'
-import { ToolbarIconComponent } from '../toolbar-icon/toolbar-icon.component'
+import { ToolbarButtonComponent } from '../toolbar-button/toolbar-button.component'
 
 @Component({
   selector: 'app-navigation-tabs',
@@ -20,7 +20,7 @@ import { ToolbarIconComponent } from '../toolbar-icon/toolbar-icon.component'
     TabComponent,
     RouterLink,
     RouterLinkActive,
-    ToolbarIconComponent,
+    ToolbarButtonComponent,
   ],
   templateUrl: './navigation-tabs.component.html',
   styleUrl: './navigation-tabs.component.scss',

--- a/src/app/header/toolbar-button/toolbar-button.component.html
+++ b/src/app/header/toolbar-button/toolbar-button.component.html
@@ -1,0 +1,1 @@
+<span appMaterialSymbol>{{ icon }}</span>

--- a/src/app/header/toolbar-button/toolbar-button.component.scss
+++ b/src/app/header/toolbar-button/toolbar-button.component.scss
@@ -7,10 +7,6 @@
   display: inline flex;
   flex-direction: column;
   justify-content: center;
-}
-
-button {
-  display: contents;
   cursor: pointer;
 
   color: var(--icon-default);

--- a/src/app/header/toolbar-button/toolbar-button.component.spec.ts
+++ b/src/app/header/toolbar-button/toolbar-button.component.spec.ts
@@ -1,10 +1,8 @@
-import { ToolbarIconComponent } from './toolbar-icon.component'
+import { ToolbarButtonComponent } from './toolbar-button.component'
 import { componentTestSetup } from '@/test/helpers/component-test-setup'
 import { MATERIAL_SYMBOLS_SELECTOR } from '@/test/helpers/material-symbols'
-import { By } from '@angular/platform-browser'
-import { ATTRIBUTE_ARIA_LABEL } from '@/test/helpers/aria'
 
-describe('ToolbarIconComponent', () => {
+describe('ToolbarButtonComponent', () => {
   it('should create', () => {
     const [fixture, component] = makeSut()
     fixture.detectChanges()
@@ -19,23 +17,11 @@ describe('ToolbarIconComponent', () => {
     const iconElement = fixture.debugElement.query(MATERIAL_SYMBOLS_SELECTOR)
     expect(iconElement.nativeElement.textContent.trim()).toBe(DUMMY_ICON)
   })
-
-  it('should set ARIA label', () => {
-    const [fixture] = makeSut()
-    fixture.detectChanges()
-
-    const buttonElement = fixture.debugElement.query(By.css('button'))
-    expect(buttonElement.attributes[ATTRIBUTE_ARIA_LABEL]).toBe(
-      DUMMY_ARIA_LABEL,
-    )
-  })
 })
 
 const DUMMY_ICON = 'icon'
-const DUMMY_ARIA_LABEL = 'label'
 const makeSut = () => {
-  const [fixture, component] = componentTestSetup(ToolbarIconComponent)
+  const [fixture, component] = componentTestSetup(ToolbarButtonComponent)
   component.icon = DUMMY_ICON
-  component.ariaLabel = DUMMY_ARIA_LABEL
   return [fixture, component] as const
 }

--- a/src/app/header/toolbar-button/toolbar-button.component.ts
+++ b/src/app/header/toolbar-button/toolbar-button.component.ts
@@ -2,14 +2,14 @@ import { ChangeDetectionStrategy, Component, Input } from '@angular/core'
 import { MaterialSymbolDirective } from '@/common/material-symbol.directive'
 
 @Component({
-  selector: 'app-toolbar-icon',
+  // eslint-disable-next-line @angular-eslint/component-selector
+  selector: '[app-toolbar-button]',
   standalone: true,
   imports: [MaterialSymbolDirective],
-  templateUrl: './toolbar-icon.component.html',
-  styleUrl: './toolbar-icon.component.scss',
+  templateUrl: './toolbar-button.component.html',
+  styleUrl: './toolbar-button.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class ToolbarIconComponent {
+export class ToolbarButtonComponent {
   @Input({ required: true }) public icon!: string
-  @Input({ required: true }) public ariaLabel!: string
 }

--- a/src/app/header/toolbar-icon/toolbar-icon.component.html
+++ b/src/app/header/toolbar-icon/toolbar-icon.component.html
@@ -1,3 +1,0 @@
-<button [attr.aria-label]="ariaLabel">
-  <span appMaterialSymbol>{{ icon }}</span>
-</button>


### PR DESCRIPTION
Mistakenly thought that toolbar icon wasn't clickable when adding tabs in #1245. So to solve it, decided to make it a `button` to see if that changed something. However, now that I'm writing this I know that the reason may be that it was disabled or something in the test side.

Anyway this transformation is a win [as mentioned in Angular docs about component selectors](https://angular.dev/guide/components/selectors#when-to-use-an-attribute-selector):

> This approach allows consumers of the component to directly use all the element's standard APIs without extra work. This is especially valuable for ARIA attributes such as aria-label.

Renaming from `icon` to `button` as now only works for buttons. Though my Java-like mind is wishing for `app-toolbar-icon-button` TBH 😛 
