### PR TITLE
test: background svg to use text el for width test

### DIFF
--- a/src/app/background/background.component.html
+++ b/src/app/background/background.component.html
@@ -1,17 +1,17 @@
 <svg xmlns="http://www.w3.org/2000/svg">
   <defs>
     <pattern
-      id="bg"
+      id="t"
       patternUnits="userSpaceOnUse"
       [attr.width]="_textSize.width"
       [attr.height]="_textSize.height"
     >
-      <text fill="white" #t>
-        @for (line of _genesisBlock.split('\n'); track line) {
+      <text>
+        @for (line of _genesisBlockLines; track line) {
           <tspan x="0" dy="1em">{{ line }}</tspan>
         }
       </text>
     </pattern>
   </defs>
-  <rect width="100%" height="100%" fill="url(#bg)" />
+  <rect width="100%" height="100%" fill="url(#t)" />
 </svg>

--- a/src/app/background/background.component.scss
+++ b/src/app/background/background.component.scss
@@ -16,7 +16,7 @@ svg {
 svg {
   font-size: 16px;
 
-  text {
+  pattern {
     white-space: pre;
     fill: var(--background-fg-color);
     @include typographies.monospace-font;

--- a/src/app/background/background.component.spec.ts
+++ b/src/app/background/background.component.spec.ts
@@ -26,28 +26,21 @@ describe('BackgroundComponent', () => {
   it("should apply the SVG's text size to the SVG's pattern size", () => {
     const svgPattern = fixture.debugElement.query(By.css('svg pattern'))
 
-    const flooredString = (x: number) => Math.floor(x).toString()
+    const svgText = svgPattern.query(By.css('text')).nativeElement as Element
+    const textWidth = svgText.clientWidth
 
-    // 👇 After applying `white-space: pre`, the `text` takes larger width than all of `tspan`
-    //    Not sure why
-    const svgTspan = svgPattern.query(By.css('tspan'))
-    const tSpanWidth = (
-      svgTspan.nativeElement as Element
-    ).getBoundingClientRect().width
-
-    expect(tSpanWidth).withContext('tspan width heuristic').toBeGreaterThan(100)
+    expect(textWidth).withContext('text width heuristic').toBeGreaterThan(100)
 
     expect(svgPattern.attributes['width'])
       .withContext('width')
-      .toEqual(flooredString(tSpanWidth))
+      .toEqual(textWidth.toString())
 
-    const svgText = svgPattern.query(By.css('text'))
-    const textHeight = (svgText.nativeElement as Element).clientHeight
+    const textHeight = svgText.clientHeight
 
     expect(textHeight).withContext('text height heuristic').toBeGreaterThan(100)
 
     expect(svgPattern.attributes['height'])
       .withContext('height')
-      .toEqual(flooredString(textHeight + HEIGHT_OFFSET))
+      .toEqual((textHeight + HEIGHT_OFFSET).toString())
   })
 })

--- a/src/app/background/background.component.ts
+++ b/src/app/background/background.component.ts
@@ -9,11 +9,13 @@ import { ChangeDetectionStrategy, Component } from '@angular/core'
   preserveWhitespaces: true,
 })
 export class BackgroundComponent {
-  protected readonly _genesisBlock = hexdump(atob(GENESIS_BLOCK_BASE_64))
+  protected readonly _genesisBlockLines = hexdump(
+    atob(GENESIS_BLOCK_BASE_64),
+  ).split('\n')
   //👇 Could be calculated on the client side.
   //   However, this component is part of the largest contentful paint (LCP)
   //   So calculating it in advance. This way, there are no changes when hydrating
-  protected readonly _textSize = { width: 777, height: 288 }
+  protected readonly _textSize = { width: 730, height: 288 }
 }
 
 /**


### PR DESCRIPTION
Recently, the test related to the background SVG size is correct started failing. See https://github.com/davidlj95/website/actions/runs/14893040472 . The test expectation of `tspan` having at least 100px width failed. It returned 0 instead. Was tricky to reproduce, as wasn't reproducible locally because had Chrome v135 installed. When updating to v136, could be able to reproduce.

After reproducing, fix has been to use `text` element `clientWidth`. However the issue was that the width was way larger than expected. After a quick try, seems that if applying the CSS with the font to the `pattern`, then the `text` `clientWidth` is appropriate. Using that then for now. 

Tried with `ch` as units for `pattern`'s `width`. However, it is larger than expected too (despite CSS setting the proper font family & size).
