### PR TITLE
refactor: use ngx-meta url resolution feature

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "@angular/platform-server": "19.0.0",
     "@angular/router": "19.0.0",
     "@angular/ssr": "19.0.1",
-    "@davidlj95/ngx-meta": "1.0.0-beta.36",
+    "@davidlj95/ngx-meta": "1.0.0-beta.38",
     "@fontsource/roboto": "5.2.5",
     "@fontsource/roboto-mono": "5.2.5",
     "@ng-icons/core": "27.5.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,8 +36,8 @@ importers:
         specifier: 19.0.1
         version: 19.0.1(115ecd1002e0981c9bbf84ab75970b8d)
       '@davidlj95/ngx-meta':
-        specifier: 1.0.0-beta.36
-        version: 1.0.0-beta.36(@angular/common@19.0.0(@angular/core@19.0.0(rxjs@7.8.2)(zone.js@0.15.0))(rxjs@7.8.2))(@angular/core@19.0.0(rxjs@7.8.2)(zone.js@0.15.0))(@angular/router@19.0.0(@angular/common@19.0.0(@angular/core@19.0.0(rxjs@7.8.2)(zone.js@0.15.0))(rxjs@7.8.2))(@angular/core@19.0.0(rxjs@7.8.2)(zone.js@0.15.0))(@angular/platform-browser@19.0.0(@angular/animations@19.0.0(@angular/core@19.0.0(rxjs@7.8.2)(zone.js@0.15.0)))(@angular/common@19.0.0(@angular/core@19.0.0(rxjs@7.8.2)(zone.js@0.15.0))(rxjs@7.8.2))(@angular/core@19.0.0(rxjs@7.8.2)(zone.js@0.15.0)))(rxjs@7.8.2))
+        specifier: 1.0.0-beta.38
+        version: 1.0.0-beta.38(@angular/common@19.0.0(@angular/core@19.0.0(rxjs@7.8.2)(zone.js@0.15.0))(rxjs@7.8.2))(@angular/core@19.0.0(rxjs@7.8.2)(zone.js@0.15.0))(@angular/router@19.0.0(@angular/common@19.0.0(@angular/core@19.0.0(rxjs@7.8.2)(zone.js@0.15.0))(rxjs@7.8.2))(@angular/core@19.0.0(rxjs@7.8.2)(zone.js@0.15.0))(@angular/platform-browser@19.0.0(@angular/animations@19.0.0(@angular/core@19.0.0(rxjs@7.8.2)(zone.js@0.15.0)))(@angular/common@19.0.0(@angular/core@19.0.0(rxjs@7.8.2)(zone.js@0.15.0))(rxjs@7.8.2))(@angular/core@19.0.0(rxjs@7.8.2)(zone.js@0.15.0)))(rxjs@7.8.2))
       '@fontsource/roboto':
         specifier: 5.2.5
         version: 5.2.5
@@ -1210,8 +1210,8 @@ packages:
   '@cypress/xvfb@1.2.4':
     resolution: {integrity: sha512-skbBzPggOVYCbnGgV+0dmBdW/s77ZkAOXIC1knS8NagwDjBrNC1LuXtQJeiN6l+m7lzmHtaoUw/ctJKdqkG57Q==}
 
-  '@davidlj95/ngx-meta@1.0.0-beta.36':
-    resolution: {integrity: sha512-Qd/Bdl8tfT0p2UKrDRWPHahIIlKh4KkFoRs4Fpk9VHNUQoh2DNGFWYpQ+mZ0aUQN7Kk8abBUa5gwQlLlHmJnsQ==}
+  '@davidlj95/ngx-meta@1.0.0-beta.38':
+    resolution: {integrity: sha512-EGGfcjI2FuY/P0leJteYw6/+bLDIyf9MOTN17nsudVwMsyi9EkBabYffjXLpBnGpZza4m9v6X7WWypO0xn5rcQ==}
     peerDependencies:
       '@angular/common': ^19 || ^18 || ^17 || ^16 || ^15
       '@angular/core': ^19 || ^18 || ^17 || ^16 || ^15
@@ -7418,7 +7418,7 @@ snapshots:
       '@vitejs/plugin-basic-ssl': 1.1.0(vite@5.4.11(@types/node@22.13.5)(less@4.2.0)(sass@1.80.7)(terser@5.36.0))
       ansi-colors: 4.1.3
       autoprefixer: 10.4.20(postcss@8.4.49)
