### PR TITLE
fix: display calendar taking full height as minimum

### DIFF
--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -16,6 +16,18 @@
   }
 }
 
+// 👇 To let `main` take as much height of wrapper as possible
+main,
+.site-wrapper {
+  display: flex;
+  flex-direction: column;
+}
+
+main,
+::ng-deep main > * {
+  flex-grow: 1;
+}
+
 router-outlet {
   display: none;
 }


### PR DESCRIPTION
After rearranging the site layout in #1094, calendar page no longer showed the Google Calendar `iframe` taking as much height as possible. This is because got rid of the `flex` displays so that the site (including content) can take as minimum 100vh height. Adding it back here
