### PR TITLE
refactor: use signals in tab component

### DIFF
--- a/src/app/header/tab/tab.component.spec.ts
+++ b/src/app/header/tab/tab.component.spec.ts
@@ -9,7 +9,7 @@ describe('TabComponent', () => {
   let fixture: ComponentFixture<TabComponent>
 
   beforeEach(() => {
-    ;[fixture, component] = makeSut()
+    ;[fixture, component] = componentTestSetup(TabComponent)
   })
 
   it('should create', () => {
@@ -60,5 +60,3 @@ describe('TabComponent', () => {
     })
   })
 })
-
-const makeSut = () => componentTestSetup(TabComponent)

--- a/src/app/header/tab/tab.component.ts
+++ b/src/app/header/tab/tab.component.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, Input } from '@angular/core'
+import { Component, ElementRef, input } from '@angular/core'
 
 @Component({
   selector: 'app-tab',
@@ -7,18 +7,18 @@ import { Component, ElementRef, Input } from '@angular/core'
   standalone: true,
   host: {
     role: 'tab',
-    '[attr.aria-selected]': 'isSelected',
-    '[attr.tabindex]': 'isSelected ? 0 : -1',
+    '[attr.aria-selected]': 'isSelected()',
+    '[attr.tabindex]': 'isSelected() ? 0 : -1',
   },
 })
 export class TabComponent {
-  @Input() isSelected = false
+  readonly isSelected = input(false)
 
   constructor(
     //👇 Useful for tabs group component to access the HTML native element
     //   Same as Angular Material does for tabs pagination
     //   https://github.com/angular/components/blob/18.0.5/src/material/tabs/paginated-tab-header.ts#L515
     //   https://github.com/angular/components/blob/18.0.5/src/material/tabs/tab-label-wrapper.ts#L29
-    public elRef: ElementRef,
+    readonly elRef: ElementRef,
   ) {}
 }


### PR DESCRIPTION
Seems this one isn't feasible yet. The reason is that `TabsComponent` needs to write the `isSelected` input. However, that's not yet possible with input signals: https://github.com/angular/angular/issues/13776 . In tests we achieved that with `ComponentRef.setInput` new function, however we can't inject that yet: https://github.com/angular/angular/issues/47398

So seems to avoid hacky workarounds, better to stay off with signals for now in this scenario.