### PR TITLE
refactor: output simple icons to generated data dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -257,6 +257,7 @@ $RECYCLE.BIN/
 .nx/cache
 .idea/git_toolbox_blame.xml
 .nyc_output
+data/generated
 # Manual changes:
 # - Remove .idea from angular, we want some settings in the repo
 # - Include dictionaries

--- a/scripts/src/utils.ts
+++ b/scripts/src/utils.ts
@@ -1,5 +1,6 @@
 import { fileURLToPath } from 'url'
 import { dirname, join, resolve } from 'path'
+import { mkdir } from 'fs/promises'
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = dirname(__filename)
@@ -7,6 +8,12 @@ const __dirname = dirname(__filename)
 export function getRepositoryRootDir() {
   // Relative to `dist`, as this file will be output there
   return resolve(__dirname, '..', '..', '..')
+}
+
+export async function createAndGetGeneratedDataDir() {
+  const generatedDataDir = resolve(getRepositoryRootDir(), 'data', 'generated')
+  await mkdir(generatedDataDir, { recursive: true })
+  return generatedDataDir
 }
 
 export const objectToJson = (object: object) => JSON.stringify(object, null, 2)

--- a/src/app/resume-page/technology/.gitignore
+++ b/src/app/resume-page/technology/.gitignore
@@ -1,1 +1,0 @@
-simple-icons-display-name-and-color-entries.json

--- a/src/app/resume-page/technology/get-technology-display-name-from-slug.spec.ts
+++ b/src/app/resume-page/technology/get-technology-display-name-from-slug.spec.ts
@@ -3,13 +3,13 @@ import {
   GET_TECHNOLOGY_DISPLAY_NAME_FROM_SLUG,
   GetTechnologyDisplayNameFromSlug,
 } from './get-technology-display-name-from-slug'
