### PR TITLE
refactor: use section title component with attr selector

### DIFF
--- a/src/app/resume-page/education-section/education-section.component.html
+++ b/src/app/resume-page/education-section/education-section.component.html
@@ -1,4 +1,4 @@
-<app-section-title><h2 id="education">Education</h2></app-section-title>
+<h2 appSectionTitle id="education">Education</h2>
 <app-card-grid>
   @for (item of _items; track item) {
     <app-education-item [item]="item"></app-education-item>

--- a/src/app/resume-page/experience-section/experience-section.component.html
+++ b/src/app/resume-page/experience-section/experience-section.component.html
@@ -1,5 +1,4 @@
-<app-section-title
-  ><h2 id="experience">Professional experience</h2></app-section-title
+<h2 appSectionTitle id="experience">Professional experience</h2>
 >
 <app-card-grid>
   @for (item of _items; track item) {

--- a/src/app/resume-page/languages-section/languages-section.component.html
+++ b/src/app/resume-page/languages-section/languages-section.component.html
@@ -1,4 +1,4 @@
-<app-section-title><h2 id="languages">Languages</h2></app-section-title>
+<h2 appSectionTitle id="languages">Languages</h2>
 <app-card-grid>
   @for (item of _items; track item) {
     <app-language-item [item]="item"></app-language-item>

--- a/src/app/resume-page/profile-section/profile-section.component.html
+++ b/src/app/resume-page/profile-section/profile-section.component.html
@@ -1,4 +1,4 @@
-<app-section-title><h2 id="profile">Profile</h2></app-section-title>
+<h2 appSectionTitle id="profile">Profile</h2>
 <div class="layout">
   <div class="contents">
     <div class="profile">

--- a/src/app/resume-page/projects-section/projects-section.component.html
+++ b/src/app/resume-page/projects-section/projects-section.component.html
@@ -1,4 +1,4 @@
-<app-section-title><h2 id="projects">Projects</h2></app-section-title>
+<h2 appSectionTitle id="projects">Projects</h2>
 <app-card-grid>
   @for (item of _items; track item) {
     <app-project-item [item]="item"></app-project-item>

--- a/src/app/resume-page/section-title/section-title.component.scss
+++ b/src/app/resume-page/section-title/section-title.component.scss
@@ -16,15 +16,12 @@
   @include borders.panel(bottom, top);
   background-color: var(--app-color-toolbar-background);
   color: var(--ui-text);
+  font-size: 1.25rem;
 
   @include animations.when-motion {
     @include animations.multiple-transitions(
       (color, background-color, border-color),
       animations.$emphasized-style
     );
-  }
-
-  ::ng-deep h2 {
-    font-size: 1.25rem;
   }
 }

--- a/src/app/resume-page/section-title/section-title.component.ts
+++ b/src/app/resume-page/section-title/section-title.component.ts
@@ -1,7 +1,8 @@
 import { Component } from '@angular/core'
 
 @Component({
-  selector: 'app-section-title',
+  // eslint-disable-next-line @angular-eslint/component-selector
+  selector: '[appSectionTitle]',
   template: '<ng-content></ng-content>',
   styleUrls: ['./section-title.component.scss'],
 })

--- a/src/sass/_quirks.scss
+++ b/src/sass/_quirks.scss
@@ -1,7 +1,7 @@
 // Just in Google Chrome. Maybe an optimization issue.
 // Happens when:
 //  - Main wrapper `div` has a left/right border
-//  - Position of a child element is sticky. Like `app-section-title`.
+//  - Position of a child element is sticky. Like `[appSectionTitle]`.
 //  - Main wrapper `div` is centered.
 // More mysteriously, the border appears when opening DevTools.
 // Can't be reproduced on Mozilla Firefox.


### PR DESCRIPTION
In same fashion of #1099 . To avoid an extra element around. Also this way no need to `ng-deep h2`
