### PR TITLE
chore: use proper phase for console easter egg hook

### DIFF
--- a/src/app/console-easter-egg/maybe-load-console-easter-egg.ts
+++ b/src/app/console-easter-egg/maybe-load-console-easter-egg.ts
@@ -6,7 +6,7 @@ export const maybeLoadConsoleEasterEgg = () => {
   const document = inject(DOCUMENT)
   const isMobile = inject(IS_MOBILE)
   afterNextRender({
-    read: () => {
+    write: () => {
       if (isMobile()) {
         return
       }


### PR DESCRIPTION
It's writing to the DOM, so should be `write` phase
