### PR TITLE
feat: set a max-width to avoid emptyness

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,10 +1,8 @@
 <app-background></app-background>
 <div class="site-wrapper">
-  <div>
-    <app-header></app-header>
-    <app-no-script></app-no-script>
-    <main>
-      <router-outlet></router-outlet>
-    </main>
-  </div>
+  <app-header></app-header>
+  <app-no-script></app-no-script>
+  <main>
+    <router-outlet></router-outlet>
+  </main>
 </div>

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,5 +1,10 @@
-<app-header></app-header>
-<app-no-script></app-no-script>
-<main>
-  <router-outlet></router-outlet>
-</main>
+<app-background></app-background>
+<div class="site-wrapper">
+  <div>
+    <app-header></app-header>
+    <app-no-script></app-no-script>
+    <main>
+      <router-outlet></router-outlet>
+    </main>
+  </div>
+</div>

--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -1,12 +1,19 @@
 @use 'borders';
+@use 'animations';
 
 .site-wrapper {
   margin: 0 auto;
-  background: var(--sys-color-cdt-base-container);
+  background-color: var(--sys-color-cdt-base-container);
 
   max-width: 960px;
   min-height: 100vh;
   @include borders.panel(left, right);
+  @include animations.when-motion {
+    @include animations.multiple-transitions(
+      (background-color, border-color),
+      animations.$emphasized-style
+    );
+  }
 }
 
 router-outlet {

--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -1,6 +1,17 @@
-:host {
-  display: block;
-  min-height: 100vh;
+@use 'borders';
+
+.site-wrapper {
+  display: flex;
+  justify-content: center;
+
+  > div {
+    flex-grow: 1;
+    background: var(--sys-color-cdt-base-container);
+
+    max-width: 960px;
+    min-height: 100vh;
+    @include borders.panel(left, right);
+  }
 }
 
 router-outlet {

--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -1,17 +1,12 @@
 @use 'borders';
 
 .site-wrapper {
-  display: flex;
-  justify-content: center;
+  margin: 0 auto;
+  background: var(--sys-color-cdt-base-container);
 
-  > div {
-    flex-grow: 1;
-    background: var(--sys-color-cdt-base-container);
-
-    max-width: 960px;
-    min-height: 100vh;
-    @include borders.panel(left, right);
-  }
+  max-width: 960px;
+  min-height: 100vh;
+  @include borders.panel(left, right);
 }
 
 router-outlet {

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -8,6 +8,7 @@ import { NoScriptComponent } from './no-script/no-script.component'
 import { By } from '@angular/platform-browser'
 import { componentTestSetup } from '@/test/helpers/component-test-setup'
 import { RouterOutlet } from '@angular/router'
+import { BackgroundComponent } from './background/background.component'
 
 describe('AppComponent', () => {
   let fixture: ComponentFixture<AppComponent>
@@ -17,7 +18,12 @@ describe('AppComponent', () => {
     ;[fixture, component] = componentTestSetup(AppComponent, {
       imports: [
         AppComponent,
-        MockComponents(NoScriptComponent, HeaderComponent, ResumePageComponent),
+        MockComponents(
+          BackgroundComponent,
+          NoScriptComponent,
+          HeaderComponent,
+          ResumePageComponent,
+        ),
         RouterOutlet,
       ],
     })

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -3,12 +3,18 @@ import { RouterOutlet } from '@angular/router'
 import { NoScriptComponent } from './no-script/no-script.component'
 import { HeaderComponent } from './header/header.component'
 import { maybeLoadConsoleEasterEgg } from './console-easter-egg/maybe-load-console-easter-egg'
+import { BackgroundComponent } from './background/background.component'
 
 @Component({
   selector: 'app-root',
   templateUrl: './app.component.html',
   styleUrls: ['./app.component.scss'],
-  imports: [HeaderComponent, NoScriptComponent, RouterOutlet],
+  imports: [
+    HeaderComponent,
+    NoScriptComponent,
+    RouterOutlet,
+    BackgroundComponent,
+  ],
 })
 export class AppComponent {
   constructor() {

--- a/src/app/background/background.component.html
+++ b/src/app/background/background.component.html
@@ -3,8 +3,8 @@
     <pattern
       id="bg"
       patternUnits="userSpaceOnUse"
-      [attr.width]="t.clientWidth || 720"
-      [attr.height]="t.clientHeight || 290"
+      [attr.width]="_textSize.width"
+      [attr.height]="_textSize.height"
     >
       <text fill="white" #t>
         @for (line of _genesisBlock.split('\n'); track line) {

--- a/src/app/background/background.component.html
+++ b/src/app/background/background.component.html
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <pattern
+      id="bg"
+      patternUnits="userSpaceOnUse"
+      [attr.width]="t.clientWidth || 720"
+      [attr.height]="t.clientHeight || 290"
+    >
+      <text fill="white" #t>
+        @for (line of _genesisBlock.split('\n'); track line) {
+          <tspan x="0" dy="1em">{{ line }}</tspan>
+        }
+      </text>
+    </pattern>
+  </defs>
+  <rect width="100%" height="100%" fill="url(#bg)" />
+</svg>

--- a/src/app/background/background.component.scss
+++ b/src/app/background/background.component.scss
@@ -1,11 +1,11 @@
 @use 'z-index';
 @use 'typographies';
+@use 'animations';
 
 :host {
   position: fixed;
   z-index: z-index.$background;
   white-space: pre-line;
-  opacity: 0.05;
 }
 
 :host,
@@ -18,6 +18,7 @@ svg {
   font-size: 16px;
 
   text {
+    fill: var(--background-fg-color);
     @include typographies.monospace-font;
   }
 }

--- a/src/app/background/background.component.scss
+++ b/src/app/background/background.component.scss
@@ -5,7 +5,6 @@
 :host {
   position: fixed;
   z-index: z-index.$background;
-  white-space: pre-line;
 }
 
 :host,
@@ -18,6 +17,7 @@ svg {
   font-size: 16px;
 
   text {
+    white-space: pre;
     fill: var(--background-fg-color);
     @include typographies.monospace-font;
     @include animations.when-motion {

--- a/src/app/background/background.component.scss
+++ b/src/app/background/background.component.scss
@@ -20,5 +20,8 @@ svg {
   text {
     fill: var(--background-fg-color);
     @include typographies.monospace-font;
+    @include animations.when-motion {
+      @include animations.single-transition(fill, animations.$emphasized-style);
+    }
   }
 }

--- a/src/app/background/background.component.scss
+++ b/src/app/background/background.component.scss
@@ -1,0 +1,23 @@
+@use 'z-index';
+@use 'typographies';
+
+:host {
+  position: fixed;
+  z-index: z-index.$background;
+  white-space: pre-line;
+  opacity: 0.05;
+}
+
+:host,
+svg {
+  width: 100%;
+  height: 100%;
+}
+
+svg {
+  font-size: 16px;
+
+  text {
+    @include typographies.monospace-font;
+  }
+}

--- a/src/app/background/background.component.spec.ts
+++ b/src/app/background/background.component.spec.ts
@@ -7,7 +7,7 @@ describe('BackgroundComponent', () => {
   let component: BackgroundComponent
   let fixture: ComponentFixture<BackgroundComponent>
   // 👇 SVG text size offset so that there's not empty space between repetitions
-  const HEIGHT_OFFSET = -3
+  const HEIGHT_OFFSET = -5
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
@@ -25,18 +25,29 @@ describe('BackgroundComponent', () => {
 
   it("should apply the SVG's text size to the SVG's pattern size", () => {
     const svgPattern = fixture.debugElement.query(By.css('svg pattern'))
-    const svgText = svgPattern.query(By.css('text'))
+
+    const flooredString = (x: number) => Math.floor(x).toString()
+
+    // 👇 After applying `white-space: pre`, the `text` takes larger width than all of `tspan`
+    //    Not sure why
+    const svgTspan = svgPattern.query(By.css('tspan'))
+    const tSpanWidth = (
+      svgTspan.nativeElement as Element
+    ).getBoundingClientRect().width
+
+    expect(tSpanWidth).withContext('tspan width heuristic').toBeGreaterThan(100)
 
     expect(svgPattern.attributes['width'])
       .withContext('width')
-      .toEqual((svgText.nativeElement as Element).clientWidth.toString())
+      .toEqual(flooredString(tSpanWidth))
+
+    const svgText = svgPattern.query(By.css('text'))
+    const textHeight = (svgText.nativeElement as Element).clientHeight
+
+    expect(textHeight).withContext('text height heuristic').toBeGreaterThan(100)
 
     expect(svgPattern.attributes['height'])
       .withContext('height')
-      .toEqual(
-        (
-          (svgText.nativeElement as Element).clientHeight + HEIGHT_OFFSET
-        ).toString(),
-      )
+      .toEqual(flooredString(textHeight + HEIGHT_OFFSET))
   })
 })

--- a/src/app/background/background.component.spec.ts
+++ b/src/app/background/background.component.spec.ts
@@ -1,0 +1,22 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing'
+
+import { BackgroundComponent } from './background.component'
+
+describe('BackgroundComponent', () => {
+  let component: BackgroundComponent
+  let fixture: ComponentFixture<BackgroundComponent>
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [BackgroundComponent],
+    }).compileComponents()
+
+    fixture = TestBed.createComponent(BackgroundComponent)
+    component = fixture.componentInstance
+    fixture.detectChanges()
+  })
+
+  it('should create', () => {
+    expect(component).toBeTruthy()
+  })
+})

--- a/src/app/background/background.component.spec.ts
+++ b/src/app/background/background.component.spec.ts
@@ -6,6 +6,8 @@ import { By } from '@angular/platform-browser'
 describe('BackgroundComponent', () => {
   let component: BackgroundComponent
   let fixture: ComponentFixture<BackgroundComponent>
+  // 👇 SVG text size offset so that there's not empty space between repetitions
+  const HEIGHT_OFFSET = -3
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
@@ -31,6 +33,10 @@ describe('BackgroundComponent', () => {
 
     expect(svgPattern.attributes['height'])
       .withContext('height')
-      .toEqual((svgText.nativeElement as Element).clientHeight.toString())
+      .toEqual(
+        (
+          (svgText.nativeElement as Element).clientHeight + HEIGHT_OFFSET
+        ).toString(),
+      )
   })
 })

--- a/src/app/background/background.component.spec.ts
+++ b/src/app/background/background.component.spec.ts
@@ -1,6 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing'
 
 import { BackgroundComponent } from './background.component'
+import { By } from '@angular/platform-browser'
 
 describe('BackgroundComponent', () => {
   let component: BackgroundComponent
@@ -18,5 +19,18 @@ describe('BackgroundComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy()
+  })
+
+  it("should apply the SVG's text size to the SVG's pattern size", () => {
+    const svgPattern = fixture.debugElement.query(By.css('svg pattern'))
+    const svgText = svgPattern.query(By.css('text'))
+
+    expect(svgPattern.attributes['width'])
+      .withContext('width')
+      .toEqual((svgText.nativeElement as Element).clientWidth.toString())
+
+    expect(svgPattern.attributes['height'])
+      .withContext('height')
+      .toEqual((svgText.nativeElement as Element).clientHeight.toString())
   })
 })

--- a/src/app/background/background.component.ts
+++ b/src/app/background/background.component.ts
@@ -9,6 +9,10 @@ import { ChangeDetectionStrategy, Component } from '@angular/core'
 })
 export class BackgroundComponent {
   protected readonly _genesisBlock = hexdump(atob(GENESIS_BLOCK_BASE_64))
+  //👇 Could be calculated on the client side.
+  //   However, this component is part of the largest contentful paint (LCP)
+  //   So calculating it in advance. This way, there are no changes when hydrating
+  protected readonly _textSize = { width: 720, height: 293 }
 }
 
 // https://gist.github.com/igorgatis/d294fe714a4f523ac3a3

--- a/src/app/background/background.component.ts
+++ b/src/app/background/background.component.ts
@@ -6,35 +6,53 @@ import { ChangeDetectionStrategy, Component } from '@angular/core'
   templateUrl: './background.component.html',
   styleUrl: './background.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
+  preserveWhitespaces: true,
 })
 export class BackgroundComponent {
   protected readonly _genesisBlock = hexdump(atob(GENESIS_BLOCK_BASE_64))
   //👇 Could be calculated on the client side.
   //   However, this component is part of the largest contentful paint (LCP)
   //   So calculating it in advance. This way, there are no changes when hydrating
-  protected readonly _textSize = { width: 720, height: 290 }
+  protected readonly _textSize = { width: 777, height: 288 }
 }
 
-// https://gist.github.com/igorgatis/d294fe714a4f523ac3a3
-// With few tweaks as block size is fixed to 16
-function hexdump(buffer: string) {
+/**
+ * Source: https://gist.github.com/igorgatis/d294fe714a4f523ac3a3
+ *
+ * Adapted for TypeScript. With a few tweaks to mock `hexdump -C` output:
+ *  - Fixed block size of 16
+ *  - Address takes 8 chars
+ *  - Extra space every 8 code blocks
+ *  - Add '|' to chars block
+ *  - Do not print \x7F - \x9F chars (most can't be seen properly)
+ */
+const hexdump = (buffer: string) => {
   const blockSize = 16
   const lines: string[] = []
   const hex = '0123456789ABCDEF'
+  const SPACE = ' '
   for (let b = 0; b < buffer.length; b += blockSize) {
     const block = buffer.slice(b, Math.min(b + blockSize, buffer.length))
     const addrSize = 8
     const addr = ('0'.repeat(addrSize) + b.toString(16)).slice(-addrSize)
-    const codes = block
-      .split('')
-      .map(function (ch) {
-        const code = ch.charCodeAt(0)
-        return ' ' + hex[(0xf0 & code) >> 4] + hex[0x0f & code]
-      })
-      .join('')
-    // eslint-disable-next-line no-control-regex
-    const chars = block.replace(/[\x00-\x1F\x20]/g, '.')
-    lines.push(addr + ' ' + codes + '  |' + chars + '|')
+    const codes =
+      block
+        .split('')
+        .map((ch, index) => {
+          const code = ch.charCodeAt(0)
+          const spaces = index % 8 === 0 ? 2 : 1
+          return (
+            SPACE.repeat(spaces) + hex[(0xf0 & code) >> 4] + hex[0x0f & code]
+          )
+        })
+        .join('') + SPACE.repeat(3).repeat(blockSize - block.length)
+    const chars =
+      block.replace(
+        // eslint-disable-next-line no-control-regex
+        /[\x00-\x1F\x20\x7F-\x9F]/g,
+        '.',
+      ) + SPACE.repeat(blockSize - block.length)
+    lines.push(addr + ' ' + codes + '  |' + chars + '|' + '  ')
   }
   return lines.join('\n')
 }

--- a/src/app/background/background.component.ts
+++ b/src/app/background/background.component.ts
@@ -12,7 +12,7 @@ export class BackgroundComponent {
   //👇 Could be calculated on the client side.
   //   However, this component is part of the largest contentful paint (LCP)
   //   So calculating it in advance. This way, there are no changes when hydrating
-  protected readonly _textSize = { width: 720, height: 293 }
+  protected readonly _textSize = { width: 720, height: 290 }
 }
 
 // https://gist.github.com/igorgatis/d294fe714a4f523ac3a3

--- a/src/app/background/background.component.ts
+++ b/src/app/background/background.component.ts
@@ -1,0 +1,41 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core'
+
+@Component({
+  selector: 'app-background',
+  imports: [],
+  templateUrl: './background.component.html',
+  styleUrl: './background.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class BackgroundComponent {
+  protected readonly _genesisBlock = hexdump(atob(GENESIS_BLOCK_BASE_64))
+}
+
+// https://gist.github.com/igorgatis/d294fe714a4f523ac3a3
+// With few tweaks as block size is fixed to 16
+function hexdump(buffer: string) {
+  const blockSize = 16
+  const lines: string[] = []
+  const hex = '0123456789ABCDEF'
+  for (let b = 0; b < buffer.length; b += blockSize) {
+    const block = buffer.slice(b, Math.min(b + blockSize, buffer.length))
+    const addrSize = 8
+    const addr = ('0'.repeat(addrSize) + b.toString(16)).slice(-addrSize)
+    const codes = block
+      .split('')
+      .map(function (ch) {
+        const code = ch.charCodeAt(0)
+        return ' ' + hex[(0xf0 & code) >> 4] + hex[0x0f & code]
+      })
+      .join('')
+    // eslint-disable-next-line no-control-regex
+    const chars = block.replace(/[\x00-\x1F\x20]/g, '.')
+    lines.push(addr + ' ' + codes + '  |' + chars + '|')
+  }
+  return lines.join('\n')
+}
+//👇 Can be quickly obtained by
+// curl 'https://blockstream.info/api/block/000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f/raw' | base64
+// noinspection SpellCheckingInspection
+const GENESIS_BLOCK_BASE_64 =
+  'AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAO6Pt/Xp7ErJ6xyw+Z3aPYX/IG8OIilEyOp+4qkseXkopq19J//8AHR2sK3wBAQAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAP////9NBP//AB0BBEVUaGUgVGltZXMgMDMvSmFuLzIwMDkgQ2hhbmNlbGxvciBvbiBicmluayBvZiBzZWNvbmQgYmFpbG91dCBmb3IgYmFua3P/////AQDyBSoBAAAAQ0EEZ4r9sP5VSCcZZ/GmcTC3EFzWqCjgOQmmeWLg6h9h3rZJ9rw/TO84xPNVBOUewRLeXDhN97oLjVeKTHAra/EdX6wAAAAA'

--- a/src/app/header/header.component.scss
+++ b/src/app/header/header.component.scss
@@ -2,6 +2,7 @@
 @use 'header';
 @use 'z-index';
 @use 'animations';
+@use 'quirks';
 
 header {
   position: sticky;
@@ -14,6 +15,8 @@ header {
   align-items: center;
   @include borders.panel(bottom);
   background-color: var(--app-color-toolbar-background);
+
+  @include quirks.leftBorderDisappearance;
 
   @include animations.when-motion {
     @include animations.multiple-transitions(

--- a/src/app/resume-page/section-title/section-title.component.scss
+++ b/src/app/resume-page/section-title/section-title.component.scss
@@ -3,6 +3,7 @@
 @use 'paddings';
 @use 'z-index';
 @use 'animations';
+@use 'quirks';
 
 :host {
   display: block;
@@ -10,7 +11,7 @@
   top: header.$height;
   transform: translateY(-#{borders.$panel-width});
   z-index: z-index.$headers;
-  width: 100%;
+  @include quirks.leftBorderDisappearance;
   padding: paddings.$s paddings.$l;
   @include borders.panel(bottom, top);
   background-color: var(--app-color-toolbar-background);

--- a/src/sass/_quirks.scss
+++ b/src/sass/_quirks.scss
@@ -1,0 +1,10 @@
+// Just in Google Chrome. Maybe an optimization issue.
+// Happens when:
+//  - Main wrapper `div` has a left/right border
+//  - Position of a child element is sticky. Like `app-section-title`.
+//  - Main wrapper `div` is centered.
+// More mysteriously, the border appears when opening DevTools.
+// Can't be reproduced on Mozilla Firefox.
+@mixin leftBorderDisappearance {
+  will-change: transform;
+}

--- a/src/sass/_z-index.scss
+++ b/src/sass/_z-index.scss
@@ -1,3 +1,3 @@
+$background: -1;
 $header: 255;
-$no-script: $header;
 $headers: $header - 1;

--- a/src/sass/themes/_devtools-dark-scheme.scss
+++ b/src/sass/themes/_devtools-dark-scheme.scss
@@ -48,7 +48,9 @@ $scheme: (
         transparent
       ),
     sys-color-primary-bright: var(--ref-palette-primary70),
+    //👇 App specific
     adorner-border-color: var(--sys-color-tonal-outline),
     img-filter: grayscale(0.5),
+    background-fg-color: var(--ref-palette-neutral25),
   ),
 );

--- a/src/sass/themes/_devtools-light-scheme.scss
+++ b/src/sass/themes/_devtools-light-scheme.scss
@@ -46,7 +46,9 @@ $scheme: (
         transparent
       ),
     sys-color-primary-bright: var(--ref-palette-primary50),
+    //👇 App specific
     adorner-border-color: var(--sys-color-neutral-outline),
     img-filter: none,
+    background-fg-color: var(--ref-palette-neutral95),
   ),
 );

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -18,6 +18,21 @@
 
 html {
   scroll-behavior: smooth;
+
+  //👇 Remove scrollbar. https://stackoverflow.com/a/38994837/3263250
+  //   Prevents centered layout position to vary when scrollbar is shown or hidden
+  -ms-overflow-style: none; /* Internet Explorer 10+ */
+  scrollbar-width: none; /* Firefox */
+  &::-webkit-scrollbar {
+    display: none; /* Safari and Chrome */
+  }
+}
+
+// Do not allow scroll "bounce" effect
+// In Chrome, it's the `body`, in Firefox, it's the `html`
+html,
+body {
+  overscroll-behavior: none;
 }
 
 body {
@@ -25,8 +40,6 @@ body {
   color: var(--sys-color-on-surface);
 
   @include typographies.body-font();
-  // Do not allow scroll "bounce" effect
-  overscroll-behavior: none;
 
   @include animations.when-motion($hostContext: false) {
     @include animations.multiple-transitions(


### PR DESCRIPTION
Content pages like sports or gifts page feels very empty in desktop screens. Some content at the left and lots of space at the right. To solve that, a `max-width` is used in order to limit the maximum width of the page. Plus later the site is centered so that the focus is in the center.

The header has been also constrained to that width as given the aesthetics of the site, it would be weird for the header to take full width whilst content page just takes a small portion of it. More panels would be needed to fill that space. That can be changed anyway.

The issue has been to fill the empty space that now is in left and right sides. After trying out several ideas, came out with putting a repeating magic text. Doesn't use much JS. Doesn't use much size. And matches the aesthetics.

Finally, there was a bug where the header and section titles hide the left border of the site. AI revealed a trick to fix it. Tried other things, but doesn't work. Seems the issue is when centering + position sticky. Otherwise it doesn't happen. Same happens if using `margin: 0 auto` instead. As it's a Chromium bug (doesn't happen on Mozilla Firefox), leaving it as is for now.

Another extra is that the overscroll behavior now works in Firefox. It wasn't working due to being applied to `body` and not `html` element.

Could be great to make the right side special by aligning the SVG to the right. So the final block of the hexdump is displayed on the right side. But maybe that's making matters worse.

TODO: 
- [x] Background style for the light scheme: text isn't displayed. Opacity was a trick to quickly shade into light gray. Doesn't work for light
- [x] Add test to ensure the SVG pattern size is correct
- [ ] hexdump doesn't have the proper format:
  - When there are multiple spaces, despite being in SSG html, it doesn't appear in the inspected HTML in DevTools. This produces errors on the ASCII part + can't mimick `hexdump -C` fully because the blocks separations (addr / code / ascii) should be two spaces and not one.
  - In the last line, the block isn't complete. Spaces should be there. Maybe related to the previous issue indeed.  
- [x] Animations for wrapper bg color + borders