### PR TITLE
feat: update styles based on Chrome DevTools

### DIFF
--- a/src/sass/themes/_devtools-common-scheme.scss
+++ b/src/sass/themes/_devtools-common-scheme.scss
@@ -3,32 +3,33 @@
 $scheme: (
   kind: constants.$common-color-scheme-kind,
   vars: (
-    // https://github.com/ChromeDevTools/devtools-frontend/blob/7500d2916c463c136fc5ce2547ceb469c61454b4/front_end/ui/legacy/tokens.css
-    // Or locally by `devtools://theme/colors.css?sets=ui,chrome` (may change depending on current theme)
-    ref-palette-primary20: rgb(6 46 111 / 100%),
-    ref-palette-primary40: rgb(11 87 208 / 100%),
-    ref-palette-primary50: rgb(27 110 243 / 100%),
-    ref-palette-primary70: rgb(124 172 248 / 100%),
-    ref-palette-primary80: rgb(168 199 250 / 100%),
-    ref-palette-primary90: rgb(211 227 253 / 100%),
-    ref-palette-primary100: rgb(255 255 255 / 100%),
-    ref-palette-secondary50: rgb(4 125 183 / 100%),
-    ref-palette-neutral10: rgb(31 31 31 / 100%),
-    ref-palette-neutral15: rgb(40 40 40 / 100%),
-    ref-palette-neutral25: rgb(60 60 60 / 100%),
-    ref-palette-neutral30: rgb(71 71 71 / 100%),
-    ref-palette-neutral40: rgb(94 94 94 / 100%),
-    ref-palette-neutral50: rgb(117 117 117 / 100%),
-    ref-palette-neutral60: rgb(143 143 143 / 100%),
-    ref-palette-neutral80: rgb(199 199 199 / 100%),
-    ref-palette-neutral90: rgb(227 227 227 / 100%),
-    ref-palette-neutral95: rgb(242 242 242 / 100%),
-    ref-palette-neutral99: rgb(253 252 251 / 100%),
-    ref-palette-neutral100: rgb(255 255 255 / 100%),
+    // Locally by `devtools://theme/colors.css?sets=ui,chrome` (may change depending on current theme)
+    ref-palette-primary20: #062e6fff,
+    ref-palette-primary40: #0b57d0ff,
+    ref-palette-primary50: #1b6ef3ff,
+    ref-palette-primary70: #7cacf8ff,
+    ref-palette-primary80: #a8c7faff,
+    ref-palette-primary90: #d3e3fdff,
+    ref-palette-primary100: #ffffffff,
+    ref-palette-secondary50: #047db7ff,
+    ref-palette-neutral10: #1f1f1fff,
+    ref-palette-neutral15: #282828ff,
+    ref-palette-neutral25: #3c3c3cff,
+    ref-palette-neutral30: #474747ff,
+    ref-palette-neutral40: #5e5e5eff,
+    ref-palette-neutral50: #757575ff,
+    ref-palette-neutral80: #c7c7c7ff,
+    ref-palette-neutral90: #e3e3e3ff,
+    ref-palette-neutral95: #f2f2f2ff,
+    ref-palette-neutral99: #fdfcfbff,
+    ref-palette-neutral100: #ffffffff,
     // Common for both themes
+    // https://github.com/ChromeDevTools/devtools-frontend/blob/0f87a613d3894a26da7d14ae48e3c3804eeb3293/front_end/application_tokens.css#L19-L20
     icon-default: var(--sys-color-on-surface-subtle),
     icon-default-hover: var(--sys-color-on-surface),
+    // https://github.com/ChromeDevTools/devtools-frontend/blob/0f87a613d3894a26da7d14ae48e3c3804eeb3293/front_end/application_tokens.css#L52
     ui-text: var(--sys-color-on-surface-subtle),
+    // https://github.com/ChromeDevTools/devtools-frontend/blob/0f87a613d3894a26da7d14ae48e3c3804eeb3293/front_end/application_tokens.css#L54
     text-primary: var(--sys-color-on-surface),
   ),
 );

