### PR TITLE
ci: try concurrency for reusable workflows

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -12,35 +12,35 @@ jobs:
     with:
       artifact-name: build
       build-run-script: 'build:pullRequest'
-  test:
-    name: Test
-    uses: ./.github/workflows/reusable-test.yml
-    secrets:
-      codecov-token: ${{ secrets.CODECOV_TOKEN }}
-  lint:
-    name: Lint
-    uses: ./.github/workflows/reusable-lint.yml
-  style:
-    name: Style
-    uses: ./.github/workflows/reusable-style.yml
-  performance:
-    name: Performance
-    needs: build
-    uses: ./.github/workflows/reusable-performance.yml
-    with:
-      build-artifact-name: build
-    secrets:
-      LHCI_GITHUB_APP_TOKEN: ${{ secrets.LHCI_GITHUB_APP_TOKEN }}
-      BUNDLEWATCH_GITHUB_TOKEN: ${{ secrets.BUNDLEWATCH_GITHUB_TOKEN }}
-  deploy-preview:
-    name: Deploy preview
-    needs: [build]
-    uses: ./.github/workflows/reusable-deploy-cloudflare-pages.yml
-    with:
-      build-artifact-name: build
-    secrets:
-      cloudflare-account-id: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-      cloudflare-api-token: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-    permissions:
-      contents: read
-      deployments: write
+  #test:
+  #  name: Test
+  #  uses: ./.github/workflows/reusable-test.yml
+  #  secrets:
+  #    codecov-token: ${{ secrets.CODECOV_TOKEN }}
+  #lint:
+  #  name: Lint
+  #  uses: ./.github/workflows/reusable-lint.yml
+  #style:
+  #  name: Style
+  #  uses: ./.github/workflows/reusable-style.yml
+  #performance:
+  #  name: Performance
+  #  needs: build
+  #  uses: ./.github/workflows/reusable-performance.yml
+  #  with:
+  #    build-artifact-name: build
+  #  secrets:
+  #    LHCI_GITHUB_APP_TOKEN: ${{ secrets.LHCI_GITHUB_APP_TOKEN }}
+  #    BUNDLEWATCH_GITHUB_TOKEN: ${{ secrets.BUNDLEWATCH_GITHUB_TOKEN }}
+  #deploy-preview:
+  #  name: Deploy preview
+  #  needs: [build]
+  #  uses: ./.github/workflows/reusable-deploy-cloudflare-pages.yml
+  #  with:
+  #    build-artifact-name: build
+  #  secrets:
+  #    cloudflare-account-id: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+  #    cloudflare-api-token: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+  #  permissions:
+  #    contents: read
+  #    deployments: write

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -22,40 +22,45 @@ on:
 permissions:
   contents: write
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-build
+
 jobs:
   build:
     name: Build app
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
-        with:
-          ref: ${{ inputs.ref }}
-          lfs: true
-      - name: Setup
-        uses: ./.github/actions/setup
-      - name: Generate info for Angular cache key
-        run: echo "week-of-year=$(date --utc '+%V')" >> $GITHUB_ENV
-      - name: Cache Angular build
-        uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a # v4
-        env:
-          cache-name: angular-cache
-        with:
-          path: .angular/cache
-          # 👇 Update cache once a week. Best effort approach
-          #    Otherwise it would never be invalidated
-          key: ${{ env.cache-name }}-${{ env.week-of-year }}
-          restore-keys: |
-            ${{ env.cache-name }}
-      - name: Prebuild tasks
-        run: pnpm run prebuild
-      - name: Build app (includes SSG|R)
-        run: pnpm run ${{ inputs.build-run-script }}
-      - name: Upload built app
-        if: ${{ inputs.artifact-name != '' }}
-        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4
-        with:
-          name: ${{ inputs.artifact-name }}
-          path: 'dist/@davidlj95/website/browser'
-          retention-days: 5
+      - name: Fake sleep
+        run: sleep 40
+      #- name: Checkout
+      #  uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      #  with:
+      #    ref: ${{ inputs.ref }}
+      #    lfs: true
+      #- name: Setup
+      #  uses: ./.github/actions/setup
+      #- name: Generate info for Angular cache key
+      #  run: echo "week-of-year=$(date --utc '+%V')" >> $GITHUB_ENV
+      #- name: Cache Angular build
+      #  uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a # v4
+      #  env:
+      #    cache-name: angular-cache
+      #  with:
+      #    path: .angular/cache
+      #    # 👇 Update cache once a week. Best effort approach
+      #    #    Otherwise it would never be invalidated
+      #    key: ${{ env.cache-name }}-${{ env.week-of-year }}
+      #    restore-keys: |
+      #      ${{ env.cache-name }}
+      #- name: Prebuild tasks
+      #  run: pnpm run prebuild
+      #- name: Build app (includes SSG|R)
+      #  run: pnpm run ${{ inputs.build-run-script }}
+      #- name: Upload built app
+      #  if: ${{ inputs.artifact-name != '' }}
+      #  uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4
+      #  with:
+      #    name: ${{ inputs.artifact-name }}
+      #    path: 'dist/@davidlj95/website/browser'
+      #    retention-days: 5


### PR DESCRIPTION
Trying to see if concurrency works for reusable workflows when specified at workflow level.

Will issue two commits fast to see if the second run starts before the first finishes.

It does:
![image](https://github.com/user-attachments/assets/fe469abe-b61f-42d8-a067-2aeb218aeeaf)

