### PR TITLE
build: remove unused component imports

### DIFF
--- a/src/app/common/simple-icon/simple-icon.component.ts
+++ b/src/app/common/simple-icon/simple-icon.component.ts
@@ -4,13 +4,12 @@ import {
   SimpleIconLoader,
 } from '@/common/simple-icon/simple-icon-loader'
 import { tap } from 'rxjs'
-import { AsyncPipe } from '@angular/common'
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop'
 import { SimpleIcon } from '@/common/simple-icon/simple-icon'
 
 @Component({
   selector: 'app-simple-icon',
-  imports: [AsyncPipe],
+  imports: [],
   templateUrl: './simple-icon.component.html',
   host: {
     '[style.fill]': '_fillColor',

--- a/src/app/header/navigation-tabs/navigation-tabs.component.ts
+++ b/src/app/header/navigation-tabs/navigation-tabs.component.ts
@@ -2,17 +2,10 @@ import { ChangeDetectionStrategy, Component, Input } from '@angular/core'
 import { TabComponent } from '../tab/tab.component'
 import { TabsComponent } from '../tabs/tabs.component'
 import { RouterLink, RouterLinkActive } from '@angular/router'
-import { ToolbarButtonComponent } from '../toolbar-button/toolbar-button.component'
 
 @Component({
   selector: 'app-navigation-tabs',
-  imports: [
-    TabsComponent,
-    TabComponent,
-    RouterLink,
-    RouterLinkActive,
-    ToolbarButtonComponent,
-  ],
+  imports: [TabsComponent, TabComponent, RouterLink, RouterLinkActive],
   templateUrl: './navigation-tabs.component.html',
   styleUrl: './navigation-tabs.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/src/app/resume-page/collapsible-tree/collapsible-tree.component.ts
+++ b/src/app/resume-page/collapsible-tree/collapsible-tree.component.ts
@@ -6,8 +6,7 @@ import {
   QueryList,
   ViewChildren,
 } from '@angular/core'
-import { MaterialSymbolDirective } from '@/common/material-symbol.directive'
-import { NgComponentOutlet, NgForOf, NgTemplateOutlet } from '@angular/common'
+import { NgComponentOutlet, NgTemplateOutlet } from '@angular/common'
 import {
   animate,
   AUTO_STYLE,
@@ -28,12 +27,7 @@ let nextId = 0
 
 @Component({
   selector: 'app-collapsible-tree',
-  imports: [
-    MaterialSymbolDirective,
-    NgTemplateOutlet,
-    NgComponentOutlet,
-    NgForOf,
-  ],
+  imports: [NgTemplateOutlet, NgComponentOutlet],
   templateUrl: './collapsible-tree.component.html',
   styleUrl: './collapsible-tree.component.scss',
   animations: [

--- a/src/app/resume-page/languages-section/language-item/language-item.component.ts
+++ b/src/app/resume-page/languages-section/language-item/language-item.component.ts
@@ -1,37 +1,21 @@
 import { Component, Input } from '@angular/core'
 import { LanguageItem } from './language-item'
-import { AttributeComponent } from '../../attribute/attribute.component'
 import { CardComponent } from '../../card/card.component'
-import { CardHeaderAttributesComponent } from '../../card/card-header/card-header-attributes/card-header-attributes.component'
 import { CardHeaderComponent } from '../../card/card-header/card-header.component'
-import { CardHeaderDetailComponent } from '../../card/card-header/card-header-detail/card-header-detail.component'
-import { CardHeaderImageComponent } from '../../card/card-header/card-header-image/card-header-image.component'
 import { CardHeaderSubtitleComponent } from '../../card/card-header/card-header-subtitle/card-header-subtitle.component'
 import { CardHeaderTextsComponent } from '../../card/card-header/card-header-texts/card-header-texts.component'
 import { CardHeaderTitleComponent } from '../../card/card-header/card-header-title/card-header-title.component'
-import { ChippedContentComponent } from '../../chipped-content/chipped-content.component'
-import { DateRangeComponent } from '../../date-range/date-range.component'
-import { LinkComponent } from '../../link/link.component'
-import { NgIf } from '@angular/common'
 import { TestIdDirective } from '@/common/test-id.directive'
 import { LanguageTagComponent } from './language-tag/language-tag.component'
 
 @Component({
   selector: 'app-language-item',
   imports: [
-    AttributeComponent,
     CardComponent,
-    CardHeaderAttributesComponent,
     CardHeaderComponent,
-    CardHeaderDetailComponent,
-    CardHeaderImageComponent,
     CardHeaderSubtitleComponent,
     CardHeaderTextsComponent,
     CardHeaderTitleComponent,
-    ChippedContentComponent,
-    DateRangeComponent,
-    LinkComponent,
-    NgIf,
     TestIdDirective,
     LanguageTagComponent,
   ],

--- a/src/app/resume-page/projects-section/project-item/project-item-technologies/project-item-technologies.component.ts
+++ b/src/app/resume-page/projects-section/project-item/project-item-technologies/project-item-technologies.component.ts
@@ -1,5 +1,4 @@
 import { Component, Input } from '@angular/core'
-import { ChipComponent } from '../../../chip/chip.component'
 import { NgForOf } from '@angular/common'
 import { TechnologyComponent } from '../../../technology/technology.component'
 import { TechnologyItem } from '../../../technology/technology-item'
@@ -9,7 +8,6 @@ import { ContentChipComponent } from '../../../content-chip/content-chip.compone
 @Component({
   selector: 'app-project-item-technologies',
   imports: [
-    ChipComponent,
     NgForOf,
     TechnologyComponent,
     ContentChipListComponent,

--- a/src/app/sports-page/sports-page.component.ts
+++ b/src/app/sports-page/sports-page.component.ts
@@ -7,7 +7,6 @@ import { CardHeaderTitleComponent } from '../resume-page/card/card-header/card-h
 import { CardHeaderSubtitleComponent } from '../resume-page/card/card-header/card-header-subtitle/card-header-subtitle.component'
 import { CardHeaderTextsComponent } from '../resume-page/card/card-header/card-header-texts/card-header-texts.component'
 import { ButtonComponent } from '../resume-page/button/button.component'
-import { CardHeaderDetailComponent } from '../resume-page/card/card-header/card-header-detail/card-header-detail.component'
 import { ContentPageComponent } from '../content-page/content-page.component'
 
 @Component({
@@ -21,7 +20,6 @@ import { ContentPageComponent } from '../content-page/content-page.component'
     CardHeaderSubtitleComponent,
     CardHeaderTextsComponent,
     ButtonComponent,
-    CardHeaderDetailComponent,
     NgTemplateOutlet,
     ContentPageComponent,
   ],


### PR DESCRIPTION
After Angular v19 upgrade, there are many warnings about unused components in `imports`

Running IDE inspection to find them and fix them all at once
