### PR TITLE
test: add textContent util

### DIFF
--- a/src/app/header/navigation-tabs/navigation-tabs.component.spec.ts
+++ b/src/app/header/navigation-tabs/navigation-tabs.component.spec.ts
@@ -10,6 +10,7 @@ import { provideRouter, Route, RouterLink, Routes } from '@angular/router'
 import { EmptyComponent } from '@/test/helpers/empty-component'
 import { RouterTestingHarness } from '@angular/router/testing'
 import { getComponentInstance } from '@/test/helpers/get-component-instance'
+import { textContent } from '@/test/helpers/text-content'
 
 describe('NavigationTabsComponent', () => {
   const FOO_ROUTE = { path: 'foo', component: EmptyComponent } satisfies Route
@@ -46,9 +47,7 @@ describe('NavigationTabsComponent', () => {
     tabElements.forEach((tabElement, i) => {
       const item = ITEMS[i]
 
-      expect(tabElement.nativeElement.textContent.trim()).toEqual(
-        item.displayName,
-      )
+      expect(textContent(tabElement)).toEqual(item.displayName)
 
       expect(tabElement.injector.get(RouterLink).urlTree?.toString()).toBe(
         '/' + item.routerLink,
@@ -68,10 +67,7 @@ describe('NavigationTabsComponent', () => {
 
     const fooTabElement = fixture.debugElement
       .queryAll(byComponent(TabComponent))
-      .find(
-        (element) =>
-          element.nativeElement.textContent.trim() === FOO_ITEM.displayName,
-      )
+      .find((element) => textContent(element) === FOO_ITEM.displayName)
 
     expect(fooTabElement).not.toBeNull()
     expect(
@@ -80,10 +76,7 @@ describe('NavigationTabsComponent', () => {
 
     const barTabElement = fixture.debugElement
       .queryAll(byComponent(TabComponent))
-      .find(
-        (element) =>
-          element.nativeElement.textContent.trim() === BAR_ITEM.displayName,
-      )
+      .find((element) => textContent(element) === BAR_ITEM.displayName)
 
     expect(barTabElement).not.toBeNull()
 

--- a/src/app/header/toolbar-button/toolbar-button.component.spec.ts
+++ b/src/app/header/toolbar-button/toolbar-button.component.spec.ts
@@ -1,6 +1,7 @@
 import { ToolbarButtonComponent } from './toolbar-button.component'
 import { componentTestSetup } from '@/test/helpers/component-test-setup'
 import { MATERIAL_SYMBOLS_SELECTOR } from '@/test/helpers/material-symbols'
+import { textContent } from '@/test/helpers/text-content'
 
 describe('ToolbarButtonComponent', () => {
   it('should create', () => {
@@ -16,7 +17,7 @@ describe('ToolbarButtonComponent', () => {
 
     const iconElement = fixture.debugElement.query(MATERIAL_SYMBOLS_SELECTOR)
 
-    expect(iconElement.nativeElement.textContent.trim()).toBe(DUMMY_ICON)
+    expect(textContent(iconElement)).toBe(DUMMY_ICON)
   })
 })
 

--- a/src/app/resume-page/attribute/attribute.component.spec.ts
+++ b/src/app/resume-page/attribute/attribute.component.spec.ts
@@ -3,6 +3,7 @@ import { MATERIAL_SYMBOLS_SELECTOR } from '@/test/helpers/material-symbols'
 import { By } from '@angular/platform-browser'
 import { shouldProjectContent } from '@/test/helpers/component-testers'
 import { componentTestSetup } from '@/test/helpers/component-test-setup'
+import { textContent } from '@/test/helpers/text-content'
 
 describe('AttributeComponent', () => {
   const symbol = 'some symbol'
@@ -27,7 +28,7 @@ describe('AttributeComponent', () => {
     const iconElement = fixture.debugElement.query(MATERIAL_SYMBOLS_SELECTOR)
 
     expect(iconElement).toBeTruthy()
-    expect(iconElement.nativeElement.textContent.trim()).toEqual(symbol)
+    expect(textContent(iconElement)).toEqual(symbol)
   })
 
   it('should be ARIA accessible: icon is described by tooltip', () => {

--- a/src/app/resume-page/chipped-content/chipped-content.component.spec.ts
+++ b/src/app/resume-page/chipped-content/chipped-content.component.spec.ts
@@ -15,6 +15,7 @@ import { tickToFinishAnimation } from '@/test/helpers/tick-to-finish-animation'
 import { MockProvider } from 'ng-mocks'
 import { SCROLL_INTO_VIEW } from '@/common/scroll-into-view'
 import { getComponentInstance } from '@/test/helpers/get-component-instance'
+import { textContent } from '@/test/helpers/text-content'
 
 describe('ChippedContentComponent', () => {
   let fixture: ComponentFixture<ChippedContentComponent>
@@ -46,7 +47,7 @@ describe('ChippedContentComponent', () => {
         .withContext(`chip ${index} is unselected`)
         .toBeFalse()
 
-      expect(chipElement.nativeElement.textContent.trim())
+      expect(textContent(chipElement))
         .withContext(`chip ${index} display name`)
         .toEqual(content.displayName)
     })
@@ -63,7 +64,7 @@ describe('ChippedContentComponent', () => {
 
     expect(firstComponentElement).toBeTruthy()
 
-    expect(firstComponentElement.nativeElement.textContent.trim()).toEqual(
+    expect(textContent(firstComponentElement)).toEqual(
       FIRST_CONTENT.inputs!['data'],
     )
     expectIsNotInLayout(contentElement.nativeElement)

--- a/src/app/resume-page/chipped-content/text-content/text-content.component.spec.ts
+++ b/src/app/resume-page/chipped-content/text-content/text-content.component.spec.ts
@@ -2,6 +2,7 @@ import { ComponentFixture } from '@angular/core/testing'
 
 import { TextContentComponent } from './text-content.component'
 import { componentTestSetup } from '@/test/helpers/component-test-setup'
+import { textContent } from '@/test/helpers/text-content'
 
 describe('TextContentComponent', () => {
   let component: TextContentComponent
@@ -21,8 +22,6 @@ describe('TextContentComponent', () => {
     component.text = 'dummy text'
     fixture.detectChanges()
 
-    expect(fixture.debugElement.nativeElement.textContent.trim()).toEqual(
-      component.text,
-    )
+    expect(textContent(fixture.debugElement)).toEqual(component.text)
   })
 })

--- a/src/app/resume-page/collapsible-tree/collapsible-tree.component.spec.ts
+++ b/src/app/resume-page/collapsible-tree/collapsible-tree.component.spec.ts
@@ -21,6 +21,7 @@ import {
 import { Component, Input } from '@angular/core'
 import { EmptyComponent } from '@/test/helpers/empty-component'
 import { getComponentInstance } from '@/test/helpers/get-component-instance'
+import { textContent } from '@/test/helpers/text-content'
 
 describe('CollapsibleTreeComponent', () => {
   let component: CollapsibleTreeComponent
@@ -83,9 +84,7 @@ describe('CollapsibleTreeComponent', () => {
 
       expect(nodeDataElement).not.toBeNull()
 
-      expect(nodeDataElement.nativeElement.textContent.trim()).toEqual(
-        DUMMY_COMPONENT_CONTENTS,
-      )
+      expect(textContent(nodeDataElement)).toEqual(DUMMY_COMPONENT_CONTENTS)
     })
   })
 
@@ -242,7 +241,7 @@ describe('CollapsibleTreeComponent', () => {
             const caretElement = fixture.debugElement.query(CARET_PREDICATE)
 
             expect(caretElement).not.toBeNull()
-            expect(caretElement.nativeElement.textContent.trim()).toEqual(
+            expect(textContent(caretElement)).toEqual(
               component[testCase.iconProperty],
             )
 

--- a/src/app/resume-page/date-range/date-range.component.spec.ts
+++ b/src/app/resume-page/date-range/date-range.component.spec.ts
@@ -3,6 +3,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing'
 import { DateRangeComponent } from './date-range.component'
 import { By } from '@angular/platform-browser'
 import { DateRange } from './date-range'
+import { textContent } from '@/test/helpers/text-content'
 
 describe('DateRangeComponent', () => {
   let component: DateRangeComponent
@@ -34,7 +35,7 @@ describe('DateRangeComponent', () => {
       .withContext('start date element exists')
       .toBeTruthy()
 
-    expect(startDateElement.nativeElement.textContent.trim())
+    expect(textContent(startDateElement))
       .withContext('start date is displayed with proper format')
       .toEqual(expectedFormattedStartDate)
   })
@@ -58,7 +59,7 @@ describe('DateRangeComponent', () => {
       const endDateElement = fixture.debugElement.query(By.css('.end'))
 
       expect(endDateElement).withContext('end date element exists').toBeTruthy()
-      expect(endDateElement.nativeElement.textContent.trim())
+      expect(textContent(endDateElement))
         .withContext('end date is present')
         .toEqual('Present')
     })
@@ -79,7 +80,7 @@ describe('DateRangeComponent', () => {
       const endDateElement = fixture.debugElement.query(By.css('.end'))
 
       expect(endDateElement).withContext('end date element exists').toBeTruthy()
-      expect(endDateElement.nativeElement.textContent.trim())
+      expect(textContent(endDateElement))
         .withContext('end date is displayed with proper format')
         .toEqual(expectedFormattedEndDate)
     })

--- a/src/app/resume-page/education-section/education-item/education-item-courses/education-item-courses.component.spec.ts
+++ b/src/app/resume-page/education-section/education-item/education-item-courses/education-item-courses.component.spec.ts
@@ -4,6 +4,7 @@ import { EducationItemCoursesComponent } from './education-item-courses.componen
 import { byComponent } from '@/test/helpers/component-query-predicates'
 import { ContentChipComponent } from '../../../content-chip/content-chip.component'
 import { componentTestSetup } from '@/test/helpers/component-test-setup'
+import { textContent } from '@/test/helpers/text-content'
 
 describe('EducationItemCoursesComponent', () => {
   let component: EducationItemCoursesComponent
@@ -27,9 +28,7 @@ describe('EducationItemCoursesComponent', () => {
 
     expect(courseElements.length).toEqual(COURSES.length)
     courseElements.forEach((courseElement, index) => {
-      expect(courseElement.nativeElement.textContent.trim()).toEqual(
-        COURSES[index],
-      )
+      expect(textContent(courseElement)).toEqual(COURSES[index])
     })
   })
 })

--- a/src/app/resume-page/education-section/education-item/education-item.component.spec.ts
+++ b/src/app/resume-page/education-section/education-item/education-item.component.spec.ts
@@ -26,6 +26,7 @@ import { ItemFactoryOverrides } from '@/test/helpers/make-item-factory'
 import { getComponentInstance } from '@/test/helpers/get-component-instance'
 import { LinkComponent } from '../../link/link.component'
 import { TestIdDirective } from '@/common/test-id.directive'
+import { textContent } from '@/test/helpers/text-content'
 
 describe('EducationItemComponent', () => {
   let component: EducationItemComponent
@@ -83,7 +84,7 @@ describe('EducationItemComponent', () => {
       byTestId('institution-name'),
     )
 
-    expect(titleElement.nativeElement.textContent.trim()).toEqual(name)
+    expect(textContent(titleElement)).toEqual(name)
   })
 
   describe('when name is long and there is short name', () => {
@@ -102,9 +103,7 @@ describe('EducationItemComponent', () => {
         byTestId('institution-name'),
       )
 
-      expect(institutionNameElement.nativeElement.textContent.trim()).toEqual(
-        shortName,
-      )
+      expect(textContent(institutionNameElement)).toEqual(shortName)
     })
   })
 
@@ -115,7 +114,7 @@ describe('EducationItemComponent', () => {
     const areaElement = fixture.debugElement.query(byTestId('area'))
 
     expect(areaElement).toBeTruthy()
-    expect(areaElement.nativeElement.textContent.trim()).toEqual(area)
+    expect(textContent(areaElement)).toEqual(area)
   })
 
   it('should display study type', () => {
@@ -125,7 +124,7 @@ describe('EducationItemComponent', () => {
     const studyTypeElement = fixture.debugElement.query(byTestId('study-type'))
 
     expect(studyTypeElement).toBeTruthy()
-    expect(studyTypeElement.nativeElement.textContent.trim()).toEqual(studyType)
+    expect(textContent(studyTypeElement)).toEqual(studyType)
   })
 
   it('should display date range component', () => {

--- a/src/app/resume-page/experience-section/experience-item/experience-item-highlights/experience-item-highlights.component.spec.ts
+++ b/src/app/resume-page/experience-section/experience-item/experience-item-highlights/experience-item-highlights.component.spec.ts
@@ -3,6 +3,7 @@ import { ComponentFixture } from '@angular/core/testing'
 import { ExperienceItemHighlightsComponent } from './experience-item-highlights.component'
 import { By } from '@angular/platform-browser'
 import { componentTestSetup } from '@/test/helpers/component-test-setup'
+import { textContent } from '@/test/helpers/text-content'
 
 describe('ExperienceItemHighlightsComponent', () => {
   let component: ExperienceItemHighlightsComponent
@@ -26,9 +27,7 @@ describe('ExperienceItemHighlightsComponent', () => {
 
     expect(listElements.length).toBe(HIGHLIGHTS.length)
     listElements.forEach((listElement, index) => {
-      expect(listElement.nativeElement.textContent.trim()).toEqual(
-        HIGHLIGHTS[index],
-      )
+      expect(textContent(listElement)).toEqual(HIGHLIGHTS[index])
     })
   })
 })

--- a/src/app/resume-page/experience-section/experience-item/experience-item.component.spec.ts
+++ b/src/app/resume-page/experience-section/experience-item/experience-item.component.spec.ts
@@ -25,6 +25,7 @@ import { ItemFactoryOverrides } from '@/test/helpers/make-item-factory'
 import { getComponentInstance } from '@/test/helpers/get-component-instance'
 import { LinkComponent } from '../../link/link.component'
 import { TestIdDirective } from '@/common/test-id.directive'
+import { textContent } from '@/test/helpers/text-content'
 
 describe('ExperienceItem', () => {
   let component: ExperienceItemComponent
@@ -83,7 +84,7 @@ describe('ExperienceItem', () => {
 
       const titleElement = fixture.debugElement.query(byTestId('company-name'))
 
-      expect(titleElement.nativeElement.textContent.trim()).toEqual(name)
+      expect(textContent(titleElement)).toEqual(name)
     })
   })
 
@@ -97,7 +98,7 @@ describe('ExperienceItem', () => {
       const positionElement = fixture.debugElement.query(byTestId('position'))
 
       expect(positionElement).toBeTruthy()
-      expect(positionElement.nativeElement.textContent.trim()).toEqual(position)
+      expect(textContent(positionElement)).toEqual(position)
     })
   })
 

--- a/src/app/resume-page/languages-section/language-item/language-item.component.spec.ts
+++ b/src/app/resume-page/languages-section/language-item/language-item.component.spec.ts
@@ -15,6 +15,7 @@ import { LanguageTagComponent } from './language-tag/language-tag.component'
 import { CardHeaderTextsComponent } from '../../card/card-header/card-header-texts/card-header-texts.component'
 import { CardHeaderSubtitleComponent } from '../../card/card-header/card-header-subtitle/card-header-subtitle.component'
 import { TestIdDirective } from '@/common/test-id.directive'
+import { textContent } from '@/test/helpers/text-content'
 
 describe('LanguageItemComponent', () => {
   let component: LanguageItemComponent
@@ -37,7 +38,7 @@ describe('LanguageItemComponent', () => {
 
     const nameElement = fixture.debugElement.query(byTestId('name'))
 
-    expect(nameElement.nativeElement.textContent.trim()).toEqual(name)
+    expect(textContent(nameElement)).toEqual(name)
   })
 
   it('should display fluency', () => {
@@ -47,7 +48,7 @@ describe('LanguageItemComponent', () => {
 
     const fluencyElement = fixture.debugElement.query(byTestId('fluency'))
 
-    expect(fluencyElement.nativeElement.textContent.trim()).toEqual(fluency)
+    expect(textContent(fluencyElement)).toEqual(fluency)
   })
 
   const COMMENT_ELEMENT_SELECTOR = byTestId('comment')
@@ -64,7 +65,7 @@ describe('LanguageItemComponent', () => {
         COMMENT_ELEMENT_SELECTOR,
       )
 
-      expect(commentElement.nativeElement.textContent.trim()).toEqual(comment)
+      expect(textContent(commentElement)).toEqual(comment)
     })
   })
 

--- a/src/app/resume-page/languages-section/language-item/language-tag/language-tag.component.spec.ts
+++ b/src/app/resume-page/languages-section/language-item/language-tag/language-tag.component.spec.ts
@@ -3,6 +3,7 @@ import { ComponentFixture } from '@angular/core/testing'
 import { LanguageTagComponent } from './language-tag.component'
 import { componentTestSetup } from '@/test/helpers/component-test-setup'
 import { By } from '@angular/platform-browser'
+import { textContent } from '@/test/helpers/text-content'
 
 describe('LanguageTagComponent', () => {
   let component: LanguageTagComponent
@@ -22,7 +23,7 @@ describe('LanguageTagComponent', () => {
     component.tag = tag
     fixture.detectChanges()
 
-    expect(fixture.debugElement.nativeElement.textContent.trim()).toContain(tag)
+    expect(textContent(fixture.debugElement)).toContain(tag)
   })
 
   it('should link tag to ISO page', () => {

--- a/src/app/resume-page/link/link.component.spec.ts
+++ b/src/app/resume-page/link/link.component.spec.ts
@@ -2,6 +2,7 @@ import { LinkComponent } from './link.component'
 import { By } from '@angular/platform-browser'
 import { Component, Type } from '@angular/core'
 import { componentTestSetup } from '@/test/helpers/component-test-setup'
+import { textContent } from '@/test/helpers/text-content'
 
 describe('LinkComponent', () => {
   it('should create', () => {
@@ -18,9 +19,7 @@ describe('LinkComponent', () => {
       const [fixture] = componentTestSetup(hostComponent)
       fixture.detectChanges()
 
-      expect(fixture.debugElement.nativeElement.textContent.trim()).toEqual(
-        someText,
-      )
+      expect(textContent(fixture.debugElement)).toEqual(someText)
     })
   }
 

--- a/src/app/resume-page/profile-section/profile-contacts/profile-contacts.component.spec.ts
+++ b/src/app/resume-page/profile-section/profile-contacts/profile-contacts.component.spec.ts
@@ -10,6 +10,7 @@ import { ATTRIBUTE_ARIA_LABEL } from '@/test/helpers/aria'
 import { JSON_RESUME_BASICS, JsonResumeBasics } from '../json-resume-basics'
 import { NgIcon } from '@ng-icons/core'
 import { NgForOf } from '@angular/common'
+import { textContent } from '@/test/helpers/text-content'
 
 describe('ProfileContactsComponent', () => {
   let component: ProfileContactsComponent
@@ -33,7 +34,7 @@ describe('ProfileContactsComponent', () => {
       By.css(`a[href="mailto:${email}"]`),
     )
 
-    expect(anchorElement.nativeElement.textContent.trim()).toEqual(Email)
+    expect(textContent(anchorElement)).toEqual(Email)
     expect(anchorElement.attributes[ATTRIBUTE_ARIA_LABEL]).toEqual('Email')
   })
 
@@ -48,7 +49,7 @@ describe('ProfileContactsComponent', () => {
       By.css(`a[href="tel:${phone}"]`),
     )
 
-    expect(anchorElement.nativeElement.textContent.trim()).toEqual(Call)
+    expect(textContent(anchorElement)).toEqual(Call)
     expect(anchorElement.attributes[ATTRIBUTE_ARIA_LABEL]).toEqual('Phone')
   })
 
@@ -70,7 +71,7 @@ describe('ProfileContactsComponent', () => {
       By.css(`a[href="${mapsUrl}"]`),
     )
 
-    expect(anchorElement.nativeElement.textContent.trim()).toEqual(MyLocation)
+    expect(textContent(anchorElement)).toEqual(MyLocation)
     expect(anchorElement.attributes[ATTRIBUTE_ARIA_LABEL]).toEqual('Location')
   })
 

--- a/src/app/resume-page/projects-section/project-item/project-item.component.spec.ts
+++ b/src/app/resume-page/projects-section/project-item/project-item.component.spec.ts
@@ -30,6 +30,7 @@ import { shouldContainComponent } from '@/test/helpers/component-testers'
 import { getComponentInstance } from '@/test/helpers/get-component-instance'
 import { TestIdDirective } from '@/common/test-id.directive'
 import { LinkComponent } from '../../link/link.component'
+import { textContent } from '@/test/helpers/text-content'
 
 describe('ProjectItemComponent', () => {
   let component: ProjectItemComponent
@@ -89,7 +90,7 @@ describe('ProjectItemComponent', () => {
 
     const titleElement = fixture.debugElement.query(byTestId('name'))
 
-    expect(titleElement.nativeElement.textContent.trim()).toEqual(name)
+    expect(textContent(titleElement)).toEqual(name)
   })
 
   describe('when no roles exist', () => {
@@ -112,7 +113,7 @@ describe('ProjectItemComponent', () => {
       const roleElement = fixture.debugElement.query(byTestId('role'))
 
       expect(roleElement).toBeTruthy()
-      expect(roleElement.nativeElement.textContent.trim()).toEqual(roles[0])
+      expect(textContent(roleElement)).toEqual(roles[0])
     })
   })
 
@@ -158,7 +159,7 @@ describe('ProjectItemComponent', () => {
         getComponentInstance(stackAttributeElement, AttributeComponent).symbol,
       ).toBe(stackContent.materialSymbol)
 
-      expect(stackAttributeElement.nativeElement.textContent.trim()).toEqual(
+      expect(textContent(stackAttributeElement)).toEqual(
         stackContent.displayName,
       )
     })

--- a/src/test/helpers/find-by-text.ts
+++ b/src/test/helpers/find-by-text.ts
@@ -1,10 +1,10 @@
 import { DebugElement } from '@angular/core'
+import { textContent } from '@/test/helpers/text-content'
 
 export const findByText = (
   debugElements: readonly DebugElement[],
   textMatcher: string,
 ): DebugElement | undefined =>
   debugElements.find(
-    (debugElement) =>
-      debugElement.nativeElement.textContent.trim() === textMatcher,
+    (debugElement) => textContent(debugElement) === textMatcher,
   )

--- a/src/test/helpers/material-symbols.ts
+++ b/src/test/helpers/material-symbols.ts
@@ -1,6 +1,7 @@
 import { By } from '@angular/platform-browser'
 import { MATERIAL_SYMBOLS_CLASS } from '@/common/material-symbol.directive'
 import { DebugElement } from '@angular/core'
+import { textContent } from '@/test/helpers/text-content'
 
 export const MATERIAL_SYMBOLS_SELECTOR = By.css(`.${MATERIAL_SYMBOLS_CLASS}`)
 export const findMaterialSymbolByText = (
@@ -9,9 +10,7 @@ export const findMaterialSymbolByText = (
 ) => {
   const icon = debugElement
     .queryAll(MATERIAL_SYMBOLS_SELECTOR)
-    .find(
-      (debugElement) => debugElement.nativeElement.textContent.trim() == text,
-    )
+    .find((debugElement) => textContent(debugElement) == text)
   expect(icon)
     .withContext(
       `icon with unicode escape \\u${text.charCodeAt(0).toString(16)} exists`,

--- a/src/test/helpers/text-content.ts
+++ b/src/test/helpers/text-content.ts
@@ -1,0 +1,4 @@
+import { DebugElement } from '@angular/core'
+
+export const textContent = (debugElement: DebugElement): string | undefined =>
+  debugElement.nativeElement?.textContent?.trim()


### PR DESCRIPTION
`debugElement.nativeElement.textContent.trim()` is repeated many times around. Can be simplified with a util. 

Adds `textContent` util, as it's repeated around and around