-      babel-loader: 9.2.1(@babel/core@7.26.0)(webpack@5.96.1)
+      babel-loader: 9.2.1(@babel/core@7.26.0)(webpack@5.96.1(esbuild@0.24.0))
       browserslist: 4.23.3
       copy-webpack-plugin: 12.0.2(webpack@5.96.1(esbuild@0.24.0))
       css-loader: 7.1.2(webpack@5.96.1(esbuild@0.24.0))
@@ -9304,7 +9304,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@davidlj95/ngx-meta@1.0.0-beta.36(@angular/common@19.0.0(@angular/core@19.0.0(rxjs@7.8.2)(zone.js@0.15.0))(rxjs@7.8.2))(@angular/core@19.0.0(rxjs@7.8.2)(zone.js@0.15.0))(@angular/router@19.0.0(@angular/common@19.0.0(@angular/core@19.0.0(rxjs@7.8.2)(zone.js@0.15.0))(rxjs@7.8.2))(@angular/core@19.0.0(rxjs@7.8.2)(zone.js@0.15.0))(@angular/platform-browser@19.0.0(@angular/animations@19.0.0(@angular/core@19.0.0(rxjs@7.8.2)(zone.js@0.15.0)))(@angular/common@19.0.0(@angular/core@19.0.0(rxjs@7.8.2)(zone.js@0.15.0))(rxjs@7.8.2))(@angular/core@19.0.0(rxjs@7.8.2)(zone.js@0.15.0)))(rxjs@7.8.2))':
+  '@davidlj95/ngx-meta@1.0.0-beta.38(@angular/common@19.0.0(@angular/core@19.0.0(rxjs@7.8.2)(zone.js@0.15.0))(rxjs@7.8.2))(@angular/core@19.0.0(rxjs@7.8.2)(zone.js@0.15.0))(@angular/router@19.0.0(@angular/common@19.0.0(@angular/core@19.0.0(rxjs@7.8.2)(zone.js@0.15.0))(rxjs@7.8.2))(@angular/core@19.0.0(rxjs@7.8.2)(zone.js@0.15.0))(@angular/platform-browser@19.0.0(@angular/animations@19.0.0(@angular/core@19.0.0(rxjs@7.8.2)(zone.js@0.15.0)))(@angular/common@19.0.0(@angular/core@19.0.0(rxjs@7.8.2)(zone.js@0.15.0))(rxjs@7.8.2))(@angular/core@19.0.0(rxjs@7.8.2)(zone.js@0.15.0)))(rxjs@7.8.2))':
     dependencies:
       '@angular/common': 19.0.0(@angular/core@19.0.0(rxjs@7.8.2)(zone.js@0.15.0))(rxjs@7.8.2)
       '@angular/core': 19.0.0(rxjs@7.8.2)(zone.js@0.15.0)
@@ -10987,7 +10987,7 @@ snapshots:
       find-up: 5.0.0
       webpack: 5.96.1(esbuild@0.24.0)
 
-  babel-loader@9.2.1(@babel/core@7.26.0)(webpack@5.96.1):
+  babel-loader@9.2.1(@babel/core@7.26.0)(webpack@5.96.1(esbuild@0.24.0)):
     dependencies:
       '@babel/core': 7.26.0
       find-cache-dir: 4.0.0

--- a/src/app/app.metadata-imports.ts
+++ b/src/app/app.metadata-imports.ts
@@ -1,5 +1,6 @@
 import {
   provideNgxMetaCore,
+  withNgxMetaBaseUrl,
   withNgxMetaDefaults,
 } from '@davidlj95/ngx-meta/core'
 import { provideNgxMetaRouting } from '@davidlj95/ngx-meta/routing'
@@ -8,12 +9,16 @@ import { provideNgxMetaOpenGraph } from '@davidlj95/ngx-meta/open-graph'
 import { provideNgxMetaTwitterCard } from '@davidlj95/ngx-meta/twitter-card'
 import { METADATA_DEFAULTS } from './app.metadata-defaults'
 import { EnvironmentProviders, Provider } from '@angular/core'
