### PR TITLE
build: allow fill variable axis for Material Symbols font

### DIFF
--- a/scripts/src/generate-font-subsets.ts
+++ b/scripts/src/generate-font-subsets.ts
@@ -13,7 +13,7 @@ async function generateFonts() {
       '@fontsource-variable',
       'material-symbols-outlined',
       'files',
-      'material-symbols-outlined-latin-wght-normal.woff2',
+      'material-symbols-outlined-latin-full-normal.woff2',
     ),
   )
   const fontBuffer = Buffer.from(materialSymbolsFont)
@@ -79,6 +79,10 @@ async function generateFontSubset(
 ) {
   const subsetBuffer = await subsetFont(fontBuffer, text, {
     targetFormat: format,
+    // @ts-expect-error Missing definition
+    variationAxes: {
+      FILL: { min: 0, max: 1 },
+    },
   })
   writeFileSync(`${filename}.${getExtensionFromFormat(format)}`, subsetBuffer)
 }


### PR DESCRIPTION
In #823, Material Symbols font file was removed to use FontSource.org instead. This way the font file will be updated from time to time.

However, lost the `fill` variable axis. After a bit of investigation, seems that an option needs to be passed when subsetting the font in order to take into account for this.
