### PR TITLE
ci: configure Codecov to don't wait for CI

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -7,8 +7,9 @@ coverage:
       default:
         threshold: 5%
 comment:
-  layout: 'header, diff, files, footer'
   hide_project_coverage: false
 
 codecov:
   require_ci_to_pass: false
+  notify:
+    wait_for_ci: false


### PR DESCRIPTION
To try speed it up

Also removes the `layout` configuration, which does almost nothing
