### PR TITLE
build: migrate sass @import and global built-in fns

### DIFF
--- a/src/app/common/simple-icon/simple-icon.component.ts
+++ b/src/app/common/simple-icon/simple-icon.component.ts
@@ -4,13 +4,12 @@ import {
   SimpleIconLoader,
 } from '@/common/simple-icon/simple-icon-loader'
 import { tap } from 'rxjs'
-import { AsyncPipe } from '@angular/common'
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop'
 import { SimpleIcon } from '@/common/simple-icon/simple-icon'
 
 @Component({
   selector: 'app-simple-icon',
-  imports: [AsyncPipe],
+  imports: [],
   templateUrl: './simple-icon.component.html',
   host: {
     '[style.fill]': '_fillColor',

--- a/src/app/header/navigation-tabs/navigation-tabs.component.ts
+++ b/src/app/header/navigation-tabs/navigation-tabs.component.ts
@@ -2,17 +2,10 @@ import { ChangeDetectionStrategy, Component, Input } from '@angular/core'
 import { TabComponent } from '../tab/tab.component'
 import { TabsComponent } from '../tabs/tabs.component'
 import { RouterLink, RouterLinkActive } from '@angular/router'
-import { ToolbarButtonComponent } from '../toolbar-button/toolbar-button.component'
 
 @Component({
   selector: 'app-navigation-tabs',
-  imports: [
-    TabsComponent,
-    TabComponent,
-    RouterLink,
-    RouterLinkActive,
-    ToolbarButtonComponent,
-  ],
+  imports: [TabsComponent, TabComponent, RouterLink, RouterLinkActive],
   templateUrl: './navigation-tabs.component.html',
   styleUrl: './navigation-tabs.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/src/app/resume-page/collapsible-tree/collapsible-tree.component.ts
+++ b/src/app/resume-page/collapsible-tree/collapsible-tree.component.ts
@@ -6,8 +6,7 @@ import {
   QueryList,
   ViewChildren,
 } from '@angular/core'
-import { MaterialSymbolDirective } from '@/common/material-symbol.directive'
-import { NgComponentOutlet, NgForOf, NgTemplateOutlet } from '@angular/common'
+import { NgComponentOutlet, NgTemplateOutlet } from '@angular/common'
 import {
   animate,
   AUTO_STYLE,
@@ -28,12 +27,7 @@ let nextId = 0
 
 @Component({
   selector: 'app-collapsible-tree',
-  imports: [
-    MaterialSymbolDirective,
-    NgTemplateOutlet,
-    NgComponentOutlet,
-    NgForOf,
-  ],
+  imports: [NgTemplateOutlet, NgComponentOutlet],
   templateUrl: './collapsible-tree.component.html',
   styleUrl: './collapsible-tree.component.scss',
   animations: [

--- a/src/app/resume-page/languages-section/language-item/language-item.component.ts
+++ b/src/app/resume-page/languages-section/language-item/language-item.component.ts
@@ -1,37 +1,21 @@
 import { Component, Input } from '@angular/core'
 import { LanguageItem } from './language-item'
-import { AttributeComponent } from '../../attribute/attribute.component'
 import { CardComponent } from '../../card/card.component'
-import { CardHeaderAttributesComponent } from '../../card/card-header/card-header-attributes/card-header-attributes.component'
 import { CardHeaderComponent } from '../../card/card-header/card-header.component'
-import { CardHeaderDetailComponent } from '../../card/card-header/card-header-detail/card-header-detail.component'
-import { CardHeaderImageComponent } from '../../card/card-header/card-header-image/card-header-image.component'
 import { CardHeaderSubtitleComponent } from '../../card/card-header/card-header-subtitle/card-header-subtitle.component'
 import { CardHeaderTextsComponent } from '../../card/card-header/card-header-texts/card-header-texts.component'
 import { CardHeaderTitleComponent } from '../../card/card-header/card-header-title/card-header-title.component'
-import { ChippedContentComponent } from '../../chipped-content/chipped-content.component'
-import { DateRangeComponent } from '../../date-range/date-range.component'
-import { LinkComponent } from '../../link/link.component'
-import { NgIf } from '@angular/common'
 import { TestIdDirective } from '@/common/test-id.directive'
 import { LanguageTagComponent } from './language-tag/language-tag.component'
 
 @Component({
   selector: 'app-language-item',
   imports: [
-    AttributeComponent,
     CardComponent,
-    CardHeaderAttributesComponent,
     CardHeaderComponent,
-    CardHeaderDetailComponent,
-    CardHeaderImageComponent,
     CardHeaderSubtitleComponent,
     CardHeaderTextsComponent,
     CardHeaderTitleComponent,
-    ChippedContentComponent,
-    DateRangeComponent,
-    LinkComponent,
-    NgIf,
     TestIdDirective,
     LanguageTagComponent,
   ],

--- a/src/app/resume-page/projects-section/project-item/project-item-technologies/project-item-technologies.component.ts
+++ b/src/app/resume-page/projects-section/project-item/project-item-technologies/project-item-technologies.component.ts
@@ -1,5 +1,4 @@
 import { Component, Input } from '@angular/core'
-import { ChipComponent } from '../../../chip/chip.component'
 import { NgForOf } from '@angular/common'
 import { TechnologyComponent } from '../../../technology/technology.component'
 import { TechnologyItem } from '../../../technology/technology-item'
@@ -9,7 +8,6 @@ import { ContentChipComponent } from '../../../content-chip/content-chip.compone
 @Component({
   selector: 'app-project-item-technologies',
   imports: [
-    ChipComponent,
     NgForOf,
     TechnologyComponent,
     ContentChipListComponent,

--- a/src/app/sports-page/sports-page.component.ts
+++ b/src/app/sports-page/sports-page.component.ts
@@ -7,7 +7,6 @@ import { CardHeaderTitleComponent } from '../resume-page/card/card-header/card-h
 import { CardHeaderSubtitleComponent } from '../resume-page/card/card-header/card-header-subtitle/card-header-subtitle.component'
 import { CardHeaderTextsComponent } from '../resume-page/card/card-header/card-header-texts/card-header-texts.component'
 import { ButtonComponent } from '../resume-page/button/button.component'
-import { CardHeaderDetailComponent } from '../resume-page/card/card-header/card-header-detail/card-header-detail.component'
 import { ContentPageComponent } from '../content-page/content-page.component'
 
 @Component({
@@ -21,7 +20,6 @@ import { ContentPageComponent } from '../content-page/content-page.component'
     CardHeaderSubtitleComponent,
     CardHeaderTextsComponent,
     ButtonComponent,
-    CardHeaderDetailComponent,
     NgTemplateOutlet,
     ContentPageComponent,
   ],

--- a/src/sass/_borders.scss
+++ b/src/sass/_borders.scss
@@ -1,13 +1,14 @@
+@use 'sass:list';
 $panel-width: 1px;
 $_panel-style: solid;
 $_panel-color: var(--sys-color-divider);
 $_panel-border-shorthand: $panel-width $_panel-style $_panel-color;
 
 @mixin panel($sides...) {
-  @if (length($sides) == 0) {
+  @if (list.length($sides) == 0) {
     border: $_panel-border-shorthand;
-  } @else if(length($sides) == 1) {
-    @include _panel-side(nth($sides, 1));
+  } @else if(list.length($sides) == 1) {
+    @include _panel-side(list.nth($sides, 1));
   } @else {
     border-color: $_panel-color;
     border-width: $panel-width;
@@ -19,7 +20,7 @@ $_panel-border-shorthand: $panel-width $_panel-style $_panel-color;
 
 $_border-sides: (top, bottom, left, right);
 @mixin _panel-side($side) {
-  @if index($_border-sides, $side) == null {
+  @if list.index($_border-sides, $side) == null {
     @error "Border side #{$side} is invalid";
   }
   border-#{$side}: $_panel-border-shorthand;

--- a/src/sass/_theming.scss
+++ b/src/sass/_theming.scss
@@ -1,30 +1,31 @@
 @use 'themes/constants';
 @use 'sass:selector';
 @use 'helpers/root-attribute';
-@import 'helpers/scss-to-css-vars';
+@use 'sass:map';
+@use 'helpers/scss-to-css-vars';
 
 @mixin define-theme($theme) {
-  @each $scheme in map-get($theme, schemes) {
+  @each $scheme in map.get($theme, schemes) {
     // When more themes are added, here we can do different if theme is not the default
     @include define-default-color-scheme($theme, $scheme);
   }
 }
 
 @mixin define-default-color-scheme($theme, $scheme) {
-  $theme-slug: map-get($theme, slug);
+  $theme-slug: map.get($theme, slug);
   @if not $theme-slug or $theme-slug == '' {
     @error "Theme slug is missing";
   }
-  $scheme-kind: map-get($scheme, kind);
+  $scheme-kind: map.get($scheme, kind);
   @if not $scheme-kind or $scheme-kind == '' {
     @error "Scheme kind is missing";
   }
-  $vars: map-get($scheme, vars);
+  $vars: map.get($scheme, vars);
 
   @if $scheme-kind == constants.$common-color-scheme-kind {
     :root,
     :root[data-theme='#{$theme-slug}'] {
-      @include scss-vars-to-css-vars($vars);
+      @include scss-to-css-vars.scss-vars-to-css-vars($vars);
     }
   }
   @if $scheme-kind == constants.$light-color-scheme-kind {
@@ -32,18 +33,18 @@
     :root[data-theme='#{$theme-slug}'],
     :root[data-color-scheme='#{$scheme-kind}'],
     :root[data-theme='#{$theme-slug}'][data-color-scheme='#{$scheme-kind}'] {
-      @include scss-vars-to-css-vars($vars);
+      @include scss-to-css-vars.scss-vars-to-css-vars($vars);
     }
   } @else if $scheme-kind == constants.$dark-color-scheme-kind {
     @media (prefers-color-scheme: dark) {
       :root,
       :root[data-theme='#{$theme-slug}'] {
-        @include scss-vars-to-css-vars($vars);
+        @include scss-to-css-vars.scss-vars-to-css-vars($vars);
       }
     }
     :root[data-color-scheme='#{$scheme-kind}'],
     :root[data-theme='#{$theme-slug}'][data-color-scheme='#{$scheme-kind}'] {
-      @include scss-vars-to-css-vars($vars);
+      @include scss-to-css-vars.scss-vars-to-css-vars($vars);
     }
   }
 }

--- a/src/sass/themes/_devtools-common-scheme.scss
+++ b/src/sass/themes/_devtools-common-scheme.scss
@@ -1,7 +1,7 @@
-@import 'constants';
+@use 'constants';
 
-$devtools-common-scheme: (
-  kind: $common-color-scheme-kind,
+$scheme: (
+  kind: constants.$common-color-scheme-kind,
   vars: (
     // https://github.com/ChromeDevTools/devtools-frontend/blob/7500d2916c463c136fc5ce2547ceb469c61454b4/front_end/ui/legacy/tokens.css
     // Or locally by `devtools://theme/colors.css?sets=ui,chrome` (may change depending on current theme)

--- a/src/sass/themes/_devtools-dark-scheme.scss
+++ b/src/sass/themes/_devtools-dark-scheme.scss
@@ -1,7 +1,7 @@
-@import 'constants';
+@use 'constants';
 
-$devtools-dark-scheme: (
-  kind: $dark-color-scheme-kind,
+$scheme: (
+  kind: constants.$dark-color-scheme-kind,
   vars: (
     sys-color-base: var(--ref-palette-neutral25),
     app-color-toolbar-background: var(--sys-color-base),

--- a/src/sass/themes/_devtools-light-scheme.scss
+++ b/src/sass/themes/_devtools-light-scheme.scss
@@ -1,7 +1,7 @@
-@import 'constants';
+@use 'constants';
 
-$devtools-light-scheme: (
-  kind: $light-color-scheme-kind,
+$scheme: (
+  kind: constants.$light-color-scheme-kind,
   vars: (
     app-color-toolbar-background: var(--sys-color-surface4),
     sys-color-on-surface: var(--ref-palette-neutral10),

--- a/src/sass/themes/devtools.scss
+++ b/src/sass/themes/devtools.scss
@@ -1,15 +1,15 @@
-@import 'devtools-common-scheme';
-@import 'devtools-light-scheme';
-@import 'devtools-dark-scheme';
-@import '../theming';
+@use 'devtools-common-scheme';
+@use 'devtools-light-scheme';
+@use 'devtools-dark-scheme';
+@use '../theming';
 
 $devtools-theme: (
   slug: 'devtools',
   schemes: (
-    $devtools-common-scheme,
-    $devtools-light-scheme,
-    $devtools-dark-scheme,
+    devtools-common-scheme.$scheme,
+    devtools-light-scheme.$scheme,
+    devtools-dark-scheme.$scheme,
   ),
 );
 
-@include define-theme($devtools-theme);
+@include theming.define-theme($devtools-theme);


### PR DESCRIPTION
After upgrading to v19, several SCSS warnings appeared related to deprecations. Some of them are related to the use of deprecated `@import` and global built-in functions. See https://sass-lang.com/documentation/breaking-changes/import/


Using the migrator to fix them all automagically:

```shell
pnpm dlx sass-migrator module --migrate-deps src/**/*.scss --load-path src/sass
```

Closes #846 

