### PR TITLE
build: improve linting scripts and cypress

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,9 +1,12 @@
 {
-  "root": false,
-  "ignorePatterns": ["projects/**/*"],
+  "root": true,
+  // 👇 Added `(coverage|dist)/**/*` to be able to run 'eslint .' successfully
+  //    When upgrading to v9, can include .gitignore here. In v8, you need to add a CLI flag
+  //    Given 'eslint .' is not something ran often, it's good enough as ienough as is
+  "ignorePatterns": ["projects/**/*", "coverage/**/*", "dist/**/*"],
   "overrides": [
     {
-      "files": ["*.ts"],
+      "files": ["*.ts", "*.mts"],
       "extends": [
         "eslint:recommended",
         "plugin:@typescript-eslint/recommended",

--- a/angular.json
+++ b/angular.json
@@ -174,7 +174,12 @@
         "lint": {
           "builder": "@angular-eslint/builder:lint",
           "options": {
-            "lintFilePatterns": ["src/**/*.ts", "src/**/*.html"]
+            "lintFilePatterns": [
+              "src/**/*.ts",
+              "src/**/*.html",
+              "cypress/**/*.ts",
+              "scripts/**/*.?(m)ts"
+            ]
           }
         }
       }

--- a/cypress/support/component.ts
+++ b/cypress/support/component.ts
@@ -23,6 +23,8 @@ import { mount } from 'cypress/angular'
 // Cypress code coverage
 import '@cypress/code-coverage/support'
 
+// https://youtrack.jetbrains.com/issue/AQUA-3130/
+// noinspection CypressCommandWithoutDeclaration
 Cypress.Commands.add('mount', mount)
 
 // Example use:

--- a/cypress/support/component.ts
+++ b/cypress/support/component.ts
@@ -23,18 +23,6 @@ import { mount } from 'cypress/angular'
 // Cypress code coverage
 import '@cypress/code-coverage/support'
 
-// Augment the Cypress namespace to include type definitions for
-// your custom command.
-// Alternatively, can be defined in cypress/support/component.d.ts
-// with a <reference path="./component" /> at the top of your spec.
-declare global {
-  namespace Cypress {
-    interface Chainable {
-      mount: typeof mount
-    }
-  }
-}
-
 Cypress.Commands.add('mount', mount)
 
 // Example use:

--- a/cypress/support/cypress.d.ts
+++ b/cypress/support/cypress.d.ts
@@ -1,4 +1,4 @@
-import { mount } from 'cypress/angular'
+import { type mount } from 'cypress/angular'
 
 declare global {
   namespace Cypress {

--- a/cypress/support/cypress.d.ts
+++ b/cypress/support/cypress.d.ts
@@ -1,0 +1,9 @@
+import { mount } from 'cypress/angular'
+
+declare global {
+  namespace Cypress {
+    interface Chainable {
+      mount: typeof mount
+    }
+  }
+}

--- a/cypress/tsconfig.json
+++ b/cypress/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "extends": "../tsconfig.json",
-  "include": ["**/*.ts", "support/cypress.d.ts"],
+  "include": ["**/*.ts"],
   "compilerOptions": {
     "sourceMap": false,
     "types": ["cypress"]

--- a/cypress/tsconfig.json
+++ b/cypress/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "extends": "../tsconfig.json",
-  "include": ["**/*.ts"],
+  "include": ["**/*.ts", "support/cypress.d.ts"],
   "compilerOptions": {
     "sourceMap": false,
     "types": ["cypress"]

--- a/scripts/src/generate-release-file.mts
+++ b/scripts/src/generate-release-file.mts
@@ -9,8 +9,8 @@ import semanticRelease, {
   ReleaseType,
   Result,
 } from 'semantic-release'
-// But we get type safety given Typescript reads the JSON
 // We can always go back to an old boring read file sync if experiment goes wrong :P
+// But we get type safety given Typescript reads the JSON
 import realReleaseOptions from '../../.releaserc.json' assert { type: 'json' }
 import { getRepositoryRootDir, isMain, Log, objectToJson } from './utils.mjs'
 import { join } from 'path'


### PR DESCRIPTION
Some improvements to the linting system via ESLint:
 - Add linting to script files:
   - Including those files in `angular.json` builder to include them in `ng lint`
   - Including `.mts` files in ESLint config for Typescript (`.eslintrc.json`'s' `overrides` key)
 - Add linting to Cypress files
   - Including them in `angular.json` builder to include them in `ng lint`

Fixes Cypress linting issue about Cypress defs by using a separate definition file as stated in docs

Changes ESLint config `root` to be `true`. As it's the default when creating the config file with Angular ESLint. Though in #36 it was changed. Probably by mistake. It tells ESLint to stop looking for ESLint files in parent directories relative to that config file. Which makes sense.

Ignores `coverage` and `dist` directories when using ESLint directly with `eslint .`
