### PR TITLE
fix: allow navigation when JS is not enabled

### DIFF
--- a/src/app/header/navigation-tabs/navigation-tabs.component.html
+++ b/src/app/header/navigation-tabs/navigation-tabs.component.html
@@ -1,11 +1,13 @@
 <app-tabs [selectedIndex]="_selectedIndex">
   @for (item of items(); track item.displayName) {
-    <app-tab
+    <a
+      appTab
       [routerLink]="item.routerLink"
       (isActiveChange)="$event ? onActiveRouteChange($index) : undefined"
       routerLinkActive
+      target="_self"
     >
       {{ item.displayName }}
-    </app-tab>
+    </a>
   }
 </app-tabs>

--- a/src/app/header/tab/tab.component.scss
+++ b/src/app/header/tab/tab.component.scss
@@ -8,14 +8,15 @@
 
   padding: paddings.$xs paddings.$m;
 
-  cursor: pointer;
-
   border-bottom-width: 2px;
   border-bottom-color: transparent;
   border-bottom-style: solid;
   font-weight: 300;
 
   color: var(--ui-text);
+
+  // Revert link style
+  text-decoration-line: none;
 
   &[aria-selected='true'] {
     color: var(--sys-color-primary);

--- a/src/app/header/tab/tab.component.ts
+++ b/src/app/header/tab/tab.component.ts
@@ -1,7 +1,8 @@
 import { Component, ElementRef, Input } from '@angular/core'
 
 @Component({
-  selector: 'app-tab',
+  // eslint-disable-next-line @angular-eslint/component-selector
+  selector: 'a[appTab]',
   template: '<ng-content></ng-content>',
   styleUrls: ['./tab.component.scss'],
   host: {

--- a/src/app/header/tabs/tabs.component.spec.cy.ts
+++ b/src/app/header/tabs/tabs.component.spec.cy.ts
@@ -15,7 +15,7 @@ describe('TabsComponent', () => {
   describe('when all tabs fit the screen', () => {
     //👇 Explicit component declaration for Cypress to support v19
     @Component({
-      template: '<app-tabs><app-tab>Hello World</app-tab></app-tabs>',
+      template: '<app-tabs><a appTab>Hello World</a></app-tabs>',
       imports: [TabsComponent, TabComponent],
     })
     class HostComponent {}
@@ -43,9 +43,7 @@ describe('TabsComponent', () => {
         [selectedIndex]="selectedIndex()"
       >
         @for (tab of ${JSON.stringify(TABS)}; track $index) {
-          <app-tab>
-            <span style="white-space: nowrap">Tab {{ tab }}</span>
-          </app-tab>
+          <a appTab style="white-space: nowrap"> Tab {{ tab }} </a>
         }
       </app-tabs>`,
       imports: [TabsComponent, TabComponent],
@@ -97,7 +95,7 @@ describe('TabsComponent', () => {
     })
 
     const MIDDLE_TAB_INDEX = Math.ceil(TABS.length / 2)
-    const MIDDLE_TAB_SELECTOR = `app-tab:nth-child(${MIDDLE_TAB_INDEX})`
+    const MIDDLE_TAB_SELECTOR = `[appTab]:nth-child(${MIDDLE_TAB_INDEX})`
     describe('when scrolled in the middle', () => {
       beforeEach(() => {
         cy.get(MIDDLE_TAB_SELECTOR).scrollIntoView()
@@ -118,7 +116,7 @@ describe('TabsComponent', () => {
       }
 
       beforeEach(() => {
-        cy.get('app-tab:last-child').scrollIntoView()
+        cy.get('[appTab]:last-child').scrollIntoView()
       })
 
       beforeEach(() => {

--- a/src/app/header/tabs/tabs.component.spec.ts
+++ b/src/app/header/tabs/tabs.component.spec.ts
@@ -89,11 +89,7 @@ const makeHostComponent = (
     template: `
       <app-tabs [selectedIndex]="selectedIndex">
         @for (tab of tabs; track $index) {
-          <app-tab>
-            <span [style.width.px]="${TAB_WIDTH_PX}">
-              {{ tab }}
-            </span></app-tab
-          >
+          <a appTab [style.width.px]="${TAB_WIDTH_PX}">{{ tab }}</a>
         }
       </app-tabs>
     `,


### PR DESCRIPTION
By turning `app-tab` components hosted by `a` elements. Updates tests accordingly. Sets `target=_self` so that links do not open a new tab (browsing context)
