### PR TITLE
build: enable pre/post scripts

### DIFF
--- a/.ci/Makefile
+++ b/.ci/Makefile
@@ -2,7 +2,7 @@
 
 # First so that running without command runs a build
 build:
-	pnpm run prebuild && pnpm run build
+	pnpm run data && pnpm run build
 
 install:
 	# Despite it's enabled by default on CI. This allows to mock CI locally

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -28,8 +28,8 @@ jobs:
           key: ${{ env.cache-name }}-${{ env.week-of-year }}
           restore-keys: |
             ${{ env.cache-name }}
-      - name: Prebuild tasks
-        run: pnpm run prebuild
+      - name: Data tasks
+        run: pnpm run data
       - name: Build app (with SSG)
         run: pnpm run ${{ github.event_name == 'pull_request' && 'build:pull-request' || 'build' }}
       - name: Upload built app

--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,2 @@
-enable-pre-post-scripts=false
 public-hoist-pattern[]=conventional-recommended-bump
 public-hoist-pattern[]=@eslint/js

--- a/README.md
+++ b/README.md
@@ -30,10 +30,10 @@ This project was generated with [Angular CLI](https://github.com/angular/angular
 
 ## To start
 
-First, run the `prebuild` command, to generate files that are required for the app to work
+First, run the `data` command, to generate data files that are required for the app to work
 
 ```shell
-pnpm run prebuild
+pnpm run data
 ```
 
 ## Development server

--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
     "url": "https://github.com/davidlj95/website.git"
   },
   "scripts": {
-    "prebuild": "cd scripts && pnpm run build && pnpm run generate",
     "build": "ng build",
     "build:pack": "DIST_DIR=dist/@davidlj95/website/browser; [ -d \"$DIST_DIR\" ] && cd $DIST_DIR && zip -r ../../../build.zip . || true",
     "build:pull-request": "pnpm run build --configuration pullRequest,production",
@@ -25,6 +24,7 @@
     "coverage:report:all": "pnpm run coverage:move-to-nyc-output && nyc report --reporter lcov --report-dir coverage",
     "coverage:report:all//": "☝️ Can't be 'coverage:report', look for that run script comments for reason",
     "cypress:open": "cypress open",
+    "data": "pnpm run --filter scripts generate",
     "e2e": "ng e2e",
     "format": "pnpm run format:files .",
     "format:check": "pnpm run format:check:files .",


### PR DESCRIPTION
To simplify workflow and `.npmrc`

Renames `prebuild` to `data` to avoid generating data if just a build is needed. 

Now `pregenerate` will run before running scripts for data generation. So `pnpm run --filter scripts generate` will build and run scripts
