### PR TITLE
test: configure Codecov

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,14 @@
+coverage:
+  status:
+    patch:
+      default:
+        threshold: 5%
+    project:
+      default:
+        threshold: 5%
+comment:
+  layout: 'header, diff, files, footer'
+  hide_project_coverage: false
+
+codecov:
+  require_ci_to_pass: false

--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
     "//2": "👇 Cypress executes it to perform custom reporting. With this:",
     "//3": "    - **same filename for local/CI**: the 'mv' command is run in both local & CI, so JSON coverage filename is the same",
     "//4": "    - **.nycrc* config files avoided:** could be mistakenly used by other tools",
-    "coverage:report": "nyc report --reporter json --report-dir coverage && mv -f coverage/coverage-final.json coverage/component-testing.json"
+    "coverage:report": "nyc report --reporter json --report-dir coverage && mv -f coverage/coverage-final.json coverage/component-testing.json",
+    "validate-codecov-yml": "curl -X POST --data-binary @codecov.yml https://codecov.io/validate"
   },
   "dependencies": {
     "@angular/animations": "18.0.5",


### PR DESCRIPTION
Does some changes to improve coverage:
- The `const findEntry` statement wasn't marked as hit. Probably because inlined by webpack.
- Same for `_onIntersectChanged`. Moving everything to another function that sets up & handles changes

This has helped testing a bit Codecov. For instance, seems the Codecov GitHub app needs to be installed for full functionality
