### PR TITLE
build: add naming convention linter rules

### DIFF
--- a/.idea/runConfigurations/Lint__typed.xml
+++ b/.idea/runConfigurations/Lint__typed.xml
@@ -1,0 +1,12 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Lint: typed" type="js.build_tools.npm">
+    <package-json value="$PROJECT_DIR$/package.json" />
+    <command value="run" />
+    <scripts>
+      <script value="lint:code:typed" />
+    </scripts>
+    <node-interpreter value="project" />
+    <envs />
+    <method v="2" />
+  </configuration>
+</component>

--- a/.lintstagedrc.json
+++ b/.lintstagedrc.json
@@ -1,7 +1,7 @@
 {
   "!*.{html,ts,json}": ["pnpm run format:files"],
   "**/*.{html,ts,json}": [
-    "pnpm run lint:code:files --fix",
+    "pnpm run lint:code:files:typed --fix",
     "pnpm run format:files"
   ],
   ".github/**/*.y?(a)ml": ["pnpm run lint:gh-actions"]

--- a/README.md
+++ b/README.md
@@ -96,6 +96,9 @@ By default, [Typescript typed linting](https://typescript-eslint.io/getting-star
 pnpm run lint:code:typed
 ```
 
+> [!NOTE]
+> Except for `lint-staged`. Trying out to weigh if the development experience feelings.
+
 ## Release
 
 [Release It!][release-it] is used to automate the release process. With the [conventional changelog plugin][release-it-cc] in order to automatically decide which kind of bump to perform (major, minor, patch) based on unreleased commits' messages.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 [![Git](https://img.shields.io/badge/VCS-Git-f05032?logo=git&logoColor=f05032&link=https%3A%2F%git-scm.com%2F)](https://git-scm.com/)
 [![GitHub](https://img.shields.io/badge/Repository%20hosting-GitHub-181717?logo=github&logoColor=181717&link=https%3A%2F%github.com%2F)](https://github.com/)
 [![Package manager: pnpm](https://img.shields.io/badge/Package_manager-pnpm-f69220?logo=pnpm&link=https%3A%2F%2Fpnpm.io%2F)](https://pnpm.io/)
-[![Linted with ESLint](https://img.shields.io/badge/Linted_with-ESLint-3A33D1?logo=eslint&logoColor=white&link=https%3A%2F%2Feslint.org)](https://eslint.org)
+[![Linted with ESLint](https://img.shields.io/badge/Linted_with-ESLint-3A33D1?logo=eslint&logoColor=white&link=https%3A%2F%2Feslint.org)][ESLint]
 [![Unit tests with Jasmine](https://img.shields.io/badge/Unit_tests_with-Jasmine-8A4182?logo=Jasmine&logoColor=white&link=https%3A%2F%2Fjasmine.github.io)](https://jasmine.github.io)
 [![Unit tests ran by Karma](https://custom-icon-badges.demolab.com/badge/Unit_tests_ran_by-Karma-42beae.svg?logo=karma-runner&link=https%3A%2F%2Fkarma-runner.github.io)](https://karma-runner.github.io)
 [![Component Testing with Cypress](https://img.shields.io/badge/Component_Testing_with-Cypress-green?logo=cypress&link=https%3A%2F%2Fwww.cypress.io)](https://www.cypress.io)
@@ -25,6 +25,8 @@
 [![Released with Release It!](https://img.shields.io/badge/Released_with-%F0%9F%9A%80_Release_It!-black?link=https%3A%2F%2Fgithub.com%2Frelease-it%2Frelease-it)](https://github.com/release-it/release-it)
 [![Dependencies updated with Renovate](https://img.shields.io/badge/Dependencies_updated_with-Renovate-1a1f6c?logo=renovate&logoColor=white&link=https%3A%2F%2Frenovatebot.com)](https://renovatebot.com)
 [![Deployed via Cloudflare Pages](https://img.shields.io/badge/Deployed_via-Cloudflare%20Pages-f38020?logo=cloudflarepages&link=https%3A%2F%pages.cloudflare.com%2F)](https://pages.cloudflare.com/)
+
+[ESLint]: https://eslint.org
 
 This project was generated with [Angular CLI](https://github.com/angular/angular-cli) version 16.2.0.
 
@@ -79,6 +81,20 @@ pnpm run commitlint:last
 ```
 
 [commitlint]: https://github.com/conventional-changelog/commitlint
+
+## Lint
+
+Linting is enabled via [Angular ESLint](https://github.com/angular-eslint/angular-eslint) which adds some nice [ESLint] default configurations for Angular projects. Some additions are done in top of that to lint more files, `package.json`, Jasmine & Cypress... Run the linter for the whole project via:
+
+```shell
+pnpm run lint:code
+```
+
+By default, [Typescript typed linting](https://typescript-eslint.io/getting-started/typed-linting/) is disabled for performance reasons. However, you can enable it to check everything's okay with rules that require types via:
+
+```shell
+pnpm run lint:code:typed
+```
 
 ## Release
 

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -1,5 +1,5 @@
 import { defineConfig } from 'cypress'
-import { CoverageWebpackConfig } from './cypress/coverage-webpack-config'
+import { COVERAGE_WEBPACK_CONFIG } from './cypress/coverage-webpack-config'
 import registerCodeCoverageTasks from '@cypress/code-coverage/task'
 
 export default defineConfig({
@@ -31,7 +31,7 @@ export default defineConfig({
           },
         },
       },
-      webpackConfig: CoverageWebpackConfig,
+      webpackConfig: COVERAGE_WEBPACK_CONFIG,
     },
     specPattern: '**/*.cy.ts',
     setupNodeEvents(on, config) {

--- a/cypress/coverage-webpack-config.ts
+++ b/cypress/coverage-webpack-config.ts
@@ -1,4 +1,4 @@
-export const CoverageWebpackConfig = {
+export const COVERAGE_WEBPACK_CONFIG = {
   module: {
     rules: [
       {

--- a/data/material-symbols.ts
+++ b/data/material-symbols.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/naming-convention */
 export const DarkMode = '\ue51c'
 export const LightMode = '\ue518'
 export const Warning = '\ue002'

--- a/data/resume.json
+++ b/data/resume.json
@@ -71,7 +71,7 @@
         "Installed New Relic as observability tool"
       ],
       "image": "https://davidlj95.com/images/companies/vesto.png",
-      "freelance": true
+      "isFreelance": true
     },
     {
       "name": "Koa Health",
@@ -89,7 +89,7 @@
         "Assisted company spin off by programmatically setting up new email signatures for all employees"
       ],
       "image": "https://davidlj95.com/images/companies/koa-health.png",
-      "promotions": true
+      "hasPromotions": true
     },
     {
       "name": "Telefónica Alpha",
@@ -114,7 +114,7 @@
         "Facilitated software project management"
       ],
       "image": "https://davidlj95.com/images/companies/btc-assessors.png",
-      "morePositions": true
+      "hasMorePositions": true
     },
     {
       "name": "SEAT",
@@ -124,8 +124,8 @@
       "endDate": "2017-06-19",
       "summary": "Organized integration of IBC Biomechanics software within SEAT IT systems. In order to be used for its internal biomechanical laboratory in the CARS center inside Martorell headquarters",
       "image": "https://davidlj95.com/images/companies/seat.png",
-      "freelance": true,
-      "internship": true
+      "isFreelance": true,
+      "isInternship": true
     },
     {
       "name": "Meditrauma",
@@ -142,7 +142,7 @@
         "Maintained labor risk prevention and medical equipment hardware and services. Like audiometers, X-Ray machines and ECGs"
       ],
       "image": "https://davidlj95.com/images/companies/meditrauma.png",
-      "freelance": true
+      "isFreelance": true
     },
     {
       "name": "IBC Biomechanics",
@@ -157,8 +157,8 @@
         "Managed and maintained company's IT infrastructure: workstations, office software, endpoint protection and backups"
       ],
       "image": "https://davidlj95.com/images/companies/ibc-biomechanics.png",
-      "freelance": true,
-      "morePositions": true
+      "isFreelance": true,
+      "hasMorePositions": true
     }
   ],
   "education": [
@@ -209,7 +209,7 @@
       ],
       "shortName": "UAB",
       "image": "https://davidlj95.com/images/education/uab.png",
-      "cumLaude": true
+      "isCumLaude": true
     },
     {
       "institution": "Institut de Mollet del Vallès",
@@ -232,7 +232,7 @@
       ],
       "shortName": "IES Mollet",
       "image": "https://davidlj95.com/images/education/ies-mollet.png",
-      "cumLaude": true,
+      "isCumLaude": true,
       "printHidden": true
     }
   ],

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -17,16 +17,19 @@ const __filename = fileURLToPath(import.meta.url)
 const __dirname = dirname(__filename)
 const gitignorePath = resolve(__dirname, '.gitignore')
 
