### PR TITLE
fix: disable automatic Cloudflare early hints

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -1,0 +1,5 @@
+# Disable automatic Cloudflare Pages early hints due to a bug
+# https://developers.cloudflare.com/pages/configuration/early-hints/#disable-automatic-link-header-generation-automatic-link-header
+# https://github.com/davidlj95/cf-pages-hints-href
+/*
+  ! Link


### PR DESCRIPTION
They don't take `<base href>` when generating the path of the resource to load. So it is incorrect for pages like `/resume`. Disabling them until it is fixed.
