### PR TITLE
fix: bring sticky header back changing its selector

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,6 +1,6 @@
 <app-background></app-background>
 <div class="site-wrapper">
-  <app-header></app-header>
+  <header></header>
   <app-no-script></app-no-script>
   <main>
     <router-outlet></router-outlet>

--- a/src/app/header/header.component.html
+++ b/src/app/header/header.component.html
@@ -1,10 +1,8 @@
-<header>
-  <app-navigation-tabs
-    [items]="_navigationItems"
-    [style.flex-grow]="1"
-  ></app-navigation-tabs>
-  <app-toolbar-divider></app-toolbar-divider>
-  <app-toolbar>
-    <app-light-dark-toggle></app-light-dark-toggle>
-  </app-toolbar>
-</header>
+<app-navigation-tabs
+  [items]="_navigationItems"
+  [style.flex-grow]="1"
+></app-navigation-tabs>
+<app-toolbar-divider></app-toolbar-divider>
+<app-toolbar>
+  <app-light-dark-toggle></app-light-dark-toggle>
+</app-toolbar>

--- a/src/app/header/header.component.scss
+++ b/src/app/header/header.component.scss
@@ -4,7 +4,7 @@
 @use 'animations';
 @use 'quirks';
 
-header {
+:host {
   position: sticky;
   top: 0;
   z-index: z-index.$header;

--- a/src/app/header/header.component.ts
+++ b/src/app/header/header.component.ts
@@ -6,7 +6,9 @@ import { NAVIGATION_ITEMS } from './navigation-items'
 import { ToolbarDividerComponent } from './toolbar-divider/toolbar-divider.component'
 
 @Component({
-  selector: 'app-header',
+  //👇 Semantic HTML ftw, sorry Angular guidelines
+  // eslint-disable-next-line @angular-eslint/component-selector
+  selector: 'header',
   templateUrl: './header.component.html',
   styleUrls: ['./header.component.scss'],
   imports: [


### PR DESCRIPTION
A bug was introduced in #1096. The header is no longer sticky. When page is scrolled, header doesn't stay on top. This is specially weird in resume page, as the section title is sticky, but the header isn't, so a bit of the scrolled page can be seen in where the header ought to be.

To solve it, removing the extra `app-header` element and using `header` as the component holding the header instead. The trade-off is that the `app-` prefix isn't used and should be according to Angular guidelines. But in this case, it's needed to fix the error and also we get rid of an unneeded container element.
