### PR TITLE
style: avoid public when unneeded

### DIFF
--- a/data/metadata.ts
+++ b/data/metadata.ts
@@ -36,10 +36,10 @@ const YEARS_OF_EXPERIENCE = Math.abs(
 )
 
 export class DescriptionLine {
-  public readonly data?: DescriptionLineData
-  public readonly children: readonly DescriptionLine[]
+  readonly data?: DescriptionLineData
+  readonly children: readonly DescriptionLine[]
 
-  public constructor(
+  constructor(
     data?: DescriptionLineData,
     children?: readonly DescriptionLine[],
   ) {
@@ -47,7 +47,7 @@ export class DescriptionLine {
     this.children = children ?? []
   }
 
-  public static fromData(
+  static fromData(
     dataArg: ConstructorParameters<typeof DescriptionLineData>[0],
     children?: readonly DescriptionLine[],
   ) {
@@ -56,11 +56,11 @@ export class DescriptionLine {
 }
 
 export class DescriptionLineData {
-  public readonly symbol: string
-  public readonly html: string
-  public readonly text: string
+  readonly symbol: string
+  readonly html: string
+  readonly text: string
 
-  public constructor({
+  constructor({
     symbol,
     html,
     text,

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -34,6 +34,12 @@ export default tsEslint.config(
       ...tsEslint.configs.recommended,
       ...tsEslint.configs.stylistic,
     ],
+    rules: {
+      '@typescript-eslint/explicit-member-accessibility': [
+        'error',
+        { accessibility: 'no-public' },
+      ],
+    },
   },
   {
     files: ['src/**/*.ts'],

--- a/src/app/common/platform.service.ts
+++ b/src/app/common/platform.service.ts
@@ -2,7 +2,7 @@ import { isPlatformBrowser } from '@angular/common'
 import { inject, InjectionToken, PLATFORM_ID } from '@angular/core'
 
 export class PlatformService {
-  constructor(public readonly isBrowser: boolean) {}
+  constructor(readonly isBrowser: boolean) {}
 }
 
 export const PLATFORM_SERVICE = new InjectionToken<PlatformService>(

--- a/src/app/common/test-id.directive.spec.ts
+++ b/src/app/common/test-id.directive.spec.ts
@@ -34,7 +34,7 @@ function makeComponentWithChildElementHavingTestIdDirectiveSetTo({
     imports: [TestIdDirective],
   })
   class TestIdComponent {
-    public readonly testId = testId
+    readonly testId = testId
   }
   return TestIdComponent
 }

--- a/src/app/common/test-id.directive.ts
+++ b/src/app/common/test-id.directive.ts
@@ -1,11 +1,11 @@
-import { Directive, ElementRef, OnChanges, input } from '@angular/core'
+import { Directive, ElementRef, input, OnChanges } from '@angular/core'
 
 @Directive({
   selector: '[appTestId]',
   standalone: true,
 })
 export class TestIdDirective implements OnChanges {
-  public readonly appTestId = input.required<string>()
+  readonly appTestId = input.required<string>()
 
   constructor(private el: ElementRef) {}
 

--- a/src/app/header/tabs/tabs.component.spec.ts
+++ b/src/app/header/tabs/tabs.component.spec.ts
@@ -99,8 +99,8 @@ const makeHostComponent = (
     imports: [TabsComponent, TabComponent],
   })
   class HostComponent {
-    public tabs = opts.tabs ?? []
-    public selectedIndex = opts.selectedIndex
+    tabs = opts.tabs ?? []
+    selectedIndex = opts.selectedIndex
   }
 
   return HostComponent

--- a/src/app/header/tabs/tabs.component.ts
+++ b/src/app/header/tabs/tabs.component.ts
@@ -43,7 +43,7 @@ export class TabsComponent implements OnDestroy {
   private _lastTab?: ElementRef<HTMLElement>
   protected _prevButtonDisabled = signal(true)
   protected _nextButtonDisabled = signal(true)
-  public _intersectionObserver!: IntersectionObserver
+  private _intersectionObserver!: IntersectionObserver
 
   // Selected management
   private _currentTabs: readonly TabComponent[] = []

--- a/src/app/not-found-page/not-found-page.component.ts
+++ b/src/app/not-found-page/not-found-page.component.ts
@@ -11,7 +11,7 @@ import { APP_BASE_URL } from '@/common/app-base-url'
   imports: [MaterialSymbolDirective],
 })
 export class NotFoundPageComponent {
-  public readonly currentUrlInWaybackMachine: URL
+  readonly currentUrlInWaybackMachine: URL
   protected readonly MaterialSymbol = {
     Lightbulb,
   }

--- a/src/app/resume-page/chip/chip.component.ts
+++ b/src/app/resume-page/chip/chip.component.ts
@@ -18,20 +18,20 @@ export class ChipComponent {
   readonly selected = input<boolean>()
 
   @Output()
-  public selectedChange = new EventEmitter<boolean>()
+  selectedChange = new EventEmitter<boolean>()
 
   @HostBinding('class.selectable')
-  public get selectable() {
+  get selectable() {
     return this.selectedChange.observed
   }
 
   @HostBinding('attr.role')
-  public get ariaRole(): string | undefined {
+  get ariaRole(): string | undefined {
     return this.selectable ? 'button' : undefined
   }
 
   @HostBinding('attr.tabindex')
-  public get tabIndex(): string | undefined {
+  get tabIndex(): string | undefined {
     return this.selectable ? (0).toString() : undefined
   }
 

--- a/src/app/resume-page/chip/chip.component.ts
+++ b/src/app/resume-page/chip/chip.component.ts
@@ -15,7 +15,7 @@ import {
   host: { '[class.selected]': 'selected()' },
 })
 export class ChipComponent {
-  public readonly selected = input<boolean>()
+  readonly selected = input<boolean>()
 
   @Output()
   public selectedChange = new EventEmitter<boolean>()

--- a/src/app/resume-page/chipped-content/chipped-content.component.spec.ts
+++ b/src/app/resume-page/chipped-content/chipped-content.component.spec.ts
@@ -178,14 +178,14 @@ describe('ChippedContentComponent', () => {
   template: `{{ data }}`,
 })
 class FooComponent {
-  @Input() public data?: string
+  @Input() data?: string
 }
 @Component({
   selector: 'app-bar',
   template: `{{ data }}`,
 })
 class BarComponent {
-  @Input() public data?: string
+  @Input() data?: string
 }
 
 const FOO_CONTENT = new ChippedContent({

--- a/src/app/resume-page/chipped-content/chipped-content.component.ts
+++ b/src/app/resume-page/chipped-content/chipped-content.component.ts
@@ -41,7 +41,7 @@ import { SCROLL_INTO_VIEW, ScrollIntoView } from '@/common/scroll-into-view'
   ],
 })
 export class ChippedContentComponent {
-  @Input() public contents!: readonly ChippedContent[]
+  @Input() contents!: readonly ChippedContent[]
 
   constructor(
     @Inject(SCROLL_INTO_VIEW) protected _scrollIntoView: ScrollIntoView,

--- a/src/app/resume-page/chipped-content/chipped-content.ts
+++ b/src/app/resume-page/chipped-content/chipped-content.ts
@@ -1,9 +1,9 @@
 import { Type } from '@angular/core'
 
 export class ChippedContent<T = unknown> {
-  public readonly displayName: string
-  public readonly component: Type<T>
-  public readonly inputs?: Partial<T>
+  readonly displayName: string
+  readonly component: Type<T>
+  readonly inputs?: Partial<T>
 
   constructor({
     displayName,

--- a/src/app/resume-page/collapsible-tree/collapsible-tree-node.ts
+++ b/src/app/resume-page/collapsible-tree/collapsible-tree-node.ts
@@ -2,15 +2,15 @@ import { NgComponentOutlet } from '@angular/common'
 
 export class CollapsibleTreeNode {
   constructor(
-    public readonly data?: CollapsibleTreeNodeData,
-    public readonly children: readonly CollapsibleTreeNode[] = [],
+    readonly data?: CollapsibleTreeNodeData,
+    readonly children: readonly CollapsibleTreeNode[] = [],
   ) {}
 }
 
 export class CollapsibleTreeNodeData {
   constructor(
-    public readonly component: NgComponentOutlet['ngComponentOutlet'],
-    public readonly options: {
+    readonly component: NgComponentOutlet['ngComponentOutlet'],
+    readonly options: {
       inputs?: NgComponentOutlet['ngComponentOutletInputs']
     } = {},
   ) {}

--- a/src/app/resume-page/collapsible-tree/collapsible-tree.component.ts
+++ b/src/app/resume-page/collapsible-tree/collapsible-tree.component.ts
@@ -47,15 +47,14 @@ let nextId = 0
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class CollapsibleTreeComponent {
-  @Input({ required: true }) public node!: CollapsibleTreeNode
-  @Input() public depth = 0
-  @Input() public parent?: CollapsibleTreeComponent
-  @Input() public collapsedIcon: string = this.parent?.collapsedIcon ?? '▶'
-  @Input() public expandedIcon: string = this.parent?.expandedIcon ?? '▼'
-  @Input() public isCollapsibleFn?: IsCollapsibleFn =
-    this.parent?.isCollapsibleFn
+  @Input({ required: true }) node!: CollapsibleTreeNode
+  @Input() depth = 0
+  @Input() parent?: CollapsibleTreeComponent
+  @Input() collapsedIcon: string = this.parent?.collapsedIcon ?? '▶'
+  @Input() expandedIcon: string = this.parent?.expandedIcon ?? '▼'
+  @Input() isCollapsibleFn?: IsCollapsibleFn = this.parent?.isCollapsibleFn
   @Input()
-  public isExpanded = false
+  isExpanded = false
 
   @ViewChildren(CollapsibleTreeComponent)
   private children!: QueryList<CollapsibleTreeComponent>
@@ -64,7 +63,7 @@ export class CollapsibleTreeComponent {
 
   constructor(private readonly cdRef: ChangeDetectorRef) {}
 
-  public get isCollapsible(): boolean {
+  get isCollapsible(): boolean {
     if (!(this.node.children.length > 0)) {
       return false
     }
@@ -74,7 +73,7 @@ export class CollapsibleTreeComponent {
     return this.isCollapsibleFn(this)
   }
 
-  public get childListId(): string | undefined {
+  get childListId(): string | undefined {
     if (!this.isCollapsible) {
       return
     }

--- a/src/app/resume-page/date-range/date-range.component.ts
+++ b/src/app/resume-page/date-range/date-range.component.ts
@@ -8,5 +8,5 @@ import { DatePipe } from '@angular/common'
   imports: [DatePipe],
 })
 export class DateRangeComponent {
-  public readonly range = input.required<DateRange>()
+  readonly range = input.required<DateRange>()
 }

--- a/src/app/resume-page/date-range/date-range.ts
+++ b/src/app/resume-page/date-range/date-range.ts
@@ -1,6 +1,6 @@
 export class DateRange {
   constructor(
-    public readonly start: Date,
-    public readonly end?: Date,
+    readonly start: Date,
+    readonly end?: Date,
   ) {}
 }

--- a/src/app/resume-page/education-section/education-item/education-item.component.ts
+++ b/src/app/resume-page/education-section/education-item/education-item.component.ts
@@ -40,7 +40,7 @@ import { educationItemToContents } from './education-item-to-contents'
 export class EducationItemComponent {
   // TODO: Skipped for migration because:
   //  Accessor inputs cannot be migrated as they are too complex.
-  @Input({ required: true }) public set item(item: EducationItem) {
+  @Input({ required: true }) set item(item: EducationItem) {
     this._item = item
     if (item.institution.name.length > 15 && item.institution.shortName) {
       this._institutionDisplayName = item.institution.shortName

--- a/src/app/resume-page/education-section/education-item/education-item.ts
+++ b/src/app/resume-page/education-section/education-item/education-item.ts
@@ -2,13 +2,13 @@ import { Organization } from '../../organization'
 import { DateRange } from '../../date-range/date-range'
 
 export class EducationItem {
-  public readonly institution: Organization
-  public readonly area: string
-  public readonly studyType: string
-  public readonly dateRange: DateRange
-  public readonly score: string
-  public readonly courses: readonly string[]
-  public readonly cumLaude: boolean
+  readonly institution: Organization
+  readonly area: string
+  readonly studyType: string
+  readonly dateRange: DateRange
+  readonly score: string
+  readonly courses: readonly string[]
+  readonly cumLaude: boolean
 
   constructor({
     institution,

--- a/src/app/resume-page/experience-section/experience-item/experience-item-highlights/experience-item-highlights.component.ts
+++ b/src/app/resume-page/experience-section/experience-item/experience-item-highlights/experience-item-highlights.component.ts
@@ -13,5 +13,5 @@ import { Component, Input } from '@angular/core'
   imports: [],
 })
 export class ExperienceItemHighlightsComponent {
-  @Input({ required: true }) public highlights!: readonly string[]
+  @Input({ required: true }) highlights!: readonly string[]
 }

--- a/src/app/resume-page/experience-section/experience-item/experience-item-tech/experience-item-tech.component.ts
+++ b/src/app/resume-page/experience-section/experience-item/experience-item-tech/experience-item-tech.component.ts
@@ -16,8 +16,8 @@ import { TechnologyComponent } from '../../../technology/technology.component'
   styleUrl: './experience-item-tech.component.scss',
 })
 export class ExperienceItemTechComponent {
-  @Input({ required: true }) public technologies!: readonly TechnologyItem[]
-  @Input({ required: true }) public set projectNames(names: readonly string[]) {
+  @Input({ required: true }) technologies!: readonly TechnologyItem[]
+  @Input({ required: true }) set projectNames(names: readonly string[]) {
     this._projectCount = names.length
     this._projectNames = new Intl.ListFormat('en').format(names)
   }

--- a/src/app/resume-page/experience-section/experience-item/experience-item.component.ts
+++ b/src/app/resume-page/experience-section/experience-item/experience-item.component.ts
@@ -40,7 +40,7 @@ import { experienceItemToContents } from './experience-item-to-contents'
 export class ExperienceItemComponent {
   // TODO: Skipped for migration because:
   //  Accessor inputs cannot be migrated as they are too complex.
-  @Input({ required: true }) public set item(item: ExperienceItem) {
+  @Input({ required: true }) set item(item: ExperienceItem) {
     this._item = item
     this._contents = experienceItemToContents(item)
   }

--- a/src/app/resume-page/experience-section/experience-item/experience-item.ts
+++ b/src/app/resume-page/experience-section/experience-item/experience-item.ts
@@ -3,16 +3,16 @@ import { DateRange } from '../../date-range/date-range'
 import { ProjectItem } from '../../projects-section/project-item/project-item'
 
 export class ExperienceItem {
-  public readonly company: Organization
-  public readonly position: string
-  public readonly dateRange: DateRange
-  public readonly summary: string
-  public readonly highlights: readonly string[]
-  public readonly freelance: boolean
-  public readonly internship: boolean
-  public readonly promotions: boolean
-  public readonly morePositions: boolean
-  public readonly projects: readonly ProjectItem[]
+  readonly company: Organization
+  readonly position: string
+  readonly dateRange: DateRange
+  readonly summary: string
+  readonly highlights: readonly string[]
+  readonly freelance: boolean
+  readonly internship: boolean
+  readonly promotions: boolean
+  readonly morePositions: boolean
+  readonly projects: readonly ProjectItem[]
 
   constructor({
     company,

--- a/src/app/resume-page/languages-section/language-item/language-tag/language-tag.component.ts
+++ b/src/app/resume-page/languages-section/language-item/language-tag/language-tag.component.ts
@@ -9,7 +9,7 @@ import { Component, Input } from '@angular/core'
 export class LanguageTagComponent {
   // TODO: Skipped for migration because:
   //  Accessor inputs cannot be migrated as they are too complex.
-  @Input({ required: true }) public set tag(tag: string) {
+  @Input({ required: true }) set tag(tag: string) {
     this._tag = tag
     this._url = getUrlForIso6391Tag(tag)
   }

--- a/src/app/resume-page/link/link.component.spec.ts
+++ b/src/app/resume-page/link/link.component.spec.ts
@@ -62,7 +62,7 @@ function makeHostComponent(
     imports: [LinkComponent],
   })
   class TestHostComponent {
-    public href = href
+    href = href
   }
   return TestHostComponent
 }

--- a/src/app/resume-page/link/link.component.ts
+++ b/src/app/resume-page/link/link.component.ts
@@ -7,5 +7,5 @@ import { NgTemplateOutlet } from '@angular/common'
   imports: [NgTemplateOutlet],
 })
 export class LinkComponent {
-  public readonly href = input.required<string | undefined>()
+  readonly href = input.required<string | undefined>()
 }

--- a/src/app/resume-page/organization.ts
+++ b/src/app/resume-page/organization.ts
@@ -1,8 +1,8 @@
 export class Organization {
-  public readonly name: string
-  public readonly website?: URL
-  public readonly imageSrc: string
-  public readonly shortName?: string
+  readonly name: string
+  readonly website?: URL
+  readonly imageSrc: string
+  readonly shortName?: string
 
   constructor({
     name,

--- a/src/app/resume-page/profile-section/profile-picture/profile-picture.component.ts
+++ b/src/app/resume-page/profile-section/profile-picture/profile-picture.component.ts
@@ -13,18 +13,18 @@ export class ProfilePictureComponent {
   readonly realName: string
   protected _hasBeenFocused = false
 
-  public static HAS_BEEN_FOCUSED_ATTR = 'data-has-been-focused'
+  static HAS_BEEN_FOCUSED_ATTR = 'data-has-been-focused'
 
   @HostBinding(`attr.${ProfilePictureComponent.HAS_BEEN_FOCUSED_ATTR}`)
-  public get hasBeenFocused() {
+  get hasBeenFocused() {
     return this._hasBeenFocused ? true : undefined
   }
 
-  @HostBinding('attr.tabindex') public get tabIndex() {
+  @HostBinding('attr.tabindex') get tabIndex() {
     return this.hasBeenFocused ? 0 : -1
   }
 
-  @HostBinding('attr.aria-label') public ariaLabel = 'Profile picture'
+  @HostBinding('attr.aria-label') ariaLabel = 'Profile picture'
 
   constructor(@Inject(METADATA) metadata: Metadata) {
     this.realName = metadata.realName

--- a/src/app/resume-page/projects-section/project-item/project-item-technologies/project-item-technologies.component.ts
+++ b/src/app/resume-page/projects-section/project-item/project-item-technologies/project-item-technologies.component.ts
@@ -15,5 +15,5 @@ import { ContentChipComponent } from '../../../content-chip/content-chip.compone
   templateUrl: './project-item-technologies.component.html',
 })
 export class ProjectItemTechnologiesComponent {
-  @Input({ required: true }) public items!: readonly TechnologyItem[]
+  @Input({ required: true }) items!: readonly TechnologyItem[]
 }

--- a/src/app/resume-page/projects-section/project-item/project-item.component.ts
+++ b/src/app/resume-page/projects-section/project-item/project-item.component.ts
@@ -40,7 +40,7 @@ import { projectItemToContents } from './project-item-to-contents'
 export class ProjectItemComponent {
   // TODO: Skipped for migration because:
   //  Accessor inputs cannot be migrated as they are too complex.
-  @Input({ required: true }) public set item(item: ProjectItem) {
+  @Input({ required: true }) set item(item: ProjectItem) {
     this._item = item
     this._contents = projectItemToContents(item)
   }

--- a/src/app/resume-page/projects-section/project-item/project-item.ts
+++ b/src/app/resume-page/projects-section/project-item/project-item.ts
@@ -2,14 +2,14 @@ import { DateRange } from '../../date-range/date-range'
 import { TechnologyItem } from '../../technology/technology-item'
 
 export class ProjectItem {
-  public readonly name: string
-  public readonly description: string
-  public readonly dateRange: DateRange
-  public readonly website?: URL
-  public readonly roles: readonly string[]
-  public readonly imageSrc?: string
-  public readonly stack?: Stack
-  public readonly technologies: readonly TechnologyItem[]
+  readonly name: string
+  readonly description: string
+  readonly dateRange: DateRange
+  readonly website?: URL
+  readonly roles: readonly string[]
+  readonly imageSrc?: string
+  readonly stack?: Stack
+  readonly technologies: readonly TechnologyItem[]
 
   constructor({
     name,


### PR DESCRIPTION
After migrating to v19 with shorter syntaxes around, I saw many `public` accessibility modifiers around. However that's the default for a class / interface member. And it's something well known.

So to write less code, let's avoid writing those. Here a linter rule is enabled to prevent `public` from being explicitly specified. And changes are done to pass that linter rule.

Finally, `_intersectionObserver` is made `private` as it isn't meant to be exposed.
