### PR TITLE
fix: add title for removed VS Code icon

### DIFF
--- a/src/app/resume-page/technology/custom-display-name-entries.ts
+++ b/src/app/resume-page/technology/custom-display-name-entries.ts
@@ -18,4 +18,6 @@ export const CUSTOM_DISPLAY_NAME_ENTRIES: readonly [string, string][] = [
   ['java', 'Java'],
   ['html', 'HTML'],
   ['css', 'CSS'],
+  // 👇 https://github.com/simple-icons/simple-icons/issues/11236
+  ['visualstudiocode', 'Visual Studio Code'],
 ]


### PR DESCRIPTION
Detected in #993