+const filterExcludingNodejsGlobals = {
+  filter: {
+    match: false,
+    regex: '__(dirname|filename)',
+  },
+}
 const namingConventionRules = {
   '@typescript-eslint/naming-convention': [
     'error',
     {
       selector: 'variableLike',
       format: ['camelCase'],
-      filter: {
-        match: false,
-        regex: '__(dirname|filename)',
-      },
+      ...filterExcludingNodejsGlobals,
     },
     {
       selector: 'memberLike',
@@ -43,10 +46,7 @@ const namingConventionRules = {
     {
       selector: 'variable',
       format: ['camelCase', 'UPPER_CASE'],
-      filter: {
-        match: false,
-        regex: '__(dirname|filename)',
-      },
+      ...filterExcludingNodejsGlobals,
     },
     {
       selector: 'typeLike',

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -17,6 +17,46 @@ const __filename = fileURLToPath(import.meta.url)
 const __dirname = dirname(__filename)
 const gitignorePath = resolve(__dirname, '.gitignore')
 
+const namingConventionRules = {
+  '@typescript-eslint/naming-convention': [
+    'error',
+    {
+      selector: 'variableLike',
+      format: ['camelCase'],
+      filter: {
+        match: false,
+        regex: '__(dirname|filename)',
+      },
+    },
+    {
+      selector: 'memberLike',
+      modifiers: ['private', 'protected'],
+      format: ['camelCase'],
+      leadingUnderscore: 'require',
+    },
+    {
+      selector: 'variable',
+      types: ['boolean'],
+      format: ['PascalCase'],
+      prefix: ['is', 'should', 'has', 'can', 'did', 'will'],
+    },
+    {
+      selector: 'variable',
+      format: ['camelCase', 'UPPER_CASE'],
+      filter: {
+        match: false,
+        regex: '__(dirname|filename)',
+      },
+    },
+    {
+      selector: 'typeLike',
+      format: ['PascalCase'],
+    },
+  ],
+}
+const typedRules = { ...namingConventionRules }
+const useTypedRules = Boolean(process.env.TYPED_RULES)
+
 export default tsEslint.config(
   includeIgnoreFile(gitignorePath),
   {
@@ -25,20 +65,38 @@ export default tsEslint.config(
       'public/manifest.json',
       'public/release.json',
       'src/environments/environment.pull-request.ts',
+      ...(useTypedRules
+        ? [
+            //👇 To allow PascalCase for symbols
+            'data/material-symbols.ts',
+          ]
+        : []),
     ],
   },
   {
     files: ['**/*.ts'],
     extends: [
       eslint.configs.recommended,
+      // TODO: enable typed check recommended / stylistic
       ...tsEslint.configs.recommended,
       ...tsEslint.configs.stylistic,
     ],
+    languageOptions: {
+      parserOptions: {
+        ...(useTypedRules
+          ? {
+              projectService: true,
+              tsconfigRootDir: import.meta.dirname,
+            }
+          : {}),
+      },
+    },
     rules: {
       '@typescript-eslint/explicit-member-accessibility': [
         'error',
         { accessibility: 'no-public' },
       ],
+      ...(useTypedRules ? typedRules : {}),
     },
   },
   {

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -53,26 +53,31 @@ export default tsEslint.config(
       ],
       '@typescript-eslint/naming-convention': [
         'error',
+        // https://github.com/typescript-eslint/typescript-eslint/blob/v8.16.0/packages/eslint-plugin/docs/rules/naming-convention.mdx#enforce-that-all-variables-functions-and-properties-follow-are-camelcase
         {
           selector: 'variableLike',
           format: ['camelCase'],
         },
+        // https://google.github.io/styleguide/tsguide.html#naming-rules-by-identifier-type
+        {
+          selector: 'variable',
+          format: ['camelCase', 'UPPER_CASE'],
+        },
+        // https://github.com/typescript-eslint/typescript-eslint/blob/v8.16.0/packages/eslint-plugin/docs/rules/naming-convention.mdx#enforce-that-private-members-are-prefixed-with-an-underscore
         {
           selector: 'memberLike',
           modifiers: ['private', 'protected'],
           format: ['camelCase'],
           leadingUnderscore: 'require',
         },
-        {
-          selector: 'variable',
-          format: ['camelCase', 'UPPER_CASE'],
-        },
+        // https://github.com/typescript-eslint/typescript-eslint/blob/v8.16.0/packages/eslint-plugin/docs/rules/naming-convention.mdx#enforce-that-interface-names-do-not-begin-with-an-i
         {
           selector: 'typeLike',
           format: ['PascalCase'],
         },
         ...(useTypedRules
           ? [
+              // https://github.com/typescript-eslint/typescript-eslint/blob/v8.16.0/packages/eslint-plugin/docs/rules/naming-convention.mdx#enforce-that-boolean-variables-are-prefixed-with-an-allowed-verb
               {
                 selector: [
                   'variable',

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -17,46 +17,7 @@ const __filename = fileURLToPath(import.meta.url)
 const __dirname = dirname(__filename)
 const gitignorePath = resolve(__dirname, '.gitignore')
 
-const filterExcludingNodejsGlobals = {
-  filter: {
-    match: false,
-    regex: '__(dirname|filename)',
-  },
-}
-const namingConventionRules = {
-  '@typescript-eslint/naming-convention': [
-    'error',
-    {
-      selector: 'variableLike',
-      format: ['camelCase'],
-      ...filterExcludingNodejsGlobals,
-    },
-    {
-      selector: 'memberLike',
-      modifiers: ['private', 'protected'],
-      format: ['camelCase'],
-      leadingUnderscore: 'require',
-    },
-    {
-      selector: 'variable',
-      types: ['boolean'],
-      format: ['PascalCase'],
-      prefix: ['is', 'should', 'has', 'can', 'did', 'will'],
-    },
-    {
-      selector: 'variable',
-      format: ['camelCase', 'UPPER_CASE'],
-      ...filterExcludingNodejsGlobals,
-    },
-    {
-      selector: 'typeLike',
-      format: ['PascalCase'],
-    },
-  ],
-}
-const typedRules = { ...namingConventionRules }
 const useTypedRules = Boolean(process.env.TYPED_RULES)
-
 export default tsEslint.config(
   includeIgnoreFile(gitignorePath),
   {
@@ -65,12 +26,6 @@ export default tsEslint.config(
       'public/manifest.json',
       'public/release.json',
       'src/environments/environment.pull-request.ts',
-      ...(useTypedRules
-        ? [
-            //👇 To allow PascalCase for symbols
-            'data/material-symbols.ts',
-          ]
-        : []),
     ],
   },
   {
@@ -96,7 +51,45 @@ export default tsEslint.config(
         'error',
         { accessibility: 'no-public' },
       ],
-      ...(useTypedRules ? typedRules : {}),
+      '@typescript-eslint/naming-convention': [
+        'error',
+        {
+          selector: 'variableLike',
+          format: ['camelCase'],
+        },
+        {
+          selector: 'memberLike',
+          modifiers: ['private', 'protected'],
+          format: ['camelCase'],
+          leadingUnderscore: 'require',
+        },
+        {
+          selector: 'variable',
+          format: ['camelCase', 'UPPER_CASE'],
+        },
+        {
+          selector: 'typeLike',
+          format: ['PascalCase'],
+        },
+        ...(useTypedRules
+          ? [
+              {
+                selector: [
+                  'variable',
+                  'classicAccessor',
+                  'autoAccessor',
+                  'classProperty',
+                  'parameter',
+                  'parameterProperty',
+                ],
+                types: ['boolean'],
+                format: ['PascalCase'],
+                prefix: ['is', 'should', 'has', 'can', 'did', 'will'],
+                leadingUnderscore: 'allow',
+              },
+            ]
+          : []),
+      ],
     },
   },
   {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,8 @@
     "lint:code": "pnpm run lint:code:files .",
     "lint:code:files": "eslint --max-warnings 0",
     "lint:code:files//": "☝️ lint-staged can't/shouldn't use 'ng lint'",
+    "lint:code:files:typed": "TYPED_RULES=true pnpm run lint:code:files",
+    "lint:code:typed": "pnpm run lint:code:files:typed .",
     "lint:commit-message": "pnpm run commitlint:edit-msg",
     "lint:gh-actions": "actionlint || true",
     "release": "release-it",

--- a/scripts/src/utils/get-repository-root-dir.ts
+++ b/scripts/src/utils/get-repository-root-dir.ts
@@ -1,10 +1,13 @@
 import { dirname, resolve } from 'path'
 import { fileURLToPath } from 'url'
 
-const __filename = fileURLToPath(import.meta.url)
-const __dirname = dirname(__filename)
-
 export function getRepositoryRootDir() {
   // Relative to `dist`, as this file will be output there
-  return resolve(__dirname, '..', '..', '..', '..')
+  return resolve(
+    dirname(fileURLToPath(import.meta.url)),
+    '..',
+    '..',
+    '..',
+    '..',
+  )
 }

--- a/src/app/common/relativize-production-url.ts
+++ b/src/app/common/relativize-production-url.ts
@@ -3,7 +3,7 @@ import { APP_BASE_HREF } from '@angular/common'
 import { METADATA } from '@/data/metadata'
 
 export type RelativizeProductionUrl = (url: URL) => string
-export const _RELATIVIZE_PRODUCTION_URL_FACTORY: (
+const RELATIVIZE_PRODUCTION_URL_FACTORY: (
   baseUrl: URL,
   baseHref: string | null,
 ) => RelativizeProductionUrl = (baseUrl, baseHref) => (url) => {
@@ -38,7 +38,7 @@ export const RELATIVIZE_PRODUCTION_URL =
     isDevMode ? 'RelativizeProductionUrl' : 'RPU',
     {
       factory: () =>
-        _RELATIVIZE_PRODUCTION_URL_FACTORY(
+        RELATIVIZE_PRODUCTION_URL_FACTORY(
           inject(APP_BASE_URL_PRODUCTION),
           inject(APP_BASE_HREF, { optional: true }),
         ),

--- a/src/app/common/scroll-into-view.spec.ts
+++ b/src/app/common/scroll-into-view.spec.ts
@@ -1,6 +1,6 @@
 import {
-  _SCROLL_INTO_VIEW_FACTORY,
   SCROLL_INTO_VIEW,
+  SCROLL_INTO_VIEW_FACTORY,
 } from '@/common/scroll-into-view'
 import { MockProvider } from 'ng-mocks'
 import { PLATFORM_SERVICE, PlatformService } from '@/common/platform.service'
@@ -41,7 +41,7 @@ function makeSut(opts: { platformService: PlatformService }) {
   return serviceTestSetup(SCROLL_INTO_VIEW, {
     providers: [
       MockProvider(PLATFORM_SERVICE, opts.platformService),
-      MockProvider(SCROLL_INTO_VIEW, _SCROLL_INTO_VIEW_FACTORY, 'useFactory'),
+      MockProvider(SCROLL_INTO_VIEW, SCROLL_INTO_VIEW_FACTORY, 'useFactory'),
     ],
   })
 }

--- a/src/app/common/scroll-into-view.ts
+++ b/src/app/common/scroll-into-view.ts
@@ -17,13 +17,13 @@ export type ScrollIntoView = (element: HTMLElement) => void
  * As workaround, creating another provider for it when testing using the same factory.
  * That's why it's exported
  */
-export const _SCROLL_INTO_VIEW_FACTORY: () => ScrollIntoView = () =>
+export const SCROLL_INTO_VIEW_FACTORY: () => ScrollIntoView = () =>
   inject(PLATFORM_SERVICE).isBrowser ? scrollIntoView : noop
 export const SCROLL_INTO_VIEW = new InjectionToken<ScrollIntoView>(
   /* istanbul ignore next */
   isDevMode ? 'ScrollIntoView' : 'SIV',
   {
     providedIn: 'platform',
-    factory: _SCROLL_INTO_VIEW_FACTORY,
+    factory: SCROLL_INTO_VIEW_FACTORY,
   },
 )

--- a/src/app/header/light-dark-toggle/color-scheme.service.spec.ts
+++ b/src/app/header/light-dark-toggle/color-scheme.service.spec.ts
@@ -19,7 +19,7 @@ describe('ColorSchemeService', () => {
     // https://www.w3.org/TR/mediaqueries-5/#prefers-color-scheme
     if (query === '(prefers-color-scheme: dark)') {
       return {
-        matches: prefersDark,
+        matches: isDarkPreferred,
         addEventListener: <K extends keyof MediaQueryListEventMap>(
           type: K,
           listener: (ev: MediaQueryListEventMap[K]) => unknown,
@@ -42,12 +42,12 @@ describe('ColorSchemeService', () => {
     }
     throw new Error('Media query not mocked')
   }
-  let prefersDark: boolean
+  let isDarkPreferred: boolean
   let prefersDarkMatchMediaChangesEmitter: EventEmitter<MediaQueryListEvent>
   let prefersDarkMatchMediaSubscriptions: Subscription[]
 
   beforeEach(() => {
-    prefersDark = false
+    isDarkPreferred = false
     prefersDarkMatchMediaChangesEmitter =
       new EventEmitter<MediaQueryListEvent>()
     prefersDarkMatchMediaSubscriptions = []
@@ -143,7 +143,7 @@ describe('ColorSchemeService', () => {
 
       describe('when user does not prefer dark color scheme', () => {
         it('should manually set the scheme to dark', () => {
-          prefersDark = false
+          isDarkPreferred = false
           sut.toggleDarkLight()
 
           const schemeAttributeValue = mockDocumentElement.getAttribute(
@@ -156,7 +156,7 @@ describe('ColorSchemeService', () => {
 
       describe('when user prefers dark color scheme', () => {
         it('should manually set the scheme to light', () => {
-          prefersDark = true
+          isDarkPreferred = true
           sut.toggleDarkLight()
 
           const schemeAttributeValue = mockDocumentElement.getAttribute(

--- a/src/app/header/light-dark-toggle/color-scheme.service.spec.ts
+++ b/src/app/header/light-dark-toggle/color-scheme.service.spec.ts
@@ -61,7 +61,7 @@ describe('ColorSchemeService', () => {
       documentElement: mockDocumentElement,
       // Make Angular testing tools happy :)
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      querySelectorAll: (_selectors: unknown) => {
+      querySelectorAll: (selectors: unknown) => {
         return { length: 0 }
       },
     } as Pick<Document, 'documentElement' | 'querySelectorAll'>

--- a/src/app/header/light-dark-toggle/color-scheme.service.ts
+++ b/src/app/header/light-dark-toggle/color-scheme.service.ts
@@ -23,7 +23,7 @@ export class ColorSchemeService {
     this.listenForMatchMediaPreferenceChanges()
   }
 
-  private get userPrefersDark(): boolean {
+  private get isDarkPreferred(): boolean {
     return !!this.matchMediaQuery && this.matchMediaQuery.matches
   }
 
@@ -39,7 +39,7 @@ export class ColorSchemeService {
       HTML_COLOR_SCHEME_ATTRIBUTE,
     )
     if (!manuallySetScheme) {
-      this.setManual(this.userPrefersDark ? Scheme.Light : Scheme.Dark)
+      this.setManual(this.isDarkPreferred ? Scheme.Light : Scheme.Dark)
       return
     }
 

--- a/src/app/header/navigation-tabs/navigation-tabs.component.spec.ts
+++ b/src/app/header/navigation-tabs/navigation-tabs.component.spec.ts
@@ -67,7 +67,7 @@ describe('NavigationTabsComponent', () => {
 
     expect(fooTabElement).not.toBeNull()
     expect(
-      getComponentInstance(fooTabElement!, TabComponent).selected,
+      getComponentInstance(fooTabElement!, TabComponent).isSelected,
     ).toBeTrue()
 
     const barTabElement = fixture.debugElement
@@ -77,7 +77,7 @@ describe('NavigationTabsComponent', () => {
     expect(barTabElement).not.toBeNull()
 
     expect(
-      getComponentInstance(barTabElement!, TabComponent).selected,
+      getComponentInstance(barTabElement!, TabComponent).isSelected,
     ).toBeFalse()
   })
 

--- a/src/app/header/tab/tab.component.spec.ts
+++ b/src/app/header/tab/tab.component.spec.ts
@@ -24,12 +24,12 @@ describe('TabComponent', () => {
   })
 
   it('should not be selected by default', () => {
-    expect(component.selected).toBeFalse()
+    expect(component.isSelected).toBeFalse()
   })
 
   describe('when selected', () => {
     beforeEach(() => {
-      fixture.componentRef.setInput('selected', true)
+      fixture.componentRef.setInput('isSelected', true)
       fixture.detectChanges()
     })
 
@@ -46,7 +46,7 @@ describe('TabComponent', () => {
 
   describe('when not selected', () => {
     beforeEach(() => {
-      fixture.componentRef.setInput('selected', false)
+      fixture.componentRef.setInput('isSelected', false)
       fixture.detectChanges()
     })
 

--- a/src/app/header/tab/tab.component.ts
+++ b/src/app/header/tab/tab.component.ts
@@ -7,12 +7,12 @@ import { Component, ElementRef, Input } from '@angular/core'
   standalone: true,
   host: {
     role: 'tab',
-    '[attr.aria-selected]': 'selected',
-    '[attr.tabindex]': 'selected ? 0 : -1',
+    '[attr.aria-selected]': 'isSelected',
+    '[attr.tabindex]': 'isSelected ? 0 : -1',
   },
 })
 export class TabComponent {
-  @Input() selected = false
+  @Input() isSelected = false
 
   constructor(
     //👇 Useful for tabs group component to access the HTML native element

--- a/src/app/header/tabs/tabs.component.spec.ts
+++ b/src/app/header/tabs/tabs.component.spec.ts
@@ -47,7 +47,7 @@ describe('TabsComponent', () => {
     tabElements.forEach((tabElement, index) => {
       const shouldBeSelected = index === selectedIndex
 
-      expect(getComponentInstance(tabElement, TabComponent).selected)
+      expect(getComponentInstance(tabElement, TabComponent).isSelected)
         .withContext(
           `tab ${index} is ${shouldBeSelected ? 'selected' : 'not selected'}`,
         )

--- a/src/app/header/tabs/tabs.component.ts
+++ b/src/app/header/tabs/tabs.component.ts
@@ -85,7 +85,7 @@ export class TabsComponent implements OnDestroy {
     )
       return
     this._currentTabs.forEach(
-      (tab, index) => (tab.selected = index === this._indexToSelect),
+      (tab, index) => (tab.isSelected = index === this._indexToSelect),
     )
     this._selectedIndex = this._indexToSelect
     this._indexToScrollTo = this._indexToSelect

--- a/src/app/resume-page/attribute/attribute.component.spec.ts
+++ b/src/app/resume-page/attribute/attribute.component.spec.ts
@@ -16,10 +16,9 @@ describe('AttributeComponent', () => {
   }
 
   it('should create', () => {
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const [_, component] = makeSut()
+    const [fixture] = makeSut()
 
-    expect(component).toBeTruthy()
+    expect(fixture.componentInstance).toBeTruthy()
   })
 
   it('should include the given symbol', () => {

--- a/src/app/resume-page/chip/chip.component.spec.ts
+++ b/src/app/resume-page/chip/chip.component.spec.ts
@@ -61,14 +61,14 @@ describe('ChipComponent', () => {
     let fixture: ComponentFixture<ChipComponent>
     let component: ChipComponent
     let subscription: Subscription
-    let newSelectedValue: boolean
+    let isSelected: boolean
 
     beforeEach(() => {
       ;[fixture, component] = componentTestSetup(ChipComponent)
       fixture.componentRef.setInput('selected', false)
       subscription = component.selectedChange
         .pipe(first())
-        .subscribe((selected) => (newSelectedValue = selected))
+        .subscribe((isSelectedReceived) => (isSelected = isSelectedReceived))
       fixture.detectChanges()
     })
 
@@ -94,19 +94,19 @@ describe('ChipComponent', () => {
     it('should emit new selected attribute on click', () => {
       fixture.debugElement.triggerEventHandler('click')
 
-      expect(newSelectedValue).toBeTrue()
+      expect(isSelected).toBeTrue()
     })
 
     it('should emit new selected attribute on space key', () => {
       fixture.debugElement.triggerEventHandler('keydown.space')
 
-      expect(newSelectedValue).toBeTrue()
+      expect(isSelected).toBeTrue()
     })
 
     it('should emit new selected attribute on enter key', () => {
       fixture.debugElement.triggerEventHandler('keydown.enter')
 
-      expect(newSelectedValue).toBeTrue()
+      expect(isSelected).toBeTrue()
     })
   })
 })

--- a/src/app/resume-page/chip/chip.component.ts
+++ b/src/app/resume-page/chip/chip.component.ts
@@ -21,18 +21,18 @@ export class ChipComponent {
   selectedChange = new EventEmitter<boolean>()
 
   @HostBinding('class.selectable')
-  get selectable() {
+  get isSelectable() {
     return this.selectedChange.observed
   }
 
   @HostBinding('attr.role')
   get ariaRole(): string | undefined {
-    return this.selectable ? 'button' : undefined
+    return this.isSelectable ? 'button' : undefined
   }
 
   @HostBinding('attr.tabindex')
   get tabIndex(): string | undefined {
-    return this.selectable ? (0).toString() : undefined
+    return this.isSelectable ? (0).toString() : undefined
   }
 
   @HostListener('click') protected onClick() {

--- a/src/app/resume-page/chipped-content/chipped-content.component.html
+++ b/src/app/resume-page/chipped-content/chipped-content.component.html
@@ -1,7 +1,7 @@
 <div class="chips">
   @for (content of contents; track content; let i = $index) {
     <app-chip
-      [selected]="_active && _activeIndex === i"
+      [selected]="_isActive && _activeIndex === i"
       (selectedChange)="onSelect(i)"
     >
       {{ content.displayName }}
@@ -10,7 +10,7 @@
 </div>
 <div
   class="content"
-  [@contentDisplayed]="_active"
+  [@contentDisplayed]="_isActive"
   (@contentDisplayed.done)="_scrollIntoView(contentElement)"
   #contentElement
 >

--- a/src/app/resume-page/chipped-content/chipped-content.component.ts
+++ b/src/app/resume-page/chipped-content/chipped-content.component.ts
@@ -47,15 +47,15 @@ export class ChippedContentComponent {
     @Inject(SCROLL_INTO_VIEW) protected _scrollIntoView: ScrollIntoView,
   ) {}
 
-  protected _active = false
+  protected _isActive = false
   protected _activeIndex = 0
 
   onSelect(index: number) {
     if (this._activeIndex == index) {
-      this._active = !this._active
+      this._isActive = !this._isActive
       return
     }
-    this._active = true
+    this._isActive = true
     this._activeIndex = index
   }
 }

--- a/src/app/resume-page/education-section/adapt-json-resume-education.spec.ts
+++ b/src/app/resume-page/education-section/adapt-json-resume-education.spec.ts
@@ -64,9 +64,9 @@ describe('AdaptJsonResumeEducation', () => {
 
   // Non standard fields
   it('should map the cum laude field', () => {
-    const item = makeSut()(makeJsonResumeEducation({ cumLaude: true }))
+    const item = makeSut()(makeJsonResumeEducation({ isCumLaude: true }))
 
-    expect(item.cumLaude).toBeTrue()
+    expect(item.isCumLaude).toBeTrue()
   })
 
   it('should relativize image URL', () => {

--- a/src/app/resume-page/education-section/adapt-json-resume-education.ts
+++ b/src/app/resume-page/education-section/adapt-json-resume-education.ts
@@ -33,7 +33,7 @@ export const ADAPT_JSON_RESUME_EDUCATION =
             ),
             score: education.score,
             courses: education.courses,
-            cumLaude: !!education.cumLaude,
+            isCumLaude: !!education.isCumLaude,
           })
       },
     },

--- a/src/app/resume-page/education-section/education-item/education-item.component.html
+++ b/src/app/resume-page/education-section/education-item/education-item.component.html
@@ -22,7 +22,7 @@
       </app-card-header-detail>
     </app-card-header-texts>
     <app-card-header-attributes>
-      @if (_item.cumLaude) {
+      @if (_item.isCumLaude) {
         <app-attribute
           [symbol]="MaterialSymbol.SocialLeaderboard"
           [appTestId]="Attribute.CumLaude"

--- a/src/app/resume-page/education-section/education-item/education-item.component.spec.ts
+++ b/src/app/resume-page/education-section/education-item/education-item.component.spec.ts
@@ -136,7 +136,7 @@ describe('EducationItemComponent', () => {
 
   describe('when cum laude attribute is not set', () => {
     it('should not display its attribute', () => {
-      setEducationItem(fixture, { cumLaude: false })
+      setEducationItem(fixture, { isCumLaude: false })
 
       expect(
         fixture.debugElement.query(byTestId(Attribute.CumLaude)),
@@ -146,7 +146,7 @@ describe('EducationItemComponent', () => {
 
   describe('when cum laude attribute is set', () => {
     it('should display its attribute', () => {
-      setEducationItem(fixture, { cumLaude: true })
+      setEducationItem(fixture, { isCumLaude: true })
 
       expect(
         fixture.debugElement.query(byTestId(Attribute.CumLaude)),

--- a/src/app/resume-page/education-section/education-item/education-item.ts
+++ b/src/app/resume-page/education-section/education-item/education-item.ts
@@ -8,7 +8,7 @@ export class EducationItem {
   readonly dateRange: DateRange
   readonly score: string
   readonly courses: readonly string[]
-  readonly cumLaude: boolean
+  readonly isCumLaude: boolean
 
   constructor({
     institution,
@@ -17,7 +17,7 @@ export class EducationItem {
     dateRange,
     score,
     courses,
-    cumLaude,
+    isCumLaude,
   }: {
     institution: Organization
     area: string
@@ -25,7 +25,7 @@ export class EducationItem {
     dateRange: DateRange
     score: string
     courses?: readonly string[]
-    cumLaude?: boolean
+    isCumLaude?: boolean
   }) {
     this.institution = institution
     this.area = area
@@ -33,6 +33,6 @@ export class EducationItem {
     this.dateRange = dateRange
     this.score = score
     this.courses = courses ?? []
-    this.cumLaude = cumLaude ?? false
+    this.isCumLaude = isCumLaude ?? false
   }
 }

--- a/src/app/resume-page/experience-section/adapt-json-resume-work.spec.ts
+++ b/src/app/resume-page/experience-section/adapt-json-resume-work.spec.ts
@@ -73,24 +73,24 @@ describe('AdaptJsonResumeWork', () => {
 
   // Non JSON Resume standard!
   it('should map the freelance, internship, promotions and more positions fields', () => {
-    const freelance = true
-    const internship = true
-    const promotions = true
-    const morePositions = true
+    const isFreelance = true
+    const isInternship = true
+    const hasPromotions = true
+    const hasMorePositions = true
 
     const item = makeSut()(
       makeJsonResumeWork({
-        freelance,
-        internship,
-        promotions,
-        morePositions,
+        isFreelance,
+        isInternship,
+        hasPromotions,
+        hasMorePositions,
       } as unknown as Partial<JsonResumeWork>),
     )
 
-    expect(item.freelance).toBe(freelance)
-    expect(item.internship).toBe(internship)
-    expect(item.promotions).toBe(promotions)
-    expect(item.morePositions).toBe(morePositions)
+    expect(item.isFreelance).toBe(isFreelance)
+    expect(item.isInternship).toBe(isInternship)
+    expect(item.hasPromotions).toBe(hasPromotions)
+    expect(item.hasMorePositions).toBe(hasMorePositions)
   })
 
   it('should relativize image URL', () => {

--- a/src/app/resume-page/experience-section/adapt-json-resume-work.ts
+++ b/src/app/resume-page/experience-section/adapt-json-resume-work.ts
@@ -33,10 +33,10 @@ export const ADAPT_JSON_RESUME_WORK = new InjectionToken<AdaptJsonResumeWork>(
             new Date(work.startDate),
             !work.endDate ? undefined : new Date(work.endDate),
           ),
-          freelance: work.freelance,
-          internship: work.internship,
-          promotions: work.promotions,
-          morePositions: work.morePositions,
+          isFreelance: work.isFreelance,
+          isInternship: work.isInternship,
+          hasPromotions: work.hasPromotions,
+          hasMorePositions: work.hasMorePositions,
           projects: projects
             .filter((project) => project.entity === work.name)
             .map((project) => adaptProject(project)),

--- a/src/app/resume-page/experience-section/experience-item/experience-item.component.html
+++ b/src/app/resume-page/experience-section/experience-item/experience-item.component.html
@@ -19,7 +19,7 @@
       </app-card-header-detail>
     </app-card-header-texts>
     <app-card-header-attributes>
-      @if (_item.freelance) {
+      @if (_item.isFreelance) {
         <app-attribute
           [symbol]="MaterialSymbol.Work"
           [appTestId]="Attribute.Freelance"
@@ -34,7 +34,7 @@
           Employee
         </app-attribute>
       }
-      @if (_item.internship) {
+      @if (_item.isInternship) {
         <app-attribute
           [symbol]="MaterialSymbol.School"
           [appTestId]="Attribute.Internship"
@@ -42,7 +42,7 @@
           Internship
         </app-attribute>
       }
-      @if (_item.morePositions) {
+      @if (_item.hasMorePositions) {
         <app-attribute
           [symbol]="MaterialSymbol.More"
           [appTestId]="Attribute.MorePositions"
@@ -51,7 +51,7 @@
           See summary for details
         </app-attribute>
       }
-      @if (_item.promotions) {
+      @if (_item.hasPromotions) {
         <app-attribute
           [symbol]="MaterialSymbol.ToolsLadder"
           [appTestId]="Attribute.Promotions"

--- a/src/app/resume-page/experience-section/experience-item/experience-item.component.spec.ts
+++ b/src/app/resume-page/experience-section/experience-item/experience-item.component.spec.ts
@@ -142,7 +142,7 @@ describe('ExperienceItem', () => {
 
     describe('when experience is not freelance, therefore it was employee', () => {
       beforeEach(() => {
-        setExperienceItem(fixture, { freelance: false })
+        setExperienceItem(fixture, { isFreelance: false })
       })
 
       testShouldDisplayItsAttribute(() => fixture, Attribute.Employee)
@@ -150,7 +150,7 @@ describe('ExperienceItem', () => {
 
     describe('when experience is freelance', () => {
       beforeEach(() => {
-        setExperienceItem(fixture, { freelance: true })
+        setExperienceItem(fixture, { isFreelance: true })
       })
 
       testShouldDisplayItsAttribute(() => fixture, Attribute.Freelance)
@@ -158,7 +158,7 @@ describe('ExperienceItem', () => {
 
     describe('when experience is not an internship', () => {
       beforeEach(() => {
-        setExperienceItem(fixture, { internship: false })
+        setExperienceItem(fixture, { isInternship: false })
       })
 
       testShouldNotDisplayItsAttribute(() => fixture, Attribute.Internship)
@@ -166,7 +166,7 @@ describe('ExperienceItem', () => {
 
     describe('when experience is an internship', () => {
       beforeEach(() => {
-        setExperienceItem(fixture, { internship: true })
+        setExperienceItem(fixture, { isInternship: true })
       })
 
       testShouldDisplayItsAttribute(() => fixture, Attribute.Internship)
@@ -174,7 +174,7 @@ describe('ExperienceItem', () => {
 
     describe('when experience contained no promotions', () => {
       beforeEach(() => {
-        setExperienceItem(fixture, { promotions: false })
+        setExperienceItem(fixture, { hasPromotions: false })
       })
 
       testShouldNotDisplayItsAttribute(() => fixture, Attribute.Promotions)
@@ -182,7 +182,7 @@ describe('ExperienceItem', () => {
 
     describe('when experience contained promotions', () => {
       beforeEach(() => {
-        setExperienceItem(fixture, { promotions: true })
+        setExperienceItem(fixture, { hasPromotions: true })
       })
 
       testShouldDisplayItsAttribute(() => fixture, Attribute.Promotions)
@@ -190,7 +190,7 @@ describe('ExperienceItem', () => {
 
     describe('when experience contained no more positions', () => {
       beforeEach(() => {
-        setExperienceItem(fixture, { morePositions: false })
+        setExperienceItem(fixture, { hasMorePositions: false })
       })
 
       testShouldNotDisplayItsAttribute(() => fixture, Attribute.MorePositions)
@@ -198,7 +198,7 @@ describe('ExperienceItem', () => {
 
     describe('when experience contained more positions', () => {
       beforeEach(() => {
-        setExperienceItem(fixture, { morePositions: true })
+        setExperienceItem(fixture, { hasMorePositions: true })
       })
 
       testShouldDisplayItsAttribute(() => fixture, Attribute.MorePositions)

--- a/src/app/resume-page/experience-section/experience-item/experience-item.ts
+++ b/src/app/resume-page/experience-section/experience-item/experience-item.ts
@@ -8,10 +8,10 @@ export class ExperienceItem {
   readonly dateRange: DateRange
   readonly summary: string
   readonly highlights: readonly string[]
-  readonly freelance: boolean
-  readonly internship: boolean
-  readonly promotions: boolean
-  readonly morePositions: boolean
+  readonly isFreelance: boolean
+  readonly isInternship: boolean
+  readonly hasPromotions: boolean
+  readonly hasMorePositions: boolean
   readonly projects: readonly ProjectItem[]
 
   constructor({
@@ -20,10 +20,10 @@ export class ExperienceItem {
     dateRange,
     summary,
     highlights,
-    freelance,
-    internship,
-    promotions,
-    morePositions,
+    isFreelance,
+    isInternship,
+    hasPromotions,
+    hasMorePositions,
     projects,
   }: {
     company: Organization
@@ -31,10 +31,10 @@ export class ExperienceItem {
     dateRange: DateRange
     summary: string
     highlights?: readonly string[]
-    freelance?: boolean
-    internship?: boolean
-    promotions?: boolean
-    morePositions?: boolean
+    isFreelance?: boolean
+    isInternship?: boolean
+    hasPromotions?: boolean
+    hasMorePositions?: boolean
     projects?: readonly ProjectItem[]
   }) {
     this.company = company
@@ -42,10 +42,10 @@ export class ExperienceItem {
     this.dateRange = dateRange
     this.summary = summary
     this.highlights = highlights ?? []
-    this.freelance = freelance ?? false
-    this.internship = internship ?? false
-    this.promotions = promotions ?? false
-    this.morePositions = morePositions ?? false
+    this.isFreelance = isFreelance ?? false
+    this.isInternship = isInternship ?? false
+    this.hasPromotions = hasPromotions ?? false
+    this.hasMorePositions = hasMorePositions ?? false
     this.projects = projects ?? []
   }
 }

--- a/src/app/resume-page/languages-section/languages-section.component.spec.ts
+++ b/src/app/resume-page/languages-section/languages-section.component.spec.ts
@@ -11,10 +11,9 @@ import { CardGridComponent } from '../card-grid/card-grid.component'
 
 describe('LanguagesSectionComponent', () => {
   it('should create', () => {
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const [_fixture, component] = makeSut()
+    const [fixture] = makeSut()
 
-    expect(component).toBeTruthy()
+    expect(fixture.componentInstance).toBeTruthy()
   })
 
   it('should display all languages', () => {

--- a/src/app/resume-page/projects-section/project-item/project-item.component.html
+++ b/src/app/resume-page/projects-section/project-item/project-item.component.html
@@ -25,10 +25,10 @@
     <app-card-header-attributes>
       @if (_item.stack) {
         <app-attribute
-          [symbol]="StackContent[_item.stack].materialSymbol"
+          [symbol]="_stackContent[_item.stack].materialSymbol"
           [appTestId]="Attribute.Stack"
         >
-          {{ StackContent[_item.stack].displayName }}
+          {{ _stackContent[_item.stack].displayName }}
         </app-attribute>
       }
     </app-card-header-attributes>

--- a/src/app/resume-page/projects-section/project-item/project-item.component.spec.ts
+++ b/src/app/resume-page/projects-section/project-item/project-item.component.spec.ts
@@ -26,7 +26,6 @@ import { getComponentInstance } from '@/test/helpers/get-component-instance'
 import { TestIdDirective } from '@/common/test-id.directive'
 import { LinkComponent } from '../../link/link.component'
 import { textContent } from '@/test/helpers/text-content'
-import { Apps, Dns, FullStackedBarChart } from '@/data/material-symbols'
 
 describe('ProjectItemComponent', () => {
   let component: ProjectItemComponent
@@ -142,17 +141,7 @@ describe('ProjectItemComponent', () => {
   describe('when stack attribute exists', () => {
     it('should include attribute with its display name and icon', () => {
       const stack = Stack.Front
-      const stackContent = {
-        [Stack.Back]: {
-          displayName: 'Backend',
-          materialSymbol: Dns,
-        },
-        [Stack.Front]: { displayName: 'Frontend', materialSymbol: Apps },
-        [Stack.Full]: {
-          displayName: 'Full stack',
-          materialSymbol: FullStackedBarChart,
-        },
-      }[stack]
+      const stackContent = ProjectItemComponent.StackContent[stack]
 
       setProjectItem(fixture, { stack })
 

--- a/src/app/resume-page/projects-section/project-item/project-item.component.spec.ts
+++ b/src/app/resume-page/projects-section/project-item/project-item.component.spec.ts
@@ -1,10 +1,6 @@
 import { ComponentFixture } from '@angular/core/testing'
 
-import {
-  Attribute,
-  ProjectItemComponent,
-  StackContent,
-} from './project-item.component'
+import { Attribute, ProjectItemComponent } from './project-item.component'
 import { MockComponents } from 'ng-mocks'
 import { CardComponent } from '../../card/card.component'
 import { CardHeaderImageComponent } from '../../card/card-header/card-header-image/card-header-image.component'
@@ -30,6 +26,7 @@ import { getComponentInstance } from '@/test/helpers/get-component-instance'
 import { TestIdDirective } from '@/common/test-id.directive'
 import { LinkComponent } from '../../link/link.component'
 import { textContent } from '@/test/helpers/text-content'
+import { Apps, Dns, FullStackedBarChart } from '@/data/material-symbols'
 
 describe('ProjectItemComponent', () => {
   let component: ProjectItemComponent
@@ -145,7 +142,17 @@ describe('ProjectItemComponent', () => {
   describe('when stack attribute exists', () => {
     it('should include attribute with its display name and icon', () => {
       const stack = Stack.Front
-      const stackContent = StackContent[stack]
+      const stackContent = {
+        [Stack.Back]: {
+          displayName: 'Backend',
+          materialSymbol: Dns,
+        },
+        [Stack.Front]: { displayName: 'Frontend', materialSymbol: Apps },
+        [Stack.Full]: {
+          displayName: 'Full stack',
+          materialSymbol: FullStackedBarChart,
+        },
+      }[stack]
 
       setProjectItem(fixture, { stack })
 

--- a/src/app/resume-page/projects-section/project-item/project-item.component.ts
+++ b/src/app/resume-page/projects-section/project-item/project-item.component.ts
@@ -48,27 +48,26 @@ export class ProjectItemComponent {
   protected _item!: ProjectItem
   protected _contents: readonly ChippedContent[] = []
 
-  protected readonly StackContent = StackContent
+  protected readonly StackContent: Record<
+    Stack,
+    {
+      displayName: string
+      materialSymbol: string
+    }
+  > = {
+    [Stack.Back]: {
+      displayName: 'Backend',
+      materialSymbol: Dns,
+    },
+    [Stack.Front]: { displayName: 'Frontend', materialSymbol: Apps },
+    [Stack.Full]: {
+      displayName: 'Full stack',
+      materialSymbol: FullStackedBarChart,
+    },
+  }
   protected readonly Attribute = Attribute
 }
 
 export enum Attribute {
   Stack = 'stack',
-}
-
-export const StackContent: Record<Stack, StackContent> = {
-  [Stack.Back]: {
-    displayName: 'Backend',
-    materialSymbol: Dns,
-  },
-  [Stack.Front]: { displayName: 'Frontend', materialSymbol: Apps },
-  [Stack.Full]: {
-    displayName: 'Full stack',
-    materialSymbol: FullStackedBarChart,
-  },
-}
-
-export interface StackContent {
-  displayName: string
-  materialSymbol: string
 }

--- a/src/app/resume-page/projects-section/project-item/project-item.component.ts
+++ b/src/app/resume-page/projects-section/project-item/project-item.component.ts
@@ -48,7 +48,7 @@ export class ProjectItemComponent {
   protected _item!: ProjectItem
   protected _contents: readonly ChippedContent[] = []
 
-  protected readonly StackContent: Record<
+  static readonly StackContent: Record<
     Stack,
     {
       displayName: string
@@ -66,6 +66,7 @@ export class ProjectItemComponent {
     },
   }
   protected readonly Attribute = Attribute
+  protected _stackContent = ProjectItemComponent.StackContent
 }
 
 export enum Attribute {

--- a/src/test/color-scheme.spec.ts
+++ b/src/test/color-scheme.spec.ts
@@ -58,18 +58,18 @@ describe('App color scheme', () => {
     })
   })
 
-  type rgbaArray = [r: number, g: number, b: number, a?: number]
+  type RgbaArray = [r: number, g: number, b: number, a?: number]
   // https://en.wikipedia.org/wiki/Relative_luminance
   // https://stackoverflow.com/a/52879332/3263250
   // It doesn't take into account alpha channel
-  const getRelativeLuminance = (rgb: rgbaArray) =>
+  const getRelativeLuminance = (rgb: RgbaArray) =>
     (0.2126 * rgb[0] + 0.7152 * rgb[1] + 0.0722 * rgb[2]) / 255
   // https://stackoverflow.com/a/3752026/3263250
-  const getRgbFromCssRgbColor = (cssRgbColor: string): rgbaArray =>
+  const getRgbFromCssRgbColor = (cssRgbColor: string): RgbaArray =>
     cssRgbColor
       .replace(/^(rgb|rgba)\(/, '')
       .replace(/\)$/, '')
       .replace(/\s/g, '')
       .split(',')
-      .map((v) => parseFloat(v)) as rgbaArray
+      .map((v) => parseFloat(v)) as RgbaArray
 })

--- a/tsconfig.configs.json
+++ b/tsconfig.configs.json
@@ -1,5 +1,5 @@
 {
-  "include": ["**/.release-it.ts"],
+  "include": [".*.ts"],
   "compilerOptions": {
     "target": "esnext",
     "moduleResolution": "bundler"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -36,6 +36,6 @@
   "references": [
     { "path": "./tsconfig.app.json" },
     { "path": "./tsconfig.spec.json" },
-    { "path": "./tsconfig.release-it.json" }
+    { "path": "./tsconfig.configs.json" }
   ]
 }


### PR DESCRIPTION
After introducing #867, thought that some naming conventions can be introduced.

Mainly to:
 - Variables, functions and parameters are in `camelCase`
 - Variables can be in `UPPER_CASE` for constants not meant to be changed
 - Ensure `_` is required for protected / private members
 - Classes, interfaces and types to be `PascalCase`
 - Booleans to start with `is`, `has`, ...

To enable the `boolean`s rule, type information is needed. Which has performance implications. So enabling those only by running another linter run script. Won't be used in CI/CD. Will be used in `lint-staged` as an experiment for now given just few files are checked (a commit shouldn't contain many files). Add docs about this in `README.md`. Adds a run configuration for the IDE.

Updates code around for code that doesn't match rules. Includes updating `resume.json` for boolean fields.

An exception is added for Material Symbols. Where `PascalCase` is used given the later usage in components. 

`tsconfig.release-it.json` is repurposed to refer to all config files so that they're included in the project and can be linted when linting with ESLint and type information. Renaming then to `tsconfig.configs.json`.

In next PRs, will enable recommended and stylistic rules when type information is enabled.