### PR TITLE
feat: do not fix JS warning on top

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,7 +1,5 @@
 <app-header></app-header>
-<div class="after-header">
-  <app-no-script></app-no-script>
-  <main>
-    <router-outlet></router-outlet>
-  </main>
-</div>
+<app-no-script></app-no-script>
+<main>
+  <router-outlet></router-outlet>
+</main>

--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -1,7 +1,5 @@
 :host {
   display: block;
-  background: var(--sys-color-cdt-base-container);
-  color: var(--sys-color-on-surface);
   min-height: 100vh;
 }
 

--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -1,28 +1,10 @@
-@use 'header';
-
-// You may wonder: why aren't you just using "min-height: 100vh"? Well, good question.
-// Seems that choosing "vh" as units isn't a wise choice. Given the viewport height can change due to
-// mostly mobile phone world quirks: virtual keyboards, address bars...
-//
-// Concretely, had this issue with my Android phone's Chrome address bar and had to switch to this way after that
-// https://blog.logrocket.com/improving-mobile-design-latest-css-viewport-units/
-.after-header {
-  position: absolute;
-  top: header.$height;
-  min-height: calc(100% - #{header.$height});
-  width: 100%;
-
-  display: flex;
+:host {
+  display: block;
+  background: var(--sys-color-cdt-base-container);
+  color: var(--sys-color-on-surface);
+  min-height: 100vh;
 }
 
-main {
-  // 👇 For children to grow to max height
-  display: flex;
-  width: 100%;
-  ::ng-deep > * {
-    width: 100%;
-  }
-}
 router-outlet {
   display: none;
 }

--- a/src/app/header/header.component.scss
+++ b/src/app/header/header.component.scss
@@ -4,7 +4,8 @@
 @use 'animations';
 
 header {
-  position: fixed;
+  position: sticky;
+  top: 0;
   z-index: z-index.$header;
   width: 100%;
 

--- a/src/app/no-script/no-script.component.html
+++ b/src/app/no-script/no-script.component.html
@@ -1,12 +1,10 @@
 <noscript>
-  <div class="contents">
-    <p>
-      <span appMaterialSymbol>{{ _materialSymbol.Warning }}</span>
-      <b>Seems you don't have JavaScript enabled</b>
-    </p>
-    <p>
-      You are viewing a simplified version of the website<br />
-      Enable it for a better user experience
-    </p>
-  </div>
+  <p>
+    <span appMaterialSymbol>{{ _materialSymbol.Warning }}</span>
+    <b>Seems you don't have JavaScript enabled</b>
+  </p>
+  <p>
+    You are viewing a simplified version of the website<br />
+    Enable it for a better user experience
+  </p>
 </noscript>

--- a/src/app/no-script/no-script.component.scss
+++ b/src/app/no-script/no-script.component.scss
@@ -1,28 +1,21 @@
 @use 'borders';
 @use 'margins';
-@use 'header';
 @use 'paddings';
-@use 'z-index';
 @use 'material-symbols';
 
-:host {
-  position: fixed;
-  top: header.$height;
-  width: 100%;
-  z-index: z-index.$no-script;
-}
-
-.contents {
+noscript {
   display: flex;
   flex-direction: column;
   justify-content: center;
+
   padding: paddings.$m;
-  gap: margins.$xs;
+  gap: margins.$s;
+
   text-align: center;
-  height: var(--no-script-height);
   background: var(--app-color-toolbar-background);
   @include borders.panel(bottom);
 }
+
 p:first-child {
   display: flex;
   justify-content: center;

--- a/src/app/sports-page/sports-page.component.scss
+++ b/src/app/sports-page/sports-page.component.scss
@@ -1,4 +1,3 @@
-@use 'page';
 @use 'theming';
 @use 'animations';
 

--- a/src/index.html
+++ b/src/index.html
@@ -89,21 +89,6 @@
       content="assets/favicons/mstile-144x144.png"
       name="msapplication-TileImage"
     />
-    <noscript>
-      <!--suppress CssUnusedSymbol (used in inner components, but WebStorm doesn't go so far :P) -->
-      <style>
-        :root {
-          --no-script-height: 100px;
-        }
-        main {
-          /** Must be kept in sync with app-no-script component **/
-          position: absolute;
-          width: 100%;
-          top: var(--no-script-height);
-          min-height: calc(100% - var(--no-script-height));
-        }
-      </style>
-    </noscript>
   </head>
   <body>
     <app-root></app-root>

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -21,6 +21,9 @@ html {
 }
 
 body {
+  background: var(--sys-color-cdt-base-container);
+  color: var(--sys-color-on-surface);
+
   @include typographies.body-font();
   // Do not allow scroll "bounce" effect
   overscroll-behavior: none;

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -21,9 +21,6 @@ html {
 }
 
 body {
-  background: var(--sys-color-cdt-base-container);
-  color: var(--sys-color-on-surface);
-
   @include typographies.body-font();
   // Do not allow scroll "bounce" effect
   overscroll-behavior: none;


### PR DESCRIPTION
This way, the page structure is simplified. Therefore will be easier to change. No need to display that warning all the time anyway.
