### PR TITLE
ci: rename test job to unit test

### DIFF
--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -37,8 +37,8 @@ jobs:
       - name: Ensure no pending changes
         run: cd .ci && make ensure-no-pending-changes
 
-  test:
-    name: All tests
+  unit-test:
+    name: Unit tests
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -119,7 +119,7 @@ jobs:
 
   coverage:
     name: Coverage
-    needs: [test, component-test]
+    needs: [unit-test, component-test]
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:


### PR DESCRIPTION
As it is what it is. All test may be confusing, as Cypress Component Testing tests are not run there for instance

Once the job runs with changed name, will change branch protection settings to make the new job name the required check to pass for PRs to merge
