### PR TITLE
ci: add data workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,10 +8,15 @@ on:
   workflow_dispatch:
 
 jobs:
+  data:
+    name: Data
+    uses: ./.github/workflows/reusable-data.yml
   build:
+    needs: data
     name: Build
     uses: ./.github/workflows/reusable-build.yml
   test:
+    needs: data
     name: Test
     uses: ./.github/workflows/reusable-test.yml
     secrets:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -4,10 +4,15 @@ on:
   pull_request:
 
 jobs:
+  data:
+    name: Data
+    uses: ./.github/workflows/reusable-data.yml
   build:
+    needs: data
     name: Build
     uses: ./.github/workflows/reusable-build.yml
   test:
+    needs: data
     name: Test
     uses: ./.github/workflows/reusable-test.yml
     secrets:

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -8,13 +8,13 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - name: Download generated data
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4
         with:
           name: data
           path: data/generated
-      - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - name: Setup
         uses: ./.github/actions/setup
       - name: Generate info for Angular cache key

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -15,9 +15,6 @@ jobs:
           path: data/generated
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
-        with:
-          #👇 To generate release information
-          fetch-depth: 0
       - name: Setup
         uses: ./.github/actions/setup
       - name: Generate info for Angular cache key

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -8,6 +8,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
+      - name: Download generated data
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4
+        with:
+          name: data
+          path: data/generated
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
@@ -28,8 +33,6 @@ jobs:
           key: ${{ env.cache-name }}-${{ env.week-of-year }}
           restore-keys: |
             ${{ env.cache-name }}
-      - name: Prebuild tasks
-        run: pnpm run prebuild
       - name: Build app (with SSG)
         run: pnpm run ${{ github.event_name == 'pull_request' && 'build:pull-request' || 'build' }}
       - name: Upload built app

--- a/.github/workflows/reusable-data.yml
+++ b/.github/workflows/reusable-data.yml
@@ -1,0 +1,27 @@
+name: Data
+on:
+  workflow_call:
+
+jobs:
+  data:
+    name: Data
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          #👇 To generate release information
+          fetch-depth: 0
+      - name: Setup
+        uses: ./.github/actions/setup
+      - name: Build scripts
+        run: pnpm run --filter scripts build
+      - name: Run data generation scripts
+        run: pnpm run --filter scripts generate
+      - name: Upload generated data
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4
+        with:
+          name: data
+          path: data/generated
+          retention-days: 5

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -29,16 +29,15 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
+      - name: Download generated data
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4
+        with:
+          name: data
+          path: data/generated
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - name: Setup
         uses: ./.github/actions/setup
-      - name: Generate files
-        run: |
-          cd scripts
-          pnpm run build
-          pnpm run generate:simple-icons
-          pnpm run generate:font-subsets
       - name: Run tests
         run: cd .ci && make unit-test
       - name: Upload coverage results
@@ -53,6 +52,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
+      - name: Download generated data
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4
+        with:
+          name: data
+          path: data/generated
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         # 👇 Needed in order for the Cypress GitHub Action to work
@@ -81,8 +85,6 @@ jobs:
         #    In that scenario, `cypress run` does not install it again and errors
       - name: Cypress install
         run: pnpm cypress install
-      - name: Generate font subsets
-        run: cd scripts && pnpm run build && pnpm run generate:font-subsets
       - name: Cypress run
         uses: cypress-io/github-action@v6
         with:

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -29,13 +29,13 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - name: Download generated data
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4
         with:
           name: data
           path: data/generated
-      - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - name: Setup
         uses: ./.github/actions/setup
       - name: Run tests
@@ -52,13 +52,13 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - name: Download generated data
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4
         with:
           name: data
           path: data/generated
-      - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         # 👇 Needed in order for the Cypress GitHub Action to work
         #    Action uses Cypress Module API to work & later report the result in check summary
         #    https://docs.cypress.io/guides/guides/module-api


### PR DESCRIPTION
In order to avoid generating data when:
 - Building
 - Running unit tests (just font subsets and simple icons are strictly needed)
 - Running component tests (just font subsets are strictly needed)


Adding here a workflow to generate data once and reuse it around
