### PR TITLE
build: update `angular.json` with Angular v19 defaults

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -28,10 +28,9 @@
         "build": {
           "builder": "@angular-devkit/build-angular:application",
           "options": {
-            "outputPath": {
-              "base": "dist/@davidlj95/website"
-            },
+            "outputPath": "dist/@davidlj95/website",
             "index": "src/index.html",
+            "browser": "src/main.ts",
             "polyfills": ["zone.js"],
             "tsConfig": "tsconfig.app.json",
             "inlineStyleLanguage": "scss",
@@ -57,8 +56,8 @@
                 "inject": false
               }
             ],
-            "browser": "src/main.ts",
             "server": "src/main.server.ts",
+            "outputMode": "static",
             "prerender": true,
             "ssr": false,
             "define": {
@@ -70,13 +69,13 @@
               "budgets": [
                 {
                   "type": "initial",
-                  "maximumWarning": "500kb",
-                  "maximumError": "1mb"
+                  "maximumWarning": "500kB",
+                  "maximumError": "1MB"
                 },
                 {
                   "type": "anyComponentStyle",
-                  "maximumWarning": "2kb",
-                  "maximumError": "4kb"
+                  "maximumWarning": "4kB",
+                  "maximumError": "8kB"
                 }
               ],
               "outputHashing": "all",
@@ -124,10 +123,7 @@
           "defaultConfiguration": "development"
         },
         "extract-i18n": {
-          "builder": "@angular-devkit/build-angular:extract-i18n",
-          "options": {
-            "buildTarget": "@davidlj95/website:build"
-          }
+          "builder": "@angular-devkit/build-angular:extract-i18n"
         },
         "test": {
           "builder": "@angular-devkit/build-angular:karma",
@@ -138,7 +134,6 @@
               "src/test/esbuild-defines"
             ],
             "tsConfig": "tsconfig.spec.json",
-            "inlineStyleLanguage": "scss",
             "assets": ["src/favicon.ico", "src/favicon.svg", "src/assets"],
             "styles": ["src/styles.scss", "src/sass/themes/devtools.scss"],
             "stylePreprocessorOptions": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
   },
   "scripts": {
     "build": "ng build",
-    "postbuild": "cp dist/@davidlj95/website/browser/index.csr.html dist/@davidlj95/website/browser/index.html",
     "build:pack": "DIST_DIR=dist/@davidlj95/website/browser; [ -d \"$DIST_DIR\" ] && cd $DIST_DIR && zip -r ../../../build.zip . || true",
     "build:pull-request": "pnpm run build --configuration pullRequest,production",
     "bundle:analyze": "pnpm run bundle:analyze:files '*.js'",


### PR DESCRIPTION
Updates `angular.json` to match v19 defaults + custom options

Removes the need of generating a manual `index.html` given with `outputMode` that's now done by default. Yay!

Everything but `assets`. Which will be done in a separate PR