+import { environment } from '../environments'
 
 export const APP_METADATA_PROVIDERS: readonly (
   | Provider
   | EnvironmentProviders
 )[] = [
-  provideNgxMetaCore(withNgxMetaDefaults(METADATA_DEFAULTS)),
+  provideNgxMetaCore(
+    withNgxMetaDefaults(METADATA_DEFAULTS),
+    withNgxMetaBaseUrl(environment.appBaseUrl.toString()),
+  ),
   provideNgxMetaRouting(),
   provideNgxMetaStandard(),
   provideNgxMetaOpenGraph(),

--- a/src/app/calendar-page/routes.ts
+++ b/src/app/calendar-page/routes.ts
@@ -4,7 +4,6 @@ import { NgxMetaRouteData } from '@davidlj95/ngx-meta/routing'
 import { GlobalMetadata } from '@davidlj95/ngx-meta/core'
 import { METADATA } from '@/data/metadata'
 import { CALENDAR_PATH } from './calendar-page.routes'
-import { environment } from '../../environments'
 
 export const routes: Routes = [
   {
@@ -14,7 +13,7 @@ export const routes: Routes = [
       meta: {
         title: `📅 Calendar | ${METADATA.nickname}`,
         description: "Book an appointment with me here. Let's hang out!",
-        canonicalUrl: new URL(CALENDAR_PATH + '/', environment.appBaseUrl),
+        canonicalUrl: CALENDAR_PATH,
       },
     } satisfies NgxMetaRouteData<GlobalMetadata>,
   },

--- a/src/app/gifts-page/routes.ts
+++ b/src/app/gifts-page/routes.ts
@@ -3,7 +3,6 @@ import { NgxMetaRouteData } from '@davidlj95/ngx-meta/routing'
 import { GlobalMetadata } from '@davidlj95/ngx-meta/core'
 import { METADATA } from '@/data/metadata'
 import { GIFTS_PATH } from './gifts-page.routes'
-import { environment } from '../../environments'
 import { GiftsPageComponent } from './gifts-page.component'
 
 export const routes: Routes = [
@@ -15,7 +14,7 @@ export const routes: Routes = [
         title: `🎁 Gifts | ${METADATA.nickname}`,
         description:
           "If you want to give me a gift, here's the page to help you out. Thanks in advance by the way. Much appreciated ❤️",
-        canonicalUrl: new URL(GIFTS_PATH + '/', environment.appBaseUrl),
+        canonicalUrl: GIFTS_PATH,
       },
     } satisfies NgxMetaRouteData<GlobalMetadata>,
   },

--- a/src/app/resume-page/resume-page.routes.ts
+++ b/src/app/resume-page/resume-page.routes.ts
@@ -12,7 +12,7 @@ export const resumePageRoutes: Routes = [
     data: {
       meta: {
         title: `Resume | ${METADATA.nickname}`,
-        canonicalUrl: new URL(RESUME_PATH, environment.appBaseUrl),
+        canonicalUrl: RESUME_PATH,
         description: METADATA.description,
         image: {
           url: new URL('images/misc/og.jpg', environment.appBaseUrl),

--- a/src/app/sports-page/routes.ts
+++ b/src/app/sports-page/routes.ts
@@ -3,7 +3,6 @@ import { NgxMetaRouteData } from '@davidlj95/ngx-meta/routing'
 import { GlobalMetadata } from '@davidlj95/ngx-meta/core'
 import { METADATA } from '@/data/metadata'
 import { SPORTS_PATH } from './sports-page.routes'
-import { environment } from '../../environments'
 import { SportsPageComponent } from './sports-page.component'
 
 export const routes: Routes = [
@@ -14,7 +13,7 @@ export const routes: Routes = [
       meta: {
         title: `👟 Sports | ${METADATA.nickname}`,
         description: "Let's play some padel! Or go running together 🏃",
-        canonicalUrl: new URL(SPORTS_PATH + '/', environment.appBaseUrl),
+        canonicalUrl: SPORTS_PATH,
       },
     } satisfies NgxMetaRouteData<GlobalMetadata>,
   },


### PR DESCRIPTION
Upgrades `ngx-meta` to latest version and uses URL resolution to avoid specifying app's URL around.

~Tried to use the title formatter, but there's a bug. The title formatter gets called twice somehow.~ It was the cache 🙃 Check next PR
