### PR TITLE
build: update tsconfig.json to match v19 fresh one

### DIFF
--- a/src/app/resume-page/profile-section/profile-description/profile-description.component.ts
+++ b/src/app/resume-page/profile-section/profile-description/profile-description.component.ts
@@ -23,16 +23,18 @@ import { ProfileDescriptionLineComponent } from './profile-description-line/prof
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class ProfileDescriptionComponent {
-  protected readonly ROOT_NODE = new CollapsibleTreeNode(
-    undefined,
-    this.metadata.descriptionLines.map(descriptionLineToCollapsibleTreeNode),
-  )
+  protected readonly ROOT_NODE: CollapsibleTreeNode
 
   protected readonly IS_COLLAPSIBLE_FN: IsCollapsibleFn = (
     node: CollapsibleTreeComponent,
   ) => node.depth > 1
 
-  constructor(@Inject(METADATA) private readonly metadata: Metadata) {}
+  constructor(@Inject(METADATA) metadata: Metadata) {
+    this.ROOT_NODE = new CollapsibleTreeNode(
+      undefined,
+      metadata.descriptionLines.map(descriptionLineToCollapsibleTreeNode),
+    )
+  }
 }
 
 const descriptionLineToCollapsibleTreeNode = (

--- a/src/app/resume-page/profile-section/profile-picture/profile-picture.component.ts
+++ b/src/app/resume-page/profile-section/profile-picture/profile-picture.component.ts
@@ -10,7 +10,7 @@ import { NgOptimizedImage } from '@angular/common'
   imports: [NgOptimizedImage],
 })
 export class ProfilePictureComponent {
-  protected realName: string = this.metadata.realName
+  readonly realName: string
   protected _hasBeenFocused = false
 
   public static HAS_BEEN_FOCUSED_ATTR = 'data-has-been-focused'
@@ -26,7 +26,9 @@ export class ProfilePictureComponent {
 
   @HostBinding('attr.aria-label') public ariaLabel = 'Profile picture'
 
-  constructor(@Inject(METADATA) private metadata: Metadata) {}
+  constructor(@Inject(METADATA) metadata: Metadata) {
+    this.realName = metadata.realName
+  }
 
   onFocus() {
     this._hasBeenFocused = true

--- a/src/app/resume-page/profile-section/profile-section.component.ts
+++ b/src/app/resume-page/profile-section/profile-section.component.ts
@@ -1,5 +1,5 @@
 import { Component, Inject } from '@angular/core'
-import { DescriptionLine, Metadata } from '@/data/metadata'
+import { Metadata } from '@/data/metadata'
 import { METADATA } from '@/common/injection-tokens'
 import { ProfilePictureComponent } from './profile-picture/profile-picture.component'
 import { SectionTitleComponent } from '../section-title/section-title.component'
@@ -18,13 +18,13 @@ import { ProfileDescriptionComponent } from './profile-description/profile-descr
   ],
 })
 export class ProfileSectionComponent {
-  public readonly realName = this.metadata.realName
-  public readonly nickname = this.metadata.nickname
-  public readonly title = this.metadata.title
-  public readonly rootLine = new DescriptionLine(
-    undefined,
-    this.metadata.descriptionLines,
-  )
+  readonly realName: string
+  readonly nickname: string
+  readonly title: string
 
-  constructor(@Inject(METADATA) private metadata: Metadata) {}
+  constructor(@Inject(METADATA) metadata: Metadata) {
+    this.realName = metadata.realName
+    this.nickname = metadata.nickname
+    this.title = metadata.title
+  }
 }

--- a/src/environments/index.ts
+++ b/src/environments/index.ts
@@ -1,4 +1,4 @@
 import { environment } from './environment'
 import { Environment } from './environment-interface'
 
-export { Environment, environment }
+export { type Environment, environment }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,9 @@
     "importHelpers": true,
     "target": "ES2022",
     "module": "ES2022",
-    // Manually added to import release.json into app
+    // Added for paths to work
+    "baseUrl": "./",
+    // Manually added to import JSONs in the app
     "resolveJsonModule": true,
     "paths": {
       "@/common/*": ["src/app/common/*"],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,24 +2,20 @@
 {
   "compileOnSave": false,
   "compilerOptions": {
-    "baseUrl": "./",
     "outDir": "./dist/out-tsc",
-    "forceConsistentCasingInFileNames": true,
     "strict": true,
-    "esModuleInterop": true,
     "noImplicitOverride": true,
     "noPropertyAccessFromIndexSignature": true,
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
-    "sourceMap": true,
-    "declaration": false,
+    "skipLibCheck": true,
+    "isolatedModules": true,
+    "esModuleInterop": true,
     "experimentalDecorators": true,
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "importHelpers": true,
     "target": "ES2022",
     "module": "ES2022",
-    "useDefineForClassFields": false,
-    "lib": ["ES2022", "dom"],
     // Manually added to import release.json into app
     "resolveJsonModule": true,
     "paths": {


### PR DESCRIPTION
There have been several changes to Typescript config `tsconfig.json` since app was created til v19

In order to be as up to date as possible, Typescript config has been replaced by default apps in v19 + the custom options needed for the app. `tsconfig.(app|spec).json` need no updates.

Then, fixes new Typescript errors raised. Mostly due to `metadata` being used before assigned
