### PR TITLE
refactor: remove unneeded `span` inside toolbar `button`

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,6 +1,6 @@
 <app-background></app-background>
 <div class="site-wrapper">
-  <header></header>
+  <header appHeader></header>
   <noscript appNoJsMessage></noscript>
   <main>
     <router-outlet></router-outlet>

--- a/src/app/header/header.component.ts
+++ b/src/app/header/header.component.ts
@@ -8,7 +8,7 @@ import { ToolbarDividerComponent } from './toolbar-divider/toolbar-divider.compo
 @Component({
   //👇 Semantic HTML ftw, sorry Angular guidelines
   // eslint-disable-next-line @angular-eslint/component-selector
-  selector: 'header',
+  selector: 'header[appHeader]',
   templateUrl: './header.component.html',
   styleUrls: ['./header.component.scss'],
   imports: [

--- a/src/app/header/light-dark-toggle/light-dark-toggle.component.html
+++ b/src/app/header/light-dark-toggle/light-dark-toggle.component.html
@@ -1,12 +1,12 @@
 <button
-  app-toolbar-button
+  appToolbarButton
   [icon]="_materialSymbol.DarkMode"
   (click)="_colorSchemeService.toggleDarkLight()"
   aria-label="Switch to dark mode"
   class="light-only"
 ></button>
 <button
-  app-toolbar-button
+  appToolbarButton
   [icon]="_materialSymbol.LightMode"
   (click)="_colorSchemeService.toggleDarkLight()"
   aria-label="Switch to light mode"

--- a/src/app/header/tabs/tabs.component.html
+++ b/src/app/header/tabs/tabs.component.html
@@ -1,5 +1,5 @@
 <button
-  app-toolbar-button
+  appToolbarButton
   [icon]="_materialSymbol.KeyboardDoubleArrowLeft"
   aria-label="Previous tab"
   [disabled]="_prevButtonDisabled()"
@@ -10,7 +10,7 @@
   <ng-content></ng-content>
 </div>
 <button
-  app-toolbar-button
+  appToolbarButton
   [icon]="_materialSymbol.KeyboardDoubleArrowRight"
   aria-label="Next tab"
   [disabled]="_nextButtonDisabled()"

--- a/src/app/header/toolbar-button/toolbar-button.component.html
+++ b/src/app/header/toolbar-button/toolbar-button.component.html
@@ -1,1 +1,1 @@
-<span appMaterialSymbol>{{ icon() }}</span>
+{{ icon() }}

--- a/src/app/header/toolbar-button/toolbar-button.component.scss
+++ b/src/app/header/toolbar-button/toolbar-button.component.scss
@@ -26,8 +26,6 @@
     @include animations.single-transition(color, animations.$emphasized-style);
   }
 
-  @include material-symbols.class {
-    @include material-symbols.font-size(header.$icons-height);
-    @include material-symbols.variation-settings($fill: false, $weight: 200);
-  }
+  @include material-symbols.font-size(header.$icons-height);
+  @include material-symbols.variation-settings($fill: false, $weight: 200);
 }

--- a/src/app/header/toolbar-button/toolbar-button.component.spec.ts
+++ b/src/app/header/toolbar-button/toolbar-button.component.spec.ts
@@ -1,24 +1,14 @@
 import { ToolbarButtonComponent } from './toolbar-button.component'
 import { componentTestSetup } from '@/test/helpers/component-test-setup'
-import { MATERIAL_SYMBOLS_SELECTOR } from '@/test/helpers/material-symbols'
 import { textContent } from '@/test/helpers/text-content'
 import { setFixtureInputsAndDetectChanges } from '@/test/helpers/set-fixture-inputs'
 
 describe('ToolbarButtonComponent', () => {
-  it('should create', () => {
-    const [fixture, component] = makeSut()
-    fixture.detectChanges()
-
-    expect(component).toBeTruthy()
-  })
-
   it('should contain icon', () => {
     const [fixture] = makeSut()
     fixture.detectChanges()
 
-    const iconElement = fixture.debugElement.query(MATERIAL_SYMBOLS_SELECTOR)
-
-    expect(textContent(iconElement)).toBe(DUMMY_ICON)
+    expect(textContent(fixture.debugElement)).toBe(DUMMY_ICON)
   })
 })
 

--- a/src/app/header/toolbar-button/toolbar-button.component.ts
+++ b/src/app/header/toolbar-button/toolbar-button.component.ts
@@ -4,7 +4,6 @@ import { MaterialSymbolDirective } from '@/common/material-symbol.directive'
 @Component({
   // eslint-disable-next-line @angular-eslint/component-selector
   selector: 'button[appToolbarButton]',
-  imports: [],
   templateUrl: './toolbar-button.component.html',
   styleUrl: './toolbar-button.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/src/app/header/toolbar-button/toolbar-button.component.ts
+++ b/src/app/header/toolbar-button/toolbar-button.component.ts
@@ -3,7 +3,7 @@ import { MaterialSymbolDirective } from '@/common/material-symbol.directive'
 
 @Component({
   // eslint-disable-next-line @angular-eslint/component-selector
-  selector: '[app-toolbar-button]',
+  selector: 'button[appToolbarButton]',
   imports: [],
   templateUrl: './toolbar-button.component.html',
   styleUrl: './toolbar-button.component.scss',

--- a/src/app/header/toolbar-button/toolbar-button.component.ts
+++ b/src/app/header/toolbar-button/toolbar-button.component.ts
@@ -4,10 +4,11 @@ import { MaterialSymbolDirective } from '@/common/material-symbol.directive'
 @Component({
   // eslint-disable-next-line @angular-eslint/component-selector
   selector: '[app-toolbar-button]',
-  imports: [MaterialSymbolDirective],
+  imports: [],
   templateUrl: './toolbar-button.component.html',
   styleUrl: './toolbar-button.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
+  hostDirectives: [MaterialSymbolDirective],
 })
 export class ToolbarButtonComponent {
   readonly icon = input.required<string>()


### PR DESCRIPTION
If applying Material Symbols directly to the host, no need to create another element to host it

Also adds `appHeader` to to app header component selector. To avoid `header` magically becoming the app header. Which can be weird as it's not very explicit.
