### PR TITLE
build: add tsconfig references to fix Jasmine globals

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -34,5 +34,9 @@
     "strictInjectionParameters": true,
     "strictInputAccessModifiers": true,
     "strictTemplates": true
-  }
+  },
+  "references": [
+    { "path": "./tsconfig.app.json" },
+    { "path": "./tsconfig.spec.json" }
+  ]
 }


### PR DESCRIPTION
Since some time ago, WebStorm / JetBrains IDEs incorrectly grab chai/mocha types for Jasmine tests. See https://youtrack.jetbrains.com/issue/WEB-68686. Which relates to https://youtrack.jetbrains.com/issue/WEB-68998

Solution offered in there is to add a ["solution" style tsconfig](https://devblogs.microsoft.com/typescript/announcing-typescript-3-9/#solution-style-tsconfig) referencing other `tsconfig.json`s in order for those to be taken into account.

So here we go.

Not everything is solved though, as can be seen in https://youtrack.jetbrains.com/issue/WEB-69759
