### PR TITLE
chore: remove CSS from extra titles

### DIFF
--- a/scripts/src/data/extra-tech-icons.ts
+++ b/scripts/src/data/extra-tech-icons.ts
@@ -9,7 +9,7 @@
 // noinspection JSUnusedGlobalSymbols
 import { SimpleIcon } from 'simple-icons'
 
-export const EXTRA_ICONS: readonly Partial<SimpleIcon>[] = [
+export const EXTRA_TECH_ICONS: readonly Partial<SimpleIcon>[] = [
   // From https://github.com/rspec/rspec.github.io/blob/source/logo.svg
   // Creator doesn't want it to be modified:
   // it can't be made monochrome to be included in simple icons

--- a/scripts/src/data/extra-tech-titles.ts
+++ b/scripts/src/data/extra-tech-titles.ts
@@ -17,7 +17,6 @@ export const EXTRA_TECH_TITLES: readonly [string, string][] = [
   ['pyqt', 'PyQt'],
   ['java', 'Java'],
   ['html', 'HTML'],
-  ['css', 'CSS'],
   // 👇 https://github.com/simple-icons/simple-icons/issues/11236
   ['visualstudiocode', 'Visual Studio Code'],
 ]


### PR DESCRIPTION
There's a logo for that already in simple icons that holds the proper title
