### PR TITLE
test(tabs): add pagination & scroll component tests

### DIFF
--- a/src/app/header/tabs/tabs.component.spec.cy.ts
+++ b/src/app/header/tabs/tabs.component.spec.cy.ts
@@ -1,26 +1,178 @@
-import { mount } from 'cypress/angular'
 import { TabsComponent } from './tabs.component'
 import { TabComponent } from '../tab/tab.component'
+import { MountResponse } from 'cypress/angular'
+import { By } from '@angular/platform-browser'
 
 describe('TabsComponent', () => {
   it('should mount', () => {
-    mount(TabsComponent)
+    cy.mount(TabsComponent)
   })
 
+  const PREV_BUTTON_SELECTOR = 'button[aria-label*="Previous"]'
+  const NEXT_BUTTON_SELECTOR = 'button[aria-label*="Next"]'
+  const TABS_CONTAINER_SELECTOR = '[role="tablist"]'
   describe('when all tabs fit the screen', () => {
     beforeEach(() => {
       cy.viewport('macbook-16')
-      mount('<app-tabs><app-tab>Hello World</app-tab></app-tabs>', {
+      cy.mount('<app-tabs><app-tab>Hello World</app-tab></app-tabs>', {
         imports: [TabsComponent, TabComponent],
       })
     })
 
     it('should disable previous paginator', () => {
-      cy.get('button[aria-label*="Previous"]').should('be.disabled')
+      cy.get(PREV_BUTTON_SELECTOR).should('be.disabled')
     })
 
     it('should disable next paginator', () => {
-      cy.get('button[aria-label*="Next"]').should('be.disabled')
+      cy.get(NEXT_BUTTON_SELECTOR).should('be.disabled')
+    })
+  })
+
+  describe('when all tabs do not fit the screen', () => {
+    const TABS = [...Array(11).keys()]
+    beforeEach(() => {
+      cy.viewport('iphone-x')
+      cy.mount(
+        `
+        <app-tabs [style.max-width.%]="100">
+        @for(tab of ${JSON.stringify(TABS)}; track $index) {
+            <app-tab>
+                <span style="white-space: nowrap">Tab {{ tab }}</span>
+            </app-tab>
+        }
+        </app-tabs>`,
+        {
+          imports: [TabsComponent, TabComponent],
+        },
+      ).then((wrapper) => {
+        cy.wrap(wrapper).as('angular')
+      })
+    })
+
+    describe('initially', () => {
+      beforeEach(() => {
+        cy.get(TABS_CONTAINER_SELECTOR).should(($element) => {
+          expect($element).to.have.length(1)
+          const scrollLeft = $element[0].scrollLeft
+          expect(scrollLeft).to.equal(
+            0,
+            'tabs container should not be scrolled',
+          )
+        })
+      })
+      it('should disable previous paginator', () => {
+        cy.get(PREV_BUTTON_SELECTOR).should('be.disabled')
+      })
+
+      it('should enable next paginator', () => {
+        cy.get(NEXT_BUTTON_SELECTOR).should('be.enabled')
+      })
+
+      describe('when tapping next paginator', () => {
+        beforeEach(() => {
+          cy.get(NEXT_BUTTON_SELECTOR).click()
+        })
+
+        it('should scroll a bit to see next tabs', () => {
+          cy.get(TABS_CONTAINER_SELECTOR).should(($element) => {
+            expect($element).to.have.length(1)
+            const element = $element[0]
+            expect(element.scrollLeft).to.be.greaterThan(
+              minimumScrollPxDistance(element),
+            )
+          })
+        })
+      })
+    })
+
+    const MIDDLE_TAB_INDEX = Math.ceil(TABS.length / 2)
+    const MIDDLE_TAB_SELECTOR = `app-tab:nth-child(${MIDDLE_TAB_INDEX})`
+    describe('when scrolled in the middle', () => {
+      beforeEach((done) => {
+        cy.get(MIDDLE_TAB_SELECTOR)
+          .scrollIntoView()
+          .then(() => done())
+      })
+
+      it('should enable previous paginator', () => {
+        cy.get(PREV_BUTTON_SELECTOR).should('be.enabled')
+      })
+
+      it('should enable next paginator', () => {
+        cy.get(NEXT_BUTTON_SELECTOR).should('be.enabled')
+      })
+    })
+
+    describe('when scrolled until the end', () => {
+      const maxScrollLeft = (element: HTMLElement) => {
+        return element.scrollWidth - element.offsetWidth
+      }
+
+      beforeEach((done) => {
+        // noinspection CypressCommandSubjectValidation
+        cy.get('app-tab:last-child')
+          .scrollIntoView()
+          .then(() => done())
+      })
+
+      beforeEach(() => {
+        cy.get(TABS_CONTAINER_SELECTOR).should(($element) => {
+          expect($element).to.have.length(1)
+          const element = $element[0]
+          expect(element.scrollLeft).to.equal(
+            maxScrollLeft(element),
+            'tabs container should be scrolled at the end',
+          )
+        })
+      })
+
+      it('should enable previous paginator', () => {
+        cy.get(PREV_BUTTON_SELECTOR).should('be.enabled')
+      })
+
+      it('should disable next paginator', () => {
+        cy.get(NEXT_BUTTON_SELECTOR).should('be.disabled')
+      })
+
+      describe('when tapping previous paginator', () => {
+        beforeEach(() => {
+          cy.get(PREV_BUTTON_SELECTOR).should('be.enabled').and('be.visible')
+          //👇 Why click needs to be forced? No idea 🙃
+          cy.get(PREV_BUTTON_SELECTOR).click({ force: true })
+        })
+
+        it('should scroll a bit to see previous tabs', () => {
+          cy.get(TABS_CONTAINER_SELECTOR).should(($element) => {
+            expect($element).to.have.length(1)
+            const element = $element[0]
+            expect(element.scrollLeft).to.be.lessThan(
+              maxScrollLeft(element) - minimumScrollPxDistance(element),
+            )
+          })
+        })
+      })
+    })
+
+    describe('when marking a tab as active', () => {
+      beforeEach(() => {
+        // noinspection CYUnresolvedAlias
+        cy.get<MountResponse<unknown>>('@angular').then((angular) => {
+          const tabsElement = angular.fixture.debugElement.query(
+            By.css('app-tabs'),
+          )
+          const tabsComponent = tabsElement.componentInstance as TabsComponent
+          tabsComponent.selectedIndex = MIDDLE_TAB_INDEX - 1
+        })
+      })
+
+      it('should scroll to the active tab', () => {
+        cy.get(MIDDLE_TAB_SELECTOR).should('be.visible')
+      })
     })
   })
 })
+
+//👇 Otherwise if it's bigger, it times out in the last test about scrolling to see previous tabs
+//   due to 'smooth' scrolling. Actual implementation is 1/3
+const minimumScrollPxDistance = (element: HTMLElement) =>
+  element.offsetWidth / 20

--- a/src/app/header/tabs/tabs.component.spec.cy.ts
+++ b/src/app/header/tabs/tabs.component.spec.cy.ts
@@ -54,8 +54,7 @@ describe('TabsComponent', () => {
       beforeEach(() => {
         cy.get(TABS_CONTAINER_SELECTOR).should(($element) => {
           expect($element).to.have.length(1)
-          const scrollLeft = $element[0].scrollLeft
-          expect(scrollLeft).to.equal(
+          expect($element[0].scrollLeft).to.equal(
             0,
             'tabs container should not be scrolled',
           )
@@ -117,7 +116,7 @@ describe('TabsComponent', () => {
           const element = $element[0]
           expect(element.scrollLeft).to.equal(
             maxScrollLeft(element),
-            'tabs container should be scrolled at the end',
+            'tabs container should be scrolled until the end',
           )
         })
       })

--- a/src/app/header/tabs/tabs.component.spec.cy.ts
+++ b/src/app/header/tabs/tabs.component.spec.cy.ts
@@ -45,6 +45,7 @@ describe('TabsComponent', () => {
           imports: [TabsComponent, TabComponent],
         },
       ).then((wrapper) => {
+        // noinspection CYUnusedAlias (used below)
         cy.wrap(wrapper).as('angular')
       })
     })
@@ -88,10 +89,8 @@ describe('TabsComponent', () => {
     const MIDDLE_TAB_INDEX = Math.ceil(TABS.length / 2)
     const MIDDLE_TAB_SELECTOR = `app-tab:nth-child(${MIDDLE_TAB_INDEX})`
     describe('when scrolled in the middle', () => {
-      beforeEach((done) => {
-        cy.get(MIDDLE_TAB_SELECTOR)
-          .scrollIntoView()
-          .then(() => done())
+      beforeEach(() => {
+        cy.get(MIDDLE_TAB_SELECTOR).scrollIntoView()
       })
 
       it('should enable previous paginator', () => {
@@ -108,11 +107,8 @@ describe('TabsComponent', () => {
         return element.scrollWidth - element.offsetWidth
       }
 
-      beforeEach((done) => {
-        // noinspection CypressCommandSubjectValidation
-        cy.get('app-tab:last-child')
-          .scrollIntoView()
-          .then(() => done())
+      beforeEach(() => {
+        cy.get('app-tab:last-child').scrollIntoView()
       })
 
       beforeEach(() => {

--- a/src/app/header/tabs/tabs.component.spec.cy.ts
+++ b/src/app/header/tabs/tabs.component.spec.cy.ts
@@ -131,7 +131,7 @@ describe('TabsComponent', () => {
 
       describe('when tapping previous paginator', () => {
         beforeEach(() => {
-          cy.get(PREV_BUTTON_SELECTOR).should('be.enabled').and('be.visible')
+          cy.get(PREV_BUTTON_SELECTOR).should('be.enabled')
           //👇 Why click needs to be forced? No idea 🙃
           cy.get(PREV_BUTTON_SELECTOR).click({ force: true })
         })

--- a/src/app/header/tabs/tabs.component.spec.ts
+++ b/src/app/header/tabs/tabs.component.spec.ts
@@ -66,16 +66,6 @@ describe('TabsComponent', () => {
     expect(findLeftArrow(fixture.debugElement)).toBeTruthy()
     expect(findRightArrow(fixture.debugElement)).toBeTruthy()
   })
-
-  // TODO: Component tests for
-  //  - Enabled/disabled arrows:
-  //     - All disabled if fit in screen
-  //     - Prev disabled when first tab visible
-  //     - Next disabled when last tab visible
-  //     - None disabled if in mid
-  //  - Scroll
-  //     - When tapping prev/next buttons
-  //     - When active
 })
 
 const makeSut = () => componentTestSetup(TabsComponent)


### PR DESCRIPTION
Adds Cypress component tests for tabs component for pagination & scrolling. It's better to add them there given Cypress will retry assertions until they succeed, which comes very handy with scrolling. Building on shoulder of that for those tests then.

Also: 
 - Use `cy.mount` to avoid importing 