### PR TITLE
build(deps-dev): update knip to v5.39.1

### DIFF
--- a/knip.jsonc
+++ b/knip.jsonc
@@ -6,20 +6,13 @@
         // 👇 No Karma plugin yet
         "karma.conf.js",
         "src/**/*.spec.ts",
-        // 👇 Missed by Cypress plugin
-        // https://github.com/webpro-nl/knip/blob/5.38.2/packages/knip/src/plugins/cypress/index.ts#L19-L23
-        "cypress/support/component.ts",
+        // 👇 As SSR is not actually enabled
+        "src/server.ts!",
         // 👇 Missed by Angular plugin. Seems it doesn't take into account:
-        //  - `application` builder's `server`
-        //  - `server.ts` (declared in `tsconfig.app.json` though)
         //  - `application` / `browser` builder's `scripts` (console easter egg)
-        //  - `application` / `browser` builder's `configurations.*.fileReplacements` (environment files)
         //  - `karma` builder's `polyfills` (or any other polyfill) (esbuild defines file)
         // https://github.com/webpro-nl/knip/blob/5.38.2/packages/knip/src/plugins/angular/index.ts#L19-L52
-        "src/main.server.ts!",
-        "src/server.ts!",
         "src/app/console-easter-egg/console-easter-egg.ts!",
-        "src/environments/environment*.ts!",
         "src/test/esbuild-defines.ts",
       ],
       "project": [

--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
     "karma-coverage": "2.2.1",
     "karma-jasmine": "5.1.0",
     "karma-jasmine-html-reporter": "2.1.0",
-    "knip": "5.38.2",
+    "knip": "5.39.1",
     "lint-staged": "15.2.11",
     "liquidjs": "10.19.0",
     "ng-mocks": "14.13.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -181,8 +181,8 @@ importers:
         specifier: 2.1.0
         version: 2.1.0(jasmine-core@5.5.0)(karma-jasmine@5.1.0(karma@6.4.4))(karma@6.4.4)
       knip:
-        specifier: 5.38.2
-        version: 5.38.2(@types/node@22.10.2)(typescript@5.6.3)
+        specifier: 5.39.1
+        version: 5.39.1(@types/node@22.10.2)(typescript@5.6.3)
       lint-staged:
         specifier: 15.2.11
         version: 15.2.11
@@ -4826,8 +4826,8 @@ packages:
     resolution: {integrity: sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==}
     engines: {node: '>=0.10.0'}
 
-  knip@5.38.2:
-    resolution: {integrity: sha512-gVduAQa80bar/uKtQDvOCBzTApdjqiz8e9eDIdRkYFyTAQM/DriWLi2vv/2AlzMcPYeSWddLptBdgN4whGzFtg==}
+  knip@5.39.1:
+    resolution: {integrity: sha512-a7QFI40JOUIXeU5PcGt6pX3amIDSA8sXwwh59RWN3X6ZbIe8U4nzAWSXyx+dBW+SJgBUt5/6uQ8zhC6BKbxR/A==}
     engines: {node: '>=18.6.0'}
     hasBin: true
     peerDependencies:
@@ -13003,7 +13003,7 @@ snapshots:
 
   kind-of@6.0.3: {}
 
-  knip@5.38.2(@types/node@22.10.2)(typescript@5.6.3):
+  knip@5.39.1(@types/node@22.10.2)(typescript@5.6.3):
     dependencies:
       '@nodelib/fs.walk': 1.2.8
       '@snyk/github-codeowners': 1.1.0


### PR DESCRIPTION
Not upgrading to latest due to a bug (see #921)

Take into account recent contributions and remove unneeded configs from `knip.jsonc`