--- a/src/sass/themes/_devtools-dark-scheme.scss
+++ b/src/sass/themes/_devtools-dark-scheme.scss
@@ -3,26 +3,12 @@
 $scheme: (
   kind: constants.$dark-color-scheme-kind,
   vars: (
-    sys-color-base: var(--ref-palette-neutral25),
-    app-color-toolbar-background: var(--sys-color-base),
-    sys-color-on-surface: var(--ref-palette-neutral90),
-    sys-color-on-surface-subtle: var(--ref-palette-neutral80),
-    sys-color-cdt-base-container: var(--sys-color-base-container),
-    sys-color-base-container: var(--ref-palette-neutral15),
-    sys-color-divider: var(--ref-palette-neutral40),
-    sys-color-surface1: color-mix(
+    // 👇 Design system
+    // 👇 Baseline grayscale
+    // https://github.com/ChromeDevTools/devtools-frontend/blob/0f87a613d3894a26da7d14ae48e3c3804eeb3293/front_end/design_system_tokens.css#L212-L226
+    sys-color-surface5: color-mix(
         in sRGB,
-        var(--ref-palette-primary80) 5%,
-        var(--ref-palette-neutral10)
-      ),
-    sys-color-surface2: color-mix(
-        in sRGB,
-        var(--ref-palette-primary80) 8%,
-        var(--ref-palette-neutral10)
-      ),
-    sys-color-surface3: color-mix(
-        in sRGB,
-        var(--ref-palette-primary80) 11%,
+        #d1e1ff 14%,
         var(--ref-palette-neutral10)
       ),
     sys-color-surface4: color-mix(
@@ -30,24 +16,50 @@ $scheme: (
         #d1e1ff 12%,
         var(--ref-palette-neutral10)
       ),
-    sys-color-surface5: color-mix(
+    sys-color-surface3: color-mix(
         in sRGB,
-        var(--ref-palette-primary80) 14%,
+        #d1e1ff 11%,
         var(--ref-palette-neutral10)
       ),
-    sys-color-primary: var(--ref-palette-primary80),
-    sys-color-neutral-outline: var(--ref-palette-neutral50),
+    sys-color-surface2: color-mix(
+        in sRGB,
+        #d1e1ff 8%,
+        var(--ref-palette-neutral10)
+      ),
+    sys-color-surface1: color-mix(
+        in sRGB,
+        #d1e1ff 5%,
+        var(--ref-palette-neutral10)
+      ),
+    sys-color-divider: var(--ref-palette-neutral40),
+    sys-color-base: var(--ref-palette-neutral25),
+    sys-color-cdt-base-container: var(--ref-palette-neutral15),
+    // https://github.com/ChromeDevTools/devtools-frontend/blob/0f87a613d3894a26da7d14ae48e3c3804eeb3293/front_end/design_system_tokens.css#L234-L235
+    sys-color-on-surface: var(--ref-palette-neutral90),
+    sys-color-on-surface-subtle: var(--ref-palette-neutral80),
+    // https://github.com/ChromeDevTools/devtools-frontend/blob/0f87a613d3894a26da7d14ae48e3c3804eeb3293/front_end/design_system_tokens.css#L252
     sys-color-neutral-container: var(--ref-palette-neutral25),
-    sys-color-state-hover-dim-blend-protection: rgb(31 31 31/10%),
-    sys-color-tonal-outline: var(--ref-palette-secondary50),
+    // https://github.com/ChromeDevTools/devtools-frontend/blob/0f87a613d3894a26da7d14ae48e3c3804eeb3293/front_end/design_system_tokens.css#L257-L258
+    sys-color-primary: var(--ref-palette-primary80),
     sys-color-on-primary: var(--ref-palette-primary20),
+    // https://github.com/ChromeDevTools/devtools-frontend/blob/0f87a613d3894a26da7d14ae48e3c3804eeb3293/front_end/design_system_tokens.css#L269
+    sys-color-base-container: var(--ref-palette-neutral15),
+    // https://github.com/ChromeDevTools/devtools-frontend/blob/0f87a613d3894a26da7d14ae48e3c3804eeb3293/front_end/design_system_tokens.css#L275
     sys-color-on-base-divider: var(--ref-palette-neutral40),
+    // https://github.com/ChromeDevTools/devtools-frontend/blob/0f87a613d3894a26da7d14ae48e3c3804eeb3293/front_end/design_system_tokens.css#L286-L287
+    sys-color-tonal-outline: var(--ref-palette-secondary50),
+    sys-color-neutral-outline: var(--ref-palette-neutral50),
+    // https://github.com/ChromeDevTools/devtools-frontend/blob/0f87a613d3894a26da7d14ae48e3c3804eeb3293/front_end/design_system_tokens.css#L296
     sys-color-state-hover-on-prominent: color-mix(
         in sRGB,
-        var(--ref-palette-neutral99) 10%,
+        var(--ref-palette-neutral10) 6%,
         transparent
       ),
-    sys-color-primary-bright: var(--ref-palette-primary70),
+    // https://github.com/ChromeDevTools/devtools-frontend/blob/0f87a613d3894a26da7d14ae48e3c3804eeb3293/front_end/design_system_tokens.css#L298
+    sys-color-state-hover-dim-blend-protection: rgb(31 31 31/10%),
+    //👇 App tokens
+    // https://github.com/ChromeDevTools/devtools-frontend/blob/0f87a613d3894a26da7d14ae48e3c3804eeb3293/front_end/application_tokens.css#L371
+    app-color-toolbar-background: var(--sys-color-base),
     //👇 App specific
     adorner-border-color: var(--sys-color-tonal-outline),
     img-filter: grayscale(0.5),

--- a/src/sass/themes/_devtools-light-scheme.scss
+++ b/src/sass/themes/_devtools-light-scheme.scss
@@ -3,50 +3,62 @@
 $scheme: (
   kind: constants.$light-color-scheme-kind,
   vars: (
-    app-color-toolbar-background: var(--sys-color-surface4),
+    // 👇 Design system
+    // https://github.com/ChromeDevTools/devtools-frontend/blob/0f87a613d3894a26da7d14ae48e3c3804eeb3293/front_end/design_system_tokens.css#L18-L19
     sys-color-on-surface: var(--ref-palette-neutral10),
     sys-color-on-surface-subtle: var(--ref-palette-neutral30),
-    sys-color-cdt-base-container: var(--sys-color-base),
-    sys-color-base: var(--ref-palette-neutral100),
-    sys-color-divider: var(--ref-palette-primary90),
-    sys-color-surface1: color-mix(
+    // https://github.com/ChromeDevTools/devtools-frontend/blob/0f87a613d3894a26da7d14ae48e3c3804eeb3293/front_end/design_system_tokens.css#L36
+    sys-color-neutral-container: var(--ref-palette-neutral95),
+    // https://github.com/ChromeDevTools/devtools-frontend/blob/0f87a613d3894a26da7d14ae48e3c3804eeb3293/front_end/design_system_tokens.css#L41-L42
+    sys-color-primary: var(--ref-palette-primary40),
+    sys-color-on-primary: var(--ref-palette-primary100),
+    // https://github.com/ChromeDevTools/devtools-frontend/blob/0f87a613d3894a26da7d14ae48e3c3804eeb3293/front_end/design_system_tokens.css#L59
+    sys-color-on-base-divider: var(--ref-palette-primary90),
+    // https://github.com/ChromeDevTools/devtools-frontend/blob/0f87a613d3894a26da7d14ae48e3c3804eeb3293/front_end/design_system_tokens.css#L70
+    sys-color-neutral-outline: var(--ref-palette-neutral80),
+    // https://github.com/ChromeDevTools/devtools-frontend/blob/0f87a613d3894a26da7d14ae48e3c3804eeb3293/front_end/design_system_tokens.css#L79
+    sys-color-state-hover-on-prominent: color-mix(
         in sRGB,
-        var(--ref-palette-primary40) 5%,
-        var(--ref-palette-neutral99)
+        var(--ref-palette-neutral99) 10%,
+        transparent
       ),
-    sys-color-surface2: color-mix(
+    // https://github.com/ChromeDevTools/devtools-frontend/blob/0f87a613d3894a26da7d14ae48e3c3804eeb3293/front_end/design_system_tokens.css#L81
+    sys-color-state-hover-dim-blend-protection: rgb(6 46 111/18%),
+    // 👇 Baseline grayscale
+    //    https://github.com/ChromeDevTools/devtools-frontend/blob/0f87a613d3894a26da7d14ae48e3c3804eeb3293/front_end/design_system_tokens.css#L202-L207
+    sys-color-divider: var(--ref-palette-neutral90),
+    sys-color-surface5: color-mix(
         in sRGB,
-        var(--ref-palette-primary40) 8%,
-        var(--ref-palette-neutral99)
-      ),
-    sys-color-surface3: color-mix(
-        in sRGB,
-        var(--ref-palette-primary40) 11%,
-        var(--ref-palette-neutral99)
+        var(--ref-palette-neutral40) 14%,
+        var(--ref-palette-neutral100)
       ),
     sys-color-surface4: color-mix(
         in sRGB,
-        #6991d6 12%,
+        var(--ref-palette-neutral40) 12%,
         var(--ref-palette-neutral100)
       ),
-    sys-color-surface5: color-mix(
+    sys-color-surface3: color-mix(
         in sRGB,
-        var(--ref-palette-primary40) 14%,
-        var(--ref-palette-neutral99)
+        var(--ref-palette-neutral40) 11%,
+        var(--ref-palette-neutral100)
       ),
-    sys-color-primary: var(--ref-palette-primary40),
-    sys-color-neutral-outline: var(--ref-palette-neutral80),
-    sys-color-neutral-container: var(--ref-palette-neutral95),
-    sys-color-state-hover-dim-blend-protection: rgb(6 46 111/18%),
-    sys-color-on-primary: var(--ref-palette-primary100),
-    sys-color-on-base-divider: var(--ref-palette-primary90),
-    sys-color-state-hover-on-prominent: color-mix(
+    sys-color-surface2: color-mix(
         in sRGB,
-        var(--ref-palette-neutral10) 6%,
-        transparent
+        var(--ref-palette-neutral40) 8%,
+        var(--ref-palette-neutral100)
       ),
-    sys-color-primary-bright: var(--ref-palette-primary50),
-    //👇 App specific
+    sys-color-surface1: color-mix(
+        in sRGB,
+        var(--ref-palette-neutral40) 5%,
+        var(--ref-palette-neutral100)
+      ),
+    // https://github.com/ChromeDevTools/devtools-frontend/blob/0f87a613d3894a26da7d14ae48e3c3804eeb3293/front_end/design_system_tokens.css#L212-L214
+    sys-color-base: var(--ref-palette-neutral100),
+    sys-color-cdt-base-container: var(--ref-palette-neutral100),
+    // 👇 App tokens
+    // https://github.com/ChromeDevTools/devtools-frontend/blob/0f87a613d3894a26da7d14ae48e3c3804eeb3293/front_end/application_tokens.css#L186
+    app-color-toolbar-background: var(--sys-color-surface4),
+    // 👇 Specific to this app
     adorner-border-color: var(--sys-color-neutral-outline),
     img-filter: none,
     background-fg-color: var(--ref-palette-neutral95),


### PR DESCRIPTION
They have changed. Most notably in light theme. Where grayscale baseline turns surfaces gray. Instead of light blue as before.

Sorted and linked each color to the source code
Updated ref colors from installed Google Chrome 
Removed `sys-color-primary-bright` and ref color `neutral60`, not used.
