### PR TITLE
refactor: minor tab/tabs component improvements

### DIFF
--- a/src/app/header/tab/tab.component.ts
+++ b/src/app/header/tab/tab.component.ts
@@ -12,6 +12,7 @@ import { Component, ElementRef, Input } from '@angular/core'
   },
 })
 export class TabComponent {
+  // Can't be migrated yet: https://github.com/davidlj95/website/pull/886
   @Input() isSelected = false
 
   constructor(

--- a/src/app/header/tabs/tabs.component.html
+++ b/src/app/header/tabs/tabs.component.html
@@ -5,6 +5,7 @@
   [disabled]="_prevButtonDisabled()"
   (click)="_scrollABit(-1)"
 ></button>
+<!--suppress JSUnusedGlobalSymbols - Used in component -->
 <div role="tablist" #tabList>
   <ng-content></ng-content>
 </div>

--- a/src/app/header/tabs/tabs.component.ts
+++ b/src/app/header/tabs/tabs.component.ts
@@ -33,19 +33,19 @@ export class TabsComponent implements OnDestroy {
     KeyboardDoubleArrowRight,
   }
 
-  private _tabs = contentChildren(TabComponent, {
-    descendants: false,
-  })
-
   // Pagination
-  private _tabList = viewChild.required<ElementRef<HTMLElement>>('tabList')
+  private readonly _tabList =
+    viewChild.required<ElementRef<HTMLElement>>('tabList')
   private _firstTab?: ElementRef<HTMLElement>
   private _lastTab?: ElementRef<HTMLElement>
-  protected _prevButtonDisabled = signal(true)
-  protected _nextButtonDisabled = signal(true)
+  protected readonly _prevButtonDisabled = signal(true)
+  protected readonly _nextButtonDisabled = signal(true)
   private _intersectionObserver!: IntersectionObserver
 
   // Selected management
+  private readonly _tabs = contentChildren(TabComponent, {
+    descendants: false,
+  })
   private _currentTabs: readonly TabComponent[] = []
   private _indexToSelect?: number
   private _selectedIndex?: number


### PR DESCRIPTION
Some minor improvements to tab and tabs components:
 - Adds reason for not migrating tab component to signals yet
 - Suppress invalid webstorm unused inspection
 - Marks everything possible as `readonly`
 - Moves `_tabs` to selected index management, where it belongs
 - Passes `elRef` and `cdRef` instead of storing them in component. Just needed for two functions called in constructor
 - Indexes intersection observer entries by target `O(n)` so they can later be found at `O(1)` compute time. Otherwise its `O(2n)` as searching twice, one for first tab, another for second tab
 - Reorder tabs component functions to be grouped by functionality
