### PR TITLE
build: update `package.json` export order as per Angular CLI warning

### DIFF
--- a/data/package.json
+++ b/data/package.json
@@ -5,8 +5,8 @@
   "type": "module",
   "exports": {
     "./*": {
-      "default": "./*",
-      "types": "./*.ts"
+      "types": "./*.ts",
+      "default": "./*"
     }
   }
 }


### PR DESCRIPTION
A warning appeared in `ng build` about `types` not taking effect due to coming after `default`. Solving that here
