### PR TITLE
build: make all components are standalone

### DIFF
--- a/src/app/maybe-load-console-easter-egg.spec.ts
+++ b/src/app/maybe-load-console-easter-egg.spec.ts
@@ -44,7 +44,6 @@ const makeSut = ({ isMobile }: { isMobile: boolean }) => {
 
   @Component({
     template: '',
-    standalone: false,
   })
   class ExampleComponent {
     constructor() {

--- a/src/app/resume-page/chipped-content/chipped-content.component.spec.ts
+++ b/src/app/resume-page/chipped-content/chipped-content.component.spec.ts
@@ -175,7 +175,6 @@ describe('ChippedContentComponent', () => {
 @Component({
   selector: 'app-foo',
   template: `{{ data }}`,
-  standalone: false,
 })
 class FooComponent {
   @Input() public data?: string
@@ -183,7 +182,6 @@ class FooComponent {
 @Component({
   selector: 'app-bar',
   template: `{{ data }}`,
-  standalone: false,
 })
 class BarComponent {
   @Input() public data?: string

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -32,7 +32,8 @@
     "enableI18nLegacyMessageIdFormat": false,
     "strictInjectionParameters": true,
     "strictInputAccessModifiers": true,
-    "strictTemplates": true
+    "strictTemplates": true,
+    "strictStandalone": true
   },
   "references": [
     { "path": "./tsconfig.app.json" },


### PR DESCRIPTION
When migrating to Angular v19 some components were marked as not-standalone by the migration schematic. However they can be standalone.

Also enables the flag to ensure all components are standalone