-import SIMPLE_ICONS_DISPLAY_NAME_AND_COLOR_ENTRIES from './simple-icons-display-name-and-color-entries.json'
+import SIMPLE_ICONS_JSON from '@/data/generated/simple-icons.json'
 import { CUSTOM_DISPLAY_NAME_ENTRIES } from './custom-display-name-entries'
 
 describe('GetTechnologyDisplayNameFromSlug', () => {
   let sut: GetTechnologyDisplayNameFromSlug
 
-  const SIMPLE_ICONS_ENTRIES = SIMPLE_ICONS_DISPLAY_NAME_AND_COLOR_ENTRIES[0]
+  const SIMPLE_ICONS_ENTRIES = SIMPLE_ICONS_JSON[0]
   const SIMPLE_ICON_SLUG = SIMPLE_ICONS_ENTRIES[0]
   const SIMPLE_ICON_DISPLAY_NAME = SIMPLE_ICONS_ENTRIES[1]
 

--- a/src/app/resume-page/technology/get-technology-display-name-from-slug.ts
+++ b/src/app/resume-page/technology/get-technology-display-name-from-slug.ts
@@ -1,5 +1,5 @@
 import { InjectionToken } from '@angular/core'
-import SIMPLE_ICONS_DISPLAY_NAME_AND_COLOR_ENTRIES from './simple-icons-display-name-and-color-entries.json'
+import SIMPLE_ICONS_JSON from '@/data/generated/simple-icons.json'
 import { CUSTOM_DISPLAY_NAME_ENTRIES } from './custom-display-name-entries'
 
 export type GetTechnologyDisplayNameFromSlug = (slug: string) => string
@@ -11,8 +11,7 @@ export const GET_TECHNOLOGY_DISPLAY_NAME_FROM_SLUG =
   )
 
 const DISPLAY_NAME_BY_SLUG = new Map<string, string>(
-  [
-    ...SIMPLE_ICONS_DISPLAY_NAME_AND_COLOR_ENTRIES,
-    ...CUSTOM_DISPLAY_NAME_ENTRIES,
-  ].map(([slug, displayName]) => [slug, displayName] as const),
+  [...SIMPLE_ICONS_JSON, ...CUSTOM_DISPLAY_NAME_ENTRIES].map(
+    ([slug, displayName]) => [slug, displayName] as const,
+  ),
 )

--- a/src/app/resume-page/technology/get-technology-icon-from-slug.spec.ts
+++ b/src/app/resume-page/technology/get-technology-icon-from-slug.spec.ts
@@ -1,4 +1,4 @@
-import SIMPLE_ICONS_DISPLAY_NAME_AND_COLOR_ENTRIES from './simple-icons-display-name-and-color-entries.json'
+import SIMPLE_ICONS_JSON from '@/data/generated/simple-icons.json'
 import { serviceTestSetup } from '@/test/helpers/service-test-setup'
 import {
   GET_TECHNOLOGY_ICON_FROM_SLUG,
@@ -7,7 +7,7 @@ import {
 
 describe('GetTechnologyIconFromSlug', () => {
   let sut: GetTechnologyIconFromSlug
-  const SIMPLE_ICONS_ENTRIES = SIMPLE_ICONS_DISPLAY_NAME_AND_COLOR_ENTRIES[0]
+  const SIMPLE_ICONS_ENTRIES = SIMPLE_ICONS_JSON[0]
   const SIMPLE_ICON_SLUG = SIMPLE_ICONS_ENTRIES[0]
   const SIMPLE_ICON_COLOR = SIMPLE_ICONS_ENTRIES[2]
 

--- a/src/app/resume-page/technology/get-technology-icon-from-slug.ts
+++ b/src/app/resume-page/technology/get-technology-icon-from-slug.ts
@@ -1,6 +1,6 @@
 import { SimpleIcon } from '@/common/simple-icon/simple-icon'
 import { InjectionToken } from '@angular/core'
-import SIMPLE_ICONS_DISPLAY_NAME_AND_COLOR_ENTRIES from './simple-icons-display-name-and-color-entries.json'
+import SIMPLE_ICONS_JSON from '@/data/generated/simple-icons.json'
 
 export type GetTechnologyIconFromSlug = (slug: string) => SimpleIcon | undefined
 export const GET_TECHNOLOGY_ICON_FROM_SLUG =
@@ -11,7 +11,7 @@ export const GET_TECHNOLOGY_ICON_FROM_SLUG =
   )
 
 const SIMPLE_ICON_BY_SLUG = new Map<string, SimpleIcon>([
-  ...SIMPLE_ICONS_DISPLAY_NAME_AND_COLOR_ENTRIES.map(
+  ...SIMPLE_ICONS_JSON.map(
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     ([slug, displayName, hex]) =>
       [

--- a/src/app/resume-page/technology/technology.component.ts
+++ b/src/app/resume-page/technology/technology.component.ts
@@ -1,5 +1,4 @@
 import { Component, Inject, Input } from '@angular/core'
-import { NgIf, NgOptimizedImage } from '@angular/common'
 import { TechnologyItem } from './technology-item'
 import { SimpleIconComponent } from '@/common/simple-icon/simple-icon.component'
 import { SimpleIcon } from '@/common/simple-icon/simple-icon'
@@ -15,7 +14,7 @@ import {
 @Component({
   selector: 'app-technology',
   standalone: true,
-  imports: [NgIf, NgOptimizedImage, SimpleIconComponent],
+  imports: [SimpleIconComponent],
   templateUrl: './technology.component.html',
   styleUrl: './technology.component.scss',
 })


### PR DESCRIPTION
There are many scripts generating data for the site:
 - Font subsets
 - Release 
 - Simple Icons
 - Templated files

Each outputs to a different directory and generated files are scattered around

However, in CI/CD we need those files to be present for build and testing. Otherwise we can't do so appropriately
And currently the scripts are being ran many times in CI/CD in order to do so.

Hence having a first step where this data is generated would be great. So that we reuse this across all jobs that need it
But first, we need to organize a little bit. As all generated data is spread around.

Hence starting here a series of PRs to output all generated data to the same directory. So later that directory
can be uploaded as an artifact and downloaded in whatever CI/CD job is needed.

Here starting with the simple icon script:
 - Output to `data/generated`
 - Use JSON file from there in code
 - For icon files, add a symlink in `assets` directory. So that directory still provides a holistic view of all published assets.
