### PR TITLE
build: fix private/protected naming convention & improve boolean one

### DIFF
--- a/data/templates/environment.pull-request.ts.liquid
+++ b/data/templates/environment.pull-request.ts.liquid
@@ -9,6 +9,6 @@ const CLOUDFLARE_PAGES_PREVIEW_BRANCH_ALIAS_URL = new URL(
   `https://${PR_BRANCH_NAME}.${CLOUDFLARE_PAGES_DOMAIN}`,
 )
 export const environment: Environment = {
-  production: false,
+  isProduction: false,
   appBaseUrl: CLOUDFLARE_PAGES_PREVIEW_BRANCH_ALIAS_URL,
 }

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -34,18 +34,14 @@ export const NAMING_CONVENTION_SELECTORS = [
     format: ['camelCase', 'UPPER_CASE'],
   },
   // https://github.com/typescript-eslint/typescript-eslint/blob/v8.16.0/packages/eslint-plugin/docs/rules/naming-convention.mdx#enforce-that-private-members-are-prefixed-with-an-underscore
-  {
+  // 👇 `modifiers` matches code with ALL modifiers specified
+  //    To specify the same for several modifiers, repeating the rule for each one
+  ...['private', 'protected'].map((modifier) => ({
     selector: 'memberLike',
-    modifiers: ['private'],
+    modifiers: [modifier],
     format: ['camelCase'],
     leadingUnderscore: 'require',
-  },
-  {
-    selector: 'memberLike',
-    modifiers: ['protected'],
-    format: ['camelCase'],
-    leadingUnderscore: 'require',
-  },
+  })),
   // https://github.com/typescript-eslint/typescript-eslint/blob/v8.16.0/packages/eslint-plugin/docs/rules/naming-convention.mdx#enforce-that-interface-names-do-not-begin-with-an-i
   {
     selector: 'typeLike',

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -36,7 +36,13 @@ export const NAMING_CONVENTION_SELECTORS = [
   // https://github.com/typescript-eslint/typescript-eslint/blob/v8.16.0/packages/eslint-plugin/docs/rules/naming-convention.mdx#enforce-that-private-members-are-prefixed-with-an-underscore
   {
     selector: 'memberLike',
-    modifiers: ['private', 'protected'],
+    modifiers: ['private'],
+    format: ['camelCase'],
+    leadingUnderscore: 'require',
+  },
+  {
+    selector: 'memberLike',
+    modifiers: ['protected'],
     format: ['camelCase'],
     leadingUnderscore: 'require',
   },

--- a/eslint.config.typed.mjs
+++ b/eslint.config.typed.mjs
@@ -23,12 +23,19 @@ export default tsEslint.config(
         // https://github.com/typescript-eslint/typescript-eslint/blob/v8.16.0/packages/eslint-plugin/docs/rules/naming-convention.mdx#enforce-that-boolean-variables-are-prefixed-with-an-allowed-verb
         {
           selector: [
-            'variable',
+            // `member-like` without:
+            //  - `property`: will be specified later, with exceptions
+            //  - `enumMember`: no types allowed
+            //  - `method`: no types allowed
             'classicAccessor',
             'autoAccessor',
-            'classProperty',
-            'parameter',
             'parameterProperty',
+            // All `property` but `objectLiteralProperty`
+            'classProperty',
+            'typeProperty',
+            // The rest
+            'parameter',
+            'variable',
           ],
           types: ['boolean'],
           format: ['PascalCase'],

--- a/src/app/common/material-symbol.directive.ts
+++ b/src/app/common/material-symbol.directive.ts
@@ -4,10 +4,8 @@ import { Directive, ElementRef } from '@angular/core'
   selector: '[appMaterialSymbol]',
 })
 export class MaterialSymbolDirective {
-  constructor(private el: ElementRef) {
-    ;(this.el.nativeElement as HTMLElement).classList.add(
-      MATERIAL_SYMBOLS_CLASS,
-    )
+  constructor(elRef: ElementRef<Element>) {
+    elRef.nativeElement.classList.add(MATERIAL_SYMBOLS_CLASS)
   }
 }
 

--- a/src/app/common/test-id.directive.ts
+++ b/src/app/common/test-id.directive.ts
@@ -4,13 +4,10 @@ import { Directive, effect, ElementRef, input } from '@angular/core'
 export class TestIdDirective {
   readonly appTestId = input.required<string>()
 
-  constructor(private el: ElementRef) {
+  constructor(elRef: ElementRef<Element>) {
     effect(() => {
       if (isDevMode) {
-        ;(this.el.nativeElement as Element).setAttribute(
-          TEST_ID_ATTRIBUTE,
-          this.appTestId(),
-        )
+        elRef.nativeElement.setAttribute(TEST_ID_ATTRIBUTE, this.appTestId())
       }
     })
   }

--- a/src/app/header/light-dark-toggle/color-scheme.service.spec.ts
+++ b/src/app/header/light-dark-toggle/color-scheme.service.spec.ts
@@ -245,17 +245,17 @@ class MockHTMLElementWithAttributes
   implements
     Pick<HTMLElement, 'getAttribute' | 'setAttribute' | 'removeAttribute'>
 {
-  private attributes = new Map<string, string>()
+  private readonly _attributes = new Map<string, string>()
 
   getAttribute(qualifiedName: string) {
-    return this.attributes.get(qualifiedName) ?? null
+    return this._attributes.get(qualifiedName) ?? null
   }
 
   setAttribute(qualifiedName: string, value: string) {
-    return this.attributes.set(qualifiedName, value)
+    return this._attributes.set(qualifiedName, value)
   }
 
   removeAttribute(qualifiedName: string): void {
-    this.attributes.delete(qualifiedName)
+    this._attributes.delete(qualifiedName)
   }
 }

--- a/src/app/header/light-dark-toggle/color-scheme.service.ts
+++ b/src/app/header/light-dark-toggle/color-scheme.service.ts
@@ -20,14 +20,14 @@ export class ColorSchemeService {
     @Inject(WINDOW) private _window: Window,
   ) {
     this._htmlElement = document.documentElement
-    this.listenForMatchMediaPreferenceChanges()
+    this._listenForMatchMediaPreferenceChanges()
   }
 
-  private get isDarkPreferred(): boolean {
-    return !!this.matchMediaQuery && this.matchMediaQuery.matches
+  private get _isDarkPreferred(): boolean {
+    return !!this._matchMediaQuery && this._matchMediaQuery.matches
   }
 
-  private get matchMediaQuery() {
+  private get _matchMediaQuery() {
     if (!this._window.matchMedia) {
       return null
     }
@@ -39,7 +39,7 @@ export class ColorSchemeService {
       HTML_COLOR_SCHEME_ATTRIBUTE,
     ) as Scheme
     if (!manuallySetScheme) {
-      this.setManual(this.isDarkPreferred ? Scheme.Light : Scheme.Dark)
+      this.setManual(this._isDarkPreferred ? Scheme.Light : Scheme.Dark)
       return
     }
 
@@ -56,8 +56,8 @@ export class ColorSchemeService {
     this._htmlElement.removeAttribute(HTML_COLOR_SCHEME_ATTRIBUTE)
   }
 
-  private listenForMatchMediaPreferenceChanges() {
-    this.matchMediaQuery?.addEventListener('change', () => {
+  private _listenForMatchMediaPreferenceChanges() {
+    this._matchMediaQuery?.addEventListener('change', () => {
       this.setSystem()
     })
   }

--- a/src/app/header/light-dark-toggle/light-dark-toggle.component.html
+++ b/src/app/header/light-dark-toggle/light-dark-toggle.component.html
@@ -1,14 +1,14 @@
 <button
   app-toolbar-button
-  [icon]="MaterialSymbol.DarkMode"
-  (click)="colorSchemeService.toggleDarkLight()"
+  [icon]="_materialSymbol.DarkMode"
+  (click)="_colorSchemeService.toggleDarkLight()"
   aria-label="Switch to dark mode"
   class="light-only"
 ></button>
 <button
   app-toolbar-button
-  [icon]="MaterialSymbol.LightMode"
-  (click)="colorSchemeService.toggleDarkLight()"
+  [icon]="_materialSymbol.LightMode"
+  (click)="_colorSchemeService.toggleDarkLight()"
   aria-label="Switch to light mode"
   class="dark-only"
 ></button>

--- a/src/app/header/light-dark-toggle/light-dark-toggle.component.ts
+++ b/src/app/header/light-dark-toggle/light-dark-toggle.component.ts
@@ -10,10 +10,10 @@ import { ToolbarButtonComponent } from '../toolbar-button/toolbar-button.compone
   styleUrl: './light-dark-toggle.component.scss',
 })
 export class LightDarkToggleComponent {
-  protected readonly MaterialSymbol = {
+  protected readonly _materialSymbol = {
     DarkMode,
     LightMode,
   }
 
-  constructor(protected readonly colorSchemeService: ColorSchemeService) {}
+  constructor(protected readonly _colorSchemeService: ColorSchemeService) {}
 }

--- a/src/app/header/tabs/tabs.component.html
+++ b/src/app/header/tabs/tabs.component.html
@@ -1,6 +1,6 @@
 <button
   app-toolbar-button
-  [icon]="MaterialSymbol.KeyboardDoubleArrowLeft"
+  [icon]="_materialSymbol.KeyboardDoubleArrowLeft"
   aria-label="Previous tab"
   [disabled]="_prevButtonDisabled()"
   (click)="_scrollABit(-1)"
@@ -11,7 +11,7 @@
 </div>
 <button
   app-toolbar-button
-  [icon]="MaterialSymbol.KeyboardDoubleArrowRight"
+  [icon]="_materialSymbol.KeyboardDoubleArrowRight"
   aria-label="Next tab"
   [disabled]="_nextButtonDisabled()"
   (click)="_scrollABit(1)"

--- a/src/app/header/tabs/tabs.component.ts
+++ b/src/app/header/tabs/tabs.component.ts
@@ -27,7 +27,7 @@ import { TabComponent } from '../tab/tab.component'
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class TabsComponent implements OnDestroy {
-  protected readonly MaterialSymbol = {
+  protected readonly _materialSymbol = {
     KeyboardDoubleArrowLeft,
     KeyboardDoubleArrowRight,
   }

--- a/src/app/no-script/no-script.component.html
+++ b/src/app/no-script/no-script.component.html
@@ -1,7 +1,7 @@
 <noscript>
   <div class="contents">
     <p>
-      <span appMaterialSymbol>{{ MaterialSymbol.Warning }}</span>
+      <span appMaterialSymbol>{{ _materialSymbol.Warning }}</span>
       <b>Seems you don't have JavaScript enabled</b>
     </p>
     <p>

--- a/src/app/no-script/no-script.component.ts
+++ b/src/app/no-script/no-script.component.ts
@@ -10,7 +10,7 @@ import { MaterialSymbolDirective } from '@/common/material-symbol.directive'
   host: { ngSkipHydration: 'true' },
 })
 export class NoScriptComponent {
-  protected readonly MaterialSymbol = {
+  protected readonly _materialSymbol = {
     Warning,
   }
 }

--- a/src/app/not-found-page/not-found-page.component.html
+++ b/src/app/not-found-page/not-found-page.component.html
@@ -22,7 +22,7 @@
     You can use
     <a href="https://web.archive.org/">Internet Archive's Wayback Machine</a>
     to see if a page existed in the past. <br />Maybe
-    <a [href]="_currentUrlInWaybackMachine"
+    <a [href]="_currentUrlInWaybackMachine" appTestId="wayback"
       >this page existed at some other point in time</a
     >
   </p>

--- a/src/app/not-found-page/not-found-page.component.html
+++ b/src/app/not-found-page/not-found-page.component.html
@@ -15,14 +15,14 @@
 </main>
 <aside class="tip">
   <header>
-    <span appMaterialSymbol>{{ MaterialSymbol.Lightbulb }}</span
+    <span appMaterialSymbol>{{ _materialSymbol.Lightbulb }}</span
     ><b>TIP: What if this page existed before?</b>
   </header>
   <p>
     You can use
     <a href="https://web.archive.org/">Internet Archive's Wayback Machine</a>
     to see if a page existed in the past. <br />Maybe
-    <a [href]="currentUrlInWaybackMachine"
+    <a [href]="_currentUrlInWaybackMachine"
       >this page existed at some other point in time</a
     >
   </p>

--- a/src/app/not-found-page/not-found-page.component.spec.ts
+++ b/src/app/not-found-page/not-found-page.component.spec.ts
@@ -8,20 +8,21 @@ import { Router } from '@angular/router'
 import { MockProvider } from 'ng-mocks'
 import { APP_BASE_URL } from '@/common/app-base-url'
 import { componentTestSetup } from '@/test/helpers/component-test-setup'
+import { byTestId } from '@/test/helpers/test-id'
 
 describe('NotFoundPageComponent', () => {
   let component: NotFoundPageComponent
   let fixture: ComponentFixture<NotFoundPageComponent>
-  const dummyAppUrlNoTrailingSlash = 'https://example.com'
-  const dummyRouter: Pick<Router, 'url'> = {
+  const DUMMY_APP_URL = 'https://example.com'
+  const DUMMY_ROUTER: Pick<Router, 'url'> = {
     url: '/foo',
   }
 
   beforeEach(() => {
     ;[fixture, component] = componentTestSetup(NotFoundPageComponent, {
       providers: [
-        MockProvider(APP_BASE_URL, new URL(dummyAppUrlNoTrailingSlash)),
-        MockProvider(Router, dummyRouter),
+        MockProvider(APP_BASE_URL, new URL(DUMMY_APP_URL)),
+        MockProvider(Router, DUMMY_ROUTER),
       ],
     })
     fixture.detectChanges()
@@ -31,15 +32,15 @@ describe('NotFoundPageComponent', () => {
     expect(component).toBeTruthy()
   })
 
-  describe('#currentUrlInWaybackMachine', () => {
-    it('should be the Wayback Machine URL prefix plus the current URL', () => {
-      expect(component._currentUrlInWaybackMachine).toEqual(
-        new URL(
-          WAYBACK_MACHINE_URL_PREFIX.toString() +
-            dummyAppUrlNoTrailingSlash +
-            dummyRouter.url,
-        ),
-      )
-    })
+  it('should contain a link to the Wayback Machine URL of the current page', () => {
+    const anchorElement = fixture.debugElement.query(byTestId('wayback'))
+
+    expect(anchorElement.attributes['href']).toEqual(
+      new URL(
+        WAYBACK_MACHINE_URL_PREFIX.toString() +
+          DUMMY_APP_URL +
+          DUMMY_ROUTER.url,
+      ).toString(),
+    )
   })
 })

--- a/src/app/not-found-page/not-found-page.component.spec.ts
+++ b/src/app/not-found-page/not-found-page.component.spec.ts
@@ -33,7 +33,7 @@ describe('NotFoundPageComponent', () => {
 
   describe('#currentUrlInWaybackMachine', () => {
     it('should be the Wayback Machine URL prefix plus the current URL', () => {
-      expect(component.currentUrlInWaybackMachine).toEqual(
+      expect(component._currentUrlInWaybackMachine).toEqual(
         new URL(
           WAYBACK_MACHINE_URL_PREFIX.toString() +
             dummyAppUrlNoTrailingSlash +

--- a/src/app/not-found-page/not-found-page.component.ts
+++ b/src/app/not-found-page/not-found-page.component.ts
@@ -3,12 +3,13 @@ import { Lightbulb } from '@/data/material-symbols'
 import { Router } from '@angular/router'
 import { MaterialSymbolDirective } from '@/common/material-symbol.directive'
 import { APP_BASE_URL } from '@/common/app-base-url'
+import { TestIdDirective } from '@/common/test-id.directive'
 
 @Component({
   selector: 'app-not-found-page',
   templateUrl: './not-found-page.component.html',
   styleUrls: ['./not-found-page.component.scss'],
-  imports: [MaterialSymbolDirective],
+  imports: [MaterialSymbolDirective, TestIdDirective],
 })
 export class NotFoundPageComponent {
   protected readonly _currentUrlInWaybackMachine: URL

--- a/src/app/not-found-page/not-found-page.component.ts
+++ b/src/app/not-found-page/not-found-page.component.ts
@@ -11,15 +11,14 @@ import { APP_BASE_URL } from '@/common/app-base-url'
   imports: [MaterialSymbolDirective],
 })
 export class NotFoundPageComponent {
-  readonly currentUrlInWaybackMachine: URL
-  protected readonly MaterialSymbol = {
+  protected readonly _currentUrlInWaybackMachine: URL
+  protected readonly _materialSymbol = {
     Lightbulb,
   }
 
   constructor(@Inject(APP_BASE_URL) appBaseUrl: URL, router: Router) {
-    const currentUrl = new URL(router.url, appBaseUrl)
-    this.currentUrlInWaybackMachine = new URL(
-      `${WAYBACK_MACHINE_URL_PREFIX}${currentUrl}`,
+    this._currentUrlInWaybackMachine = new URL(
+      `${WAYBACK_MACHINE_URL_PREFIX}${new URL(router.url, appBaseUrl)}`,
     )
   }
 }

--- a/src/app/resume-page/chip/chip.component.ts
+++ b/src/app/resume-page/chip/chip.component.ts
@@ -9,9 +9,9 @@ import { Component, EventEmitter, input, Output } from '@angular/core'
     '[class.selectable]': 'isSelectedChange.observed',
     '[attr.role]': "isSelectedChange.observed ? 'button': undefined",
     '[attr.tabindex]': 'isSelectedChange.observed ? 0 : undefined',
-    '(click)': 'emitToggledSelected()',
-    '(keydown.enter)': 'emitToggledSelected()',
-    '(keydown.space)': 'emitToggledSelected()',
+    '(click)': '_emitToggledSelected()',
+    '(keydown.enter)': '_emitToggledSelected()',
+    '(keydown.space)': '_emitToggledSelected()',
   },
 })
 export class ChipComponent {
@@ -20,7 +20,7 @@ export class ChipComponent {
   @Output()
   isSelectedChange = new EventEmitter<boolean>()
 
-  protected emitToggledSelected() {
+  protected _emitToggledSelected() {
     this.isSelectedChange.emit(!this.isSelected())
   }
 }

--- a/src/app/resume-page/collapsible-tree/collapsible-tree.component.ts
+++ b/src/app/resume-page/collapsible-tree/collapsible-tree.component.ts
@@ -55,11 +55,11 @@ export class CollapsibleTreeComponent {
   isExpanded = false
 
   @ViewChildren(CollapsibleTreeComponent)
-  private children!: QueryList<CollapsibleTreeComponent>
+  private readonly _children!: QueryList<CollapsibleTreeComponent>
 
   private readonly _id = nextId++
 
-  constructor(private readonly cdRef: ChangeDetectorRef) {}
+  constructor(private readonly _cdRef: ChangeDetectorRef) {}
 
   get isCollapsible(): boolean {
     if (!(this.node.children.length > 0)) {
@@ -81,7 +81,7 @@ export class CollapsibleTreeComponent {
   collapse() {
     if (this.isExpanded) {
       this.isExpanded = false
-      this.cdRef.markForCheck()
+      this._cdRef.markForCheck()
     }
   }
 
@@ -93,7 +93,9 @@ export class CollapsibleTreeComponent {
   }
 
   collapseAllChildren({ except }: { except?: CollapsibleTreeComponent } = {}) {
-    const childrenToCollapse = this.children.filter((child) => child !== except)
+    const childrenToCollapse = this._children.filter(
+      (child) => child !== except,
+    )
     for (const child of childrenToCollapse) {
       child.collapse()
     }

--- a/src/app/resume-page/education-section/education-item/education-item.component.html
+++ b/src/app/resume-page/education-section/education-item/education-item.component.html
@@ -25,7 +25,7 @@
     <app-card-header-attributes>
       @if (item.isCumLaude) {
         <app-attribute
-          [symbol]="MaterialSymbol.SocialLeaderboard"
+          [symbol]="_materialSymbol.SocialLeaderboard"
           [appTestId]="_attribute.CumLaude"
         >
           Cum laude

--- a/src/app/resume-page/education-section/education-item/education-item.component.ts
+++ b/src/app/resume-page/education-section/education-item/education-item.component.ts
@@ -46,7 +46,7 @@ export class EducationItemComponent {
     return name.length > 15 && shortName ? shortName : name
   })
 
-  protected readonly MaterialSymbol = {
+  protected readonly _materialSymbol = {
     SocialLeaderboard,
   }
   protected readonly _attribute = ATTRIBUTE

--- a/src/app/resume-page/education-section/education-section.component.html
+++ b/src/app/resume-page/education-section/education-section.component.html
@@ -1,6 +1,6 @@
 <app-section-title><h2 id="education">Education</h2></app-section-title>
 <app-card-grid>
-  @for (item of items; track item) {
+  @for (item of _items; track item) {
     <app-education-item [item]="item"></app-education-item>
   }
 </app-card-grid>

--- a/src/app/resume-page/education-section/education-section.component.ts
+++ b/src/app/resume-page/education-section/education-section.component.ts
@@ -12,11 +12,11 @@ import { GET_EDUCATION_ITEMS, GetEducationItems } from './get-education-items'
   imports: [SectionTitleComponent, CardGridComponent, EducationItemComponent],
 })
 export class EducationSectionComponent {
-  protected readonly items: readonly EducationItem[]
+  protected readonly _items: readonly EducationItem[]
 
   constructor(
     @Inject(GET_EDUCATION_ITEMS) getEducationItems: GetEducationItems,
   ) {
-    this.items = getEducationItems()
+    this._items = getEducationItems()
   }
 }

--- a/src/app/resume-page/experience-section/experience-item/experience-item.component.html
+++ b/src/app/resume-page/experience-section/experience-item/experience-item.component.html
@@ -22,14 +22,14 @@
     <app-card-header-attributes>
       @if (item.isFreelance) {
         <app-attribute
-          [symbol]="MaterialSymbol.Work"
+          [symbol]="_materialSymbol.Work"
           [appTestId]="_attribute.Freelance"
         >
           Freelance
         </app-attribute>
       } @else {
         <app-attribute
-          [symbol]="MaterialSymbol.Badge"
+          [symbol]="_materialSymbol.Badge"
           [appTestId]="_attribute.Employee"
         >
           Employee
@@ -37,7 +37,7 @@
       }
       @if (item.isInternship) {
         <app-attribute
-          [symbol]="MaterialSymbol.School"
+          [symbol]="_materialSymbol.School"
           [appTestId]="_attribute.Internship"
         >
           Internship
@@ -45,7 +45,7 @@
       }
       @if (item.hasMorePositions) {
         <app-attribute
-          [symbol]="MaterialSymbol.More"
+          [symbol]="_materialSymbol.More"
           [appTestId]="_attribute.MorePositions"
         >
           More positions during this period<br />
@@ -54,7 +54,7 @@
       }
       @if (item.hasPromotions) {
         <app-attribute
-          [symbol]="MaterialSymbol.ToolsLadder"
+          [symbol]="_materialSymbol.ToolsLadder"
           [appTestId]="_attribute.Promotions"
         >
           Promotions during this period<br />See highlights for details

--- a/src/app/resume-page/experience-section/experience-item/experience-item.component.ts
+++ b/src/app/resume-page/experience-section/experience-item/experience-item.component.ts
@@ -42,7 +42,7 @@ export class ExperienceItemComponent {
     experienceItemToContents(this.item()),
   )
 
-  protected readonly MaterialSymbol = {
+  protected readonly _materialSymbol = {
     Badge,
     Work,
     School,

--- a/src/app/resume-page/experience-section/experience-section.component.html
+++ b/src/app/resume-page/experience-section/experience-section.component.html
@@ -2,7 +2,7 @@
   ><h2 id="experience">Professional experience</h2></app-section-title
 >
 <app-card-grid>
-  @for (item of items; track item) {
+  @for (item of _items; track item) {
     <app-experience-item [item]="item"></app-experience-item>
   }
 </app-card-grid>

--- a/src/app/resume-page/experience-section/experience-section.component.ts
+++ b/src/app/resume-page/experience-section/experience-section.component.ts
@@ -15,11 +15,11 @@ import {
   imports: [SectionTitleComponent, CardGridComponent, ExperienceItemComponent],
 })
 export class ExperienceSectionComponent {
-  protected readonly items: readonly ExperienceItem[]
+  protected readonly _items: readonly ExperienceItem[]
 
   constructor(
     @Inject(GET_EXPERIENCE_ITEMS) getExperienceItems: GetExperienceItems,
   ) {
-    this.items = getExperienceItems()
+    this._items = getExperienceItems()
   }
 }

--- a/src/app/resume-page/languages-section/languages-section.component.html
+++ b/src/app/resume-page/languages-section/languages-section.component.html
@@ -1,6 +1,6 @@
 <app-section-title><h2 id="languages">Languages</h2></app-section-title>
 <app-card-grid>
-  @for (item of items; track item) {
+  @for (item of _items; track item) {
     <app-language-item [item]="item"></app-language-item>
   }
 </app-card-grid>

--- a/src/app/resume-page/languages-section/languages-section.component.ts
+++ b/src/app/resume-page/languages-section/languages-section.component.ts
@@ -12,9 +12,9 @@ import { LanguageItemComponent } from './language-item/language-item.component'
   templateUrl: './languages-section.component.html',
 })
 export class LanguagesSectionComponent {
-  protected readonly items: readonly LanguageItem[]
+  protected readonly _items: readonly LanguageItem[]
 
   constructor(@Inject(GET_LANGUAGE_ITEMS) getLanguageItems: GetLanguageItems) {
-    this.items = getLanguageItems()
+    this._items = getLanguageItems()
   }
 }

--- a/src/app/resume-page/profile-section/profile-description/profile-description.component.ts
+++ b/src/app/resume-page/profile-section/profile-description/profile-description.component.ts
@@ -15,22 +15,21 @@ import { ProfileDescriptionLineComponent } from './profile-description-line/prof
   selector: 'app-profile-description',
   template: `
     <app-collapsible-tree
-      [node]="ROOT_NODE"
-      [isCollapsibleFn]="IS_COLLAPSIBLE_FN"
+      [node]="_rootNode"
+      [isCollapsibleFn]="_isCollapsibleFn"
     ></app-collapsible-tree>
   `,
   imports: [CollapsibleTreeComponent],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class ProfileDescriptionComponent {
-  protected readonly ROOT_NODE: CollapsibleTreeNode
-
-  protected readonly IS_COLLAPSIBLE_FN: IsCollapsibleFn = (
+  protected readonly _rootNode: CollapsibleTreeNode
+  protected readonly _isCollapsibleFn: IsCollapsibleFn = (
     node: CollapsibleTreeComponent,
   ) => node.depth > 1
 
   constructor(@Inject(METADATA) metadata: Metadata) {
-    this.ROOT_NODE = new CollapsibleTreeNode(
+    this._rootNode = new CollapsibleTreeNode(
       undefined,
       metadata.descriptionLines.map(descriptionLineToCollapsibleTreeNode),
     )

--- a/src/app/resume-page/projects-section/projects-section.component.html
+++ b/src/app/resume-page/projects-section/projects-section.component.html
@@ -1,6 +1,6 @@
 <app-section-title><h2 id="projects">Projects</h2></app-section-title>
 <app-card-grid>
-  @for (item of items; track item) {
+  @for (item of _items; track item) {
     <app-project-item [item]="item"></app-project-item>
   }
 </app-card-grid>

--- a/src/app/resume-page/projects-section/projects-section.component.ts
+++ b/src/app/resume-page/projects-section/projects-section.component.ts
@@ -12,9 +12,9 @@ import { GET_PROJECT_ITEMS, GetProjectItems } from './get-project-items'
   imports: [SectionTitleComponent, CardGridComponent, ProjectItemComponent],
 })
 export class ProjectsSectionComponent {
-  protected readonly items: readonly ProjectItem[]
+  protected readonly _items: readonly ProjectItem[]
 
   constructor(@Inject(GET_PROJECT_ITEMS) getProjectItems: GetProjectItems) {
-    this.items = getProjectItems()
+    this._items = getProjectItems()
   }
 }

--- a/src/environments/environment-interface.ts
+++ b/src/environments/environment-interface.ts
@@ -1,4 +1,4 @@
 export interface Environment {
-  production: boolean
+  isProduction: boolean
   appBaseUrl: URL
 }

--- a/src/environments/environment.development.ts
+++ b/src/environments/environment.development.ts
@@ -1,7 +1,7 @@
 import { Environment } from '.'
 
 export const environment: Environment = {
-  production: false,
+  isProduction: false,
   // ⚠️ When locally serving production SSR, server will run at http://localhost:4000 by default
   //    However, given was built with production profile, app base URL will be production's one.
   //    Nothing too bad happens right now given it's used just for SEO metadata. But to bear in mind.

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -2,6 +2,6 @@ import { METADATA } from '@/data/metadata'
 import { Environment } from '.'
 
 export const environment: Environment = {
-  production: true,
+  isProduction: true,
   appBaseUrl: new URL(`https://${METADATA.domainName}`),
 }


### PR DESCRIPTION
Private and protected naming convention wasn't enforced. Turns out it was because `modifiers` works by combining them in and `and/&&` fashion. So only `private` & `protected` (not possible) code was enforced. Instead, we want both `protected` and `private` code to have same rules. Uses a map to avoid repeating the same rules twice. Nothing is added for `#private`, the hashtag is enough.

Then, enforces a bit more the boolean naming convention. By specifying all available selectors that aren't too greedy (i.e.: object literal expressions are a bit too much, can't control some of them as they're external)

Finally, types `ElementRef` elements around / doesn't store those in class if possible
