### PR TITLE
build: lint JS configuration files

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -13,11 +13,17 @@ import eslintPluginCypress from 'eslint-plugin-cypress/flat'
 import eslintPluginJasmine from 'eslint-plugin-jasmine'
 import eslintPluginJsonFiles from 'eslint-plugin-json-files'
 
-const __filename = fileURLToPath(import.meta.url)
-const __dirname = dirname(__filename)
-const gitignorePath = resolve(__dirname, '.gitignore')
+import globals from 'globals'
 
-const useTypedRules = Boolean(process.env.TYPED_RULES)
+const gitignorePath = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  '.gitignore',
+)
+
+const shouldEnableTypedRules = Boolean(process.env.TYPED_RULES)
+
+const jsRules = [eslint.configs.recommended]
+
 export default tsEslint.config(
   includeIgnoreFile(gitignorePath),
   {
@@ -28,17 +34,27 @@ export default tsEslint.config(
       'src/environments/environment.pull-request.ts',
     ],
   },
+  // Configuration files. Right now ESLint and Karma.
+  {
+    files: ['*.mjs', '*.js'],
+    extends: [...jsRules],
+    languageOptions: {
+      globals: {
+        ...globals.node,
+      },
+    },
+  },
   {
     files: ['**/*.ts'],
     extends: [
-      eslint.configs.recommended,
+      ...jsRules,
       // TODO: enable typed check recommended / stylistic
       ...tsEslint.configs.recommended,
       ...tsEslint.configs.stylistic,
     ],
     languageOptions: {
       parserOptions: {
-        ...(useTypedRules
+        ...(shouldEnableTypedRules
           ? {
               projectService: true,
               tsconfigRootDir: import.meta.dirname,
@@ -75,7 +91,7 @@ export default tsEslint.config(
           selector: 'typeLike',
           format: ['PascalCase'],
         },
-        ...(useTypedRules
+        ...(shouldEnableTypedRules
           ? [
               // https://github.com/typescript-eslint/typescript-eslint/blob/v8.16.0/packages/eslint-plugin/docs/rules/naming-convention.mdx#enforce-that-boolean-variables-are-prefixed-with-an-allowed-verb
               {

--- a/package.json
+++ b/package.json
@@ -113,6 +113,7 @@
     "eslint-plugin-json-files": "4.4.2",
     "execa": "9.5.1",
     "extensionless": "1.9.9",
+    "globals": "15.12.0",
     "husky": "9.1.6",
     "jasmine-core": "5.4.0",
     "karma": "6.4.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -171,6 +171,9 @@ importers:
       extensionless:
         specifier: 1.9.9
         version: 1.9.9
+      globals:
+        specifier: 15.12.0
+        version: 15.12.0
       husky:
         specifier: 9.1.6
         version: 9.1.6


### PR DESCRIPTION
Moar linter additions. In this case, adding JavaScript configuration files (ESLint config file (:inception:) and Karma configuration files) as files to lint.

To achieve that, ESLint recommended rules are applied to JS files in root of repo.

Fixes issues about `__dirname` and `__filename`. Adds Node.js globals.

Renames boolean constant about using typed rules or not. This wasn't linter-triggered, as there are no types in the ESLint config file as it is a `*.mjs`, not TS file. Using TypeScript for ESLint configuration files is enabled behind a flag + requires an extra dependency. So keeping that file as JavaScript to avoid introducing complexity.
