### PR TITLE
chore: remove warnings about scroll into view

### DIFF
--- a/src/app/common/scroll-into-view.ts
+++ b/src/app/common/scroll-into-view.ts
@@ -1,0 +1,9 @@
+export const scrollIntoView = (
+  element: Element,
+  ...args: Parameters<Element['scrollIntoView']>
+) => {
+  // 👇 For the server
+  if (element.scrollIntoView) {
+    element.scrollIntoView(...args)
+  }
+}

--- a/src/app/resume-page/chipped-content/chipped-content.component.html
+++ b/src/app/resume-page/chipped-content/chipped-content.component.html
@@ -11,7 +11,7 @@
 <div
   class="content"
   [@contentDisplayed]="isActive()"
-  (@contentDisplayed.done)="contentElement.scrollIntoView({ block: 'nearest' })"
+  (@contentDisplayed.done)="onAnimationDone(contentElement)"
   #contentElement
 >
   <ng-container

--- a/src/app/resume-page/chipped-content/chipped-content.component.ts
+++ b/src/app/resume-page/chipped-content/chipped-content.component.ts
@@ -11,6 +11,7 @@ import {
   transition,
   trigger,
 } from '@angular/animations'
+import { scrollIntoView } from '@/common/scroll-into-view'
 
 @Component({
   selector: 'app-chipped-content',
@@ -53,5 +54,9 @@ export class ChippedContentComponent {
     }
     this.isActive.set(true)
     this.activeContent.set(content)
+  }
+
+  onAnimationDone(contentElement: Element) {
+    scrollIntoView(contentElement, { block: 'nearest' })
   }
 }


### PR DESCRIPTION
```
ERROR TypeError: contentElement_r5.scrollIntoView is not a function
```

Probably as being ran in the server