### PR TITLE
test: fix Cypress component build errors

### DIFF
--- a/cypress/support/component.ts
+++ b/cypress/support/component.ts
@@ -1,31 +1,11 @@
-// ***********************************************************
-// This example support/component.ts is processed and
-// loaded automatically before your test files.
-//
-// This is a great place to put global configuration and
-// behavior that modifies Cypress.
-//
-// You can change the location of this file or turn off
-// automatically serving support files with the
-// 'supportFile' configuration option.
-//
-// You can read more here:
-// https://on.cypress.io/configuration
-// ***********************************************************
-
-// Import commands.js using ES2015 syntax:
+import './cypress.d'
 import './commands'
-
-// Alternatively you can use CommonJS syntax:
-// require('./commands')
-import { mount } from 'cypress/angular'
 
 // Cypress code coverage
 import '@cypress/code-coverage/support'
 
+// Mount alias
+import { mount } from 'cypress/angular'
 // https://youtrack.jetbrains.com/issue/AQUA-3130/
 // noinspection CypressCommandWithoutDeclaration
 Cypress.Commands.add('mount', mount)
-
-// Example use:
-// cy.mount(MyComponent)


### PR DESCRIPTION
After running Cypress, noticed some errors appear when building the component to test:

```
ERROR in cypress/support/component.ts:10:22 - error TS2345: Argument of type '"mount"' is not assignable to parameter of type 'keyof Chainable<any>'.

10 Cypress.Commands.add('mount', mount)
                        ~~~~~~~

ERROR in src/app/header/tabs/tabs.component.spec.cy.ts:8:8 - error TS2339: Property 'mount' does not exist on type 'cy & CyEventEmitter'.

8     cy.mount(TabsComponent)
         ~~~~~

ERROR in src/app/header/tabs/tabs.component.spec.cy.ts:17:10 - error TS2339: Property 'mount' does not exist on type 'cy & CyEventEmitter'.

17       cy.mount('<app-tabs><app-tab>Hello World</app-tab></app-tabs>', {
            ~~~~~

ERROR in src/app/header/tabs/tabs.component.spec.cy.ts:35:10 - error TS2339: Property 'mount' does not exist on type 'cy & CyEventEmitter'.

35       cy.mount(
            ~~~~~

ERROR in src/app/header/tabs/tabs.component.spec.cy.ts:47:15 - error TS7006: Parameter 'wrapper' implicitly has an 'any' type.

47       ).then((wrapper) => {
                 ~~~~~~~

```

The main source of the issue is the first one about `Cypress.Commands.add`. Seems Cypress types aren't found, so can't be augmented.

After trying many things:
 - Adding `support/cypress.d.ts` in `cypress/tsconfig.json`, [as stated in docs](https://docs.cypress.io/app/tooling/typescript-support#Using-an-External-Typings-File).
   - This file seems not to matter when building the component to test (it's when the error appears). Placed a random string in `extends` and worked anyway.
   - Docs actually say to add that in any Typescript config. Maybe because the error happens at component build time, not when building Cypress config and so.
 - Adding `cypress/support/cypress.d.ts` as `includes` in `tsconfig.json`
   - Adding `support/commands.ts` too doesn't impact
 - Using `tsConfig` `buildOption` in `devServer` in `cypress.config.ts`. It does something (if using an invalid path, the build fails). But given previous point, doesn't matter. Doesn't seem to work.
 
Found that just importing `cypress.d.ts` at the beginning of the `component.ts` file is enough for types to be found. Ideally, having that as part of `tsconfig.json` would be great. But haven't managed to. I suspect it relates to how `webpack-dev-server` is used by Cypress under the hood to build the component.
