### PR TITLE
test: do not force Cypress click

### DIFF
--- a/src/app/header/tabs/tabs.component.spec.cy.ts
+++ b/src/app/header/tabs/tabs.component.spec.cy.ts
@@ -138,8 +138,7 @@ describe('TabsComponent', () => {
       describe('when tapping previous paginator', () => {
         beforeEach(() => {
           cy.get(PREV_BUTTON_SELECTOR).should('be.enabled')
-          //👇 Why click needs to be forced? No idea 🙃
-          cy.get(PREV_BUTTON_SELECTOR).click({ force: true })
+          cy.get(PREV_BUTTON_SELECTOR).click()
         })
 
         it('should scroll a bit to see previous tabs', () => {


### PR DESCRIPTION
Didn't understand why that was needed. It isn't in theory. And now it works without it. So removing it
