### PR TITLE
test: remove log messages from test output

### DIFF
--- a/src/app/header/navigation-tabs/navigation-tabs.component.spec.ts
+++ b/src/app/header/navigation-tabs/navigation-tabs.component.spec.ts
@@ -19,6 +19,11 @@ describe('NavigationTabsComponent', () => {
   const BAR_ITEM = makeNavigationItemFromRoutePath(BAR_ROUTE.path)
   const ITEMS = [FOO_ITEM, BAR_ITEM]
 
+  beforeEach(() => {
+    // do not log tabs component messages
+    spyOn(console, 'log')
+  })
+
   it('should create', () => {
     const [fixture, component] = makeSut()
     fixture.detectChanges()

--- a/src/app/header/tabs/tabs.component.spec.ts
+++ b/src/app/header/tabs/tabs.component.spec.ts
@@ -13,6 +13,10 @@ import { By } from '@angular/platform-browser'
 import { getComponentInstance } from '@/test/helpers/get-component-instance'
 
 describe('TabsComponent', () => {
+  beforeEach(() => {
+    spyOn(console, 'log')
+  })
+
   it('should create', () => {
     const [fixture, component] = makeSut()
     fixture.detectChanges()
@@ -53,18 +57,22 @@ describe('TabsComponent', () => {
   const findToolbarIcons = (debugElement: DebugElement) =>
     debugElement.queryAll(byComponent(ToolbarButtonComponent))
 
-  const findLeftArrow = (debugElement: DebugElement) =>
-    findByText(findToolbarIcons(debugElement), KeyboardDoubleArrowLeft)!
-
-  const findRightArrow = (debugElement: DebugElement) =>
-    findByText(findToolbarIcons(debugElement), KeyboardDoubleArrowRight)!
-
   it('should display left and right arrows', () => {
     const [fixture] = makeSut()
     fixture.detectChanges()
 
-    expect(findLeftArrow(fixture.debugElement)).toBeTruthy()
-    expect(findRightArrow(fixture.debugElement)).toBeTruthy()
+    expect(
+      findByText(
+        findToolbarIcons(fixture.debugElement),
+        KeyboardDoubleArrowLeft,
+      )!,
+    ).toBeTruthy()
+    expect(
+      findByText(
+        findToolbarIcons(fixture.debugElement),
+        KeyboardDoubleArrowRight,
+      )!,
+    ).toBeTruthy()
   })
 })
 

--- a/src/app/resume-page/profile-section/profile-contacts/profile-contacts.component.spec.ts
+++ b/src/app/resume-page/profile-section/profile-contacts/profile-contacts.component.spec.ts
@@ -97,6 +97,7 @@ describe('ProfileContactsComponent', () => {
   })
 
   it(`should not display link if icon cannot be found`, () => {
+    const consoleErrorSpy = spyOn(console, 'error')
     const profile = makeJsonResumeBasicsProfile('non-existent')
     const profiles = [profile]
     const jsonResumeBasics = makeJsonResumeBasics({ profiles })
@@ -108,6 +109,9 @@ describe('ProfileContactsComponent', () => {
       By.css(`a[href="${profile.url}"]`),
     )
     expect(anchorElement).toBeNull()
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      jasmine.stringContaining('Icon not found'),
+    )
   })
 })
 


### PR DESCRIPTION
Unit tests output contained many console messages. Which can lead to issues understanding output in the long run. Specially in CI/CD

Remove those from test output by stubbing console logs on unit tests
