### PR TITLE
chore: remove `standalone: true` around

### DIFF
--- a/src/app/common/material-symbol.directive.ts
+++ b/src/app/common/material-symbol.directive.ts
@@ -2,7 +2,6 @@ import { Directive, ElementRef } from '@angular/core'
 
 @Directive({
   selector: '[appMaterialSymbol]',
-  standalone: true,
 })
 export class MaterialSymbolDirective {
   constructor(private el: ElementRef) {

--- a/src/app/common/test-id.directive.ts
+++ b/src/app/common/test-id.directive.ts
@@ -1,9 +1,6 @@
 import { Directive, effect, ElementRef, input } from '@angular/core'
 
-@Directive({
-  selector: '[appTestId]',
-  standalone: true,
-})
+@Directive({ selector: '[appTestId]' })
 export class TestIdDirective {
   readonly appTestId = input.required<string>()
 

--- a/src/app/header/tab/tab.component.ts
+++ b/src/app/header/tab/tab.component.ts
@@ -4,7 +4,6 @@ import { Component, ElementRef, Input } from '@angular/core'
   selector: 'app-tab',
   template: '<ng-content></ng-content>',
   styleUrls: ['./tab.component.scss'],
-  standalone: true,
   host: {
     role: 'tab',
     '[attr.aria-selected]': 'isSelected',

--- a/src/app/resume-page/button/button.component.ts
+++ b/src/app/resume-page/button/button.component.ts
@@ -3,7 +3,6 @@ import { Component } from '@angular/core'
 @Component({
   // eslint-disable-next-line @angular-eslint/component-selector
   selector: 'button[app-button]',
-  standalone: true,
   template: '<ng-content></ng-content>',
   styleUrl: './button.component.scss',
 })

--- a/src/app/resume-page/card/card-header/card-header-attributes/card-header-attributes.component.ts
+++ b/src/app/resume-page/card/card-header/card-header-attributes/card-header-attributes.component.ts
@@ -4,6 +4,5 @@ import { Component } from '@angular/core'
   selector: 'app-card-header-attributes',
   template: '<ng-content></ng-content>',
   styleUrls: ['./card-header-attributes.component.scss'],
-  standalone: true,
 })
 export class CardHeaderAttributesComponent {}

--- a/src/app/resume-page/card/card-header/card-header-detail/card-header-detail.component.ts
+++ b/src/app/resume-page/card/card-header/card-header-detail/card-header-detail.component.ts
@@ -4,6 +4,5 @@ import { Component } from '@angular/core'
   selector: 'app-card-header-detail',
   template: '<ng-content></ng-content>',
   styleUrls: ['./card-header-detail.component.scss'],
-  standalone: true,
 })
 export class CardHeaderDetailComponent {}

--- a/src/app/resume-page/card/card-header/card-header-subtitle/card-header-subtitle.component.ts
+++ b/src/app/resume-page/card/card-header/card-header-subtitle/card-header-subtitle.component.ts
@@ -4,6 +4,5 @@ import { Component } from '@angular/core'
   selector: 'app-card-header-subtitle',
   template: '<ng-content></ng-content>',
   styleUrls: ['./card-header-subtitle.component.scss'],
-  standalone: true,
 })
 export class CardHeaderSubtitleComponent {}

--- a/src/app/resume-page/card/card-header/card-header-texts/card-header-texts.component.ts
+++ b/src/app/resume-page/card/card-header/card-header-texts/card-header-texts.component.ts
@@ -4,6 +4,5 @@ import { Component } from '@angular/core'
   selector: 'app-card-header-texts',
   template: '<ng-content></ng-content>',
   styleUrls: ['./card-header-texts.component.scss'],
-  standalone: true,
 })
 export class CardHeaderTextsComponent {}

--- a/src/app/resume-page/card/card-header/card-header-title/card-header-title.component.ts
+++ b/src/app/resume-page/card/card-header/card-header-title/card-header-title.component.ts
@@ -4,6 +4,5 @@ import { Component } from '@angular/core'
   selector: 'app-card-header-title',
   template: '<ng-content></ng-content>',
   styleUrls: ['./card-header-title.component.scss'],
-  standalone: true,
 })
 export class CardHeaderTitleComponent {}

--- a/src/app/resume-page/card/card-header/card-header.component.ts
+++ b/src/app/resume-page/card/card-header/card-header.component.ts
@@ -4,6 +4,5 @@ import { Component } from '@angular/core'
   selector: 'app-card-header',
   template: '<ng-content></ng-content>',
   styleUrls: ['./card-header.component.scss'],
-  standalone: true,
 })
 export class CardHeaderComponent {}

--- a/src/app/resume-page/card/card.component.ts
+++ b/src/app/resume-page/card/card.component.ts
@@ -4,6 +4,5 @@ import { Component } from '@angular/core'
   selector: 'app-card',
   template: '<ng-content></ng-content>',
   styleUrls: ['./card.component.scss'],
-  standalone: true,
 })
 export class CardComponent {}

--- a/src/app/resume-page/chip/chip.component.ts
+++ b/src/app/resume-page/chip/chip.component.ts
@@ -4,7 +4,6 @@ import { Component, EventEmitter, input, Output } from '@angular/core'
   selector: 'app-chip',
   template: '<ng-content></ng-content>',
   styleUrls: ['./chip.component.scss'],
-  standalone: true,
   host: {
     '[class.selected]': 'isSelected()',
     '[class.selectable]': 'isSelectedChange.observed',

--- a/src/app/resume-page/section-title/section-title.component.ts
+++ b/src/app/resume-page/section-title/section-title.component.ts
@@ -4,6 +4,5 @@ import { Component } from '@angular/core'
   selector: 'app-section-title',
   template: '<ng-content></ng-content>',
   styleUrls: ['./section-title.component.scss'],
-  standalone: true,
 })
 export class SectionTitleComponent {}

--- a/src/test/helpers/empty-component.ts
+++ b/src/test/helpers/empty-component.ts
@@ -3,6 +3,5 @@ import { Component } from '@angular/core'
 @Component({
   selector: 'app-empty-component', // not mandatory, but added to be able to use `byComponent` API with it
   template: '',
-  standalone: true,
 })
 export class EmptyComponent {}

--- a/src/test/helpers/get-component-instance.spec.ts
+++ b/src/test/helpers/get-component-instance.spec.ts
@@ -5,13 +5,11 @@ import { getComponentInstance } from '@/test/helpers/get-component-instance'
 @Component({
   selector: 'app-test-component',
   template: '',
-  standalone: true,
 })
 export class TestComponent {}
 @Component({
   selector: 'app-another-test-component',
   template: '',
-  standalone: true,
 })
 export class AnotherTestComponent {}
 


### PR DESCRIPTION
It's the default in Angular v19. Seems the migration left some unapplied
