### PR TITLE
fix: add Microsoft Word as csutom tech entry

### DIFF
--- a/src/app/resume-page/technology/custom-display-name-entries.ts
+++ b/src/app/resume-page/technology/custom-display-name-entries.ts
@@ -1,4 +1,5 @@
 export const CUSTOM_DISPLAY_NAME_ENTRIES: ReadonlyArray<[string, string]> = [
+  ['microsoftword', 'Microsoft Word'],
   ['rspec', 'RSpec'],
   ['zenqms', 'ZenQMS'],
   ['karmarunner', 'Karma Runner'],


### PR DESCRIPTION
Since it was removed from simple icons
