### PR TITLE
test: improve collapsible tree component unit tests

### DIFF
--- a/src/app/resume-page/collapsible-tree/collapsible-tree.component.html
+++ b/src/app/resume-page/collapsible-tree/collapsible-tree.component.html
@@ -8,7 +8,7 @@
       (click)="isExpanded ? this.collapse() : this.expand()"
     >
       <span class="caret" aria-hidden="true">
-        {{ isExpanded ? expandedIcon : collapsedIcon }}
+        {{ isExpanded ? '▼' : '▶' }}
       </span>
       <ng-container [ngTemplateOutlet]="data"></ng-container>
     </button>

--- a/src/app/resume-page/collapsible-tree/collapsible-tree.component.ts
+++ b/src/app/resume-page/collapsible-tree/collapsible-tree.component.ts
@@ -50,8 +50,6 @@ export class CollapsibleTreeComponent {
   @Input({ required: true }) node!: CollapsibleTreeNode
   @Input() depth = 0
   @Input() parent?: CollapsibleTreeComponent
-  @Input() collapsedIcon: string = this.parent?.collapsedIcon ?? '▶'
-  @Input() expandedIcon: string = this.parent?.expandedIcon ?? '▼'
   @Input() isCollapsibleFn?: IsCollapsibleFn = this.parent?.isCollapsibleFn
   @Input()
   isExpanded = false


### PR DESCRIPTION
Improves collapsible tree unit tests by:
 - **Reducing cognitive load**: due to deep nesting `beforeEach`s. Up to 4 nesting levels: root (`makeSut`) -> has children -> is collapsible -> when expanded|collapsed). It's easy to get lost of the context at the deepeset level. Also, the fact that `fixture.detectChanges` is delayed until the whole setup is complete makes it easy to miss calling change detection or calling it more than the actually needed. Leaving only 2 levels of `beforeEach` nesting. Root one setting component and fixture and per-case ones. Test setup may be repeated, but it's worth to reduce cognitive load.
 - **Reduce collapsible test case object**: by inlining `name`, `opposite`. This way no need to set an interface, as it's quite a simple interface.
 - **Ensuring `fixture.detectChanges()` is called only when needed**: it was called more than actually needed due to first issue about cognitive load.
 - **Using input signals for dummy component**. And remove `standalone`, it's `true` by default now.
 - **Inline functions**: always / never collapsible, `makeSut`

Also reduces implementation complexity by removing icon inputs
