### PR TITLE
feat: add filters to tech stack

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="TypeScriptCompiler">
+    <option name="useTypesFromServer" value="true" />
+  </component>
+</project>

--- a/data/resume.json
+++ b/data/resume.json
@@ -352,6 +352,10 @@
       "stack": "back",
       "technologies": [
         {
+          "slug": "ruby",
+          "version": "~2.7.0"
+        },
+        {
           "slug": "rubyonrails",
           "version": "^6"
         },

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "lint:gh-actions": "actionlint || true",
     "lint:unused": "pnpm run '/^lint:unused:.*$/'",
     "lint:unused:development": "knip",
-    "lint:unused:production": "knip --production --tags=-visibleForTesting",
+    "lint:unused:production": "knip --production --tags=-visibleForTesting,-knipIgnore",
     "release": "release-it",
     "release:dry-run": "release-it --dry-run --no-git.requireBranch",
     "release:dry-run:local": "pnpm run release:dry-run --no-git.requireCleanWorkingDir --no-git.requireUpstream",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "lint:commit-message": "pnpm run commitlint:edit-msg",
     "lint:gh-actions": "actionlint || true",
     "lint:unused": "pnpm run '/^lint:unused:.*$/'",
-    "lint:unused:development": "knip",
+    "lint:unused:development": "knip --tags=-knipIgnore",
     "lint:unused:production": "knip --production --tags=-visibleForTesting,-knipIgnore",
     "release": "release-it",
     "release:dry-run": "release-it --dry-run --no-git.requireBranch",

--- a/src/app/resume-page/tech-stack-section/filtered-techs/filtered-techs.component.html
+++ b/src/app/resume-page/tech-stack-section/filtered-techs/filtered-techs.component.html
@@ -1,4 +1,4 @@
-<p>{{ tag().name }}</p>
+<p>{{ _getTechTagName(tag()) }}</p>
 <app-content-chip-list>
   @for (tech of _topTechs(); track tech) {
     <app-content-chip

--- a/src/app/resume-page/tech-stack-section/filtered-techs/filtered-techs.component.ts
+++ b/src/app/resume-page/tech-stack-section/filtered-techs/filtered-techs.component.ts
@@ -25,9 +25,13 @@ export class FilteredTechsComponent {
   private readonly _findTechsByTag = inject(FIND_TECHS_BY_TAG)
 
   readonly tag = input.required<TechTag>()
+  readonly includeTags = input<readonly TagChar[]>([])
   readonly excludeTags = input<readonly TagChar[]>([])
   protected readonly _techsForTag = computed<readonly string[]>(() =>
-    this._findTechsByTag(this.tag().char, { excludes: this.excludeTags() }),
+    this._findTechsByTag(this.tag().char, {
+      includes: this.includeTags(),
+      excludes: this.excludeTags(),
+    }),
   )
   protected readonly _topTechs = computed(() =>
     this._techsForTag().slice(0, TECH_LIMIT),

--- a/src/app/resume-page/tech-stack-section/filtered-techs/filtered-techs.component.ts
+++ b/src/app/resume-page/tech-stack-section/filtered-techs/filtered-techs.component.ts
@@ -8,7 +8,7 @@ import {
 import { ContentChipListComponent } from '../../content-chip-list/content-chip-list.component'
 import { ContentChipComponent } from '../../content-chip/content-chip.component'
 import { TechnologyComponent } from '../../technology/technology.component'
-import { FIND_TECHS_BY_TAG, TagChar, TechTag } from '../tags'
+import { FIND_TECHS_BY_TAG, getTechTagName, TechTag } from '../tags'
 
 @Component({
   selector: 'app-filtered-techs',
@@ -23,12 +23,13 @@ import { FIND_TECHS_BY_TAG, TagChar, TechTag } from '../tags'
 })
 export class FilteredTechsComponent {
   private readonly _findTechsByTag = inject(FIND_TECHS_BY_TAG)
+  protected readonly _getTechTagName = getTechTagName
 
   readonly tag = input.required<TechTag>()
-  readonly includeTags = input<readonly TagChar[]>([])
-  readonly excludeTags = input<readonly TagChar[]>([])
+  readonly includeTags = input<readonly TechTag[]>([])
+  readonly excludeTags = input<readonly TechTag[]>([])
   protected readonly _techsForTag = computed<readonly string[]>(() =>
-    this._findTechsByTag(this.tag().char, {
+    this._findTechsByTag(this.tag(), {
       includes: this.includeTags(),
       excludes: this.excludeTags(),
     }),

--- a/src/app/resume-page/tech-stack-section/tags.spec.ts
+++ b/src/app/resume-page/tech-stack-section/tags.spec.ts
@@ -34,20 +34,19 @@ describe('Tags', () => {
     })
 
     it('should return all techs with the given tag', () => {
-      const actualTechs = sut(aTag.char)
+      const actualTechs = sut(aTag)
       const expectedTechs = Object.entries(TECHS_TAGS)
-        .filter((entry) => entry[1].includes(aTag.char))
+        .filter((entry) => entry[1].includes(aTag))
         .map((entry) => entry[0])
 
       expect(sort(actualTechs)).toEqual(sort(expectedTechs))
     })
 
     it('should only include techs with given tags if given', () => {
-      const actualTechs = sut(aTag.char, { includes: [anotherTag.char] })
+      const actualTechs = sut(aTag, { includes: [anotherTag] })
       const expectedTechs = Object.entries(TECHS_TAGS)
         .filter(
-          (entry) =>
-            entry[1].includes(aTag.char) && entry[1].includes(anotherTag.char),
+          (entry) => entry[1].includes(aTag) && entry[1].includes(anotherTag),
         )
         .map((entry) => entry[0])
 
@@ -55,11 +54,10 @@ describe('Tags', () => {
     })
 
     it('should exclude techs with given tags', () => {
-      const actualTechs = sut(aTag.char, { excludes: [anotherTag.char] })
+      const actualTechs = sut(aTag, { excludes: [anotherTag] })
       const expectedTechs = Object.entries(TECHS_TAGS)
         .filter(
-          (entry) =>
-            entry[1].includes(aTag.char) && !entry[1].includes(anotherTag.char),
+          (entry) => entry[1].includes(aTag) && !entry[1].includes(anotherTag),
         )
         .map((entry) => entry[0])
 

--- a/src/app/resume-page/tech-stack-section/tags.spec.ts
+++ b/src/app/resume-page/tech-stack-section/tags.spec.ts
@@ -42,6 +42,18 @@ describe('Tags', () => {
       expect(sort(actualTechs)).toEqual(sort(expectedTechs))
     })
 
+    it('should only include techs with given tags if given', () => {
+      const actualTechs = sut(aTag.char, { includes: [anotherTag.char] })
+      const expectedTechs = Object.entries(TECHS_TAGS)
+        .filter(
+          (entry) =>
+            entry[1].includes(aTag.char) && entry[1].includes(anotherTag.char),
+        )
+        .map((entry) => entry[0])
+
+      expect(sort(actualTechs)).toEqual(sort(expectedTechs))
+    })
+
     it('should exclude techs with given tags', () => {
       const actualTechs = sut(aTag.char, { excludes: [anotherTag.char] })
       const expectedTechs = Object.entries(TECHS_TAGS)

--- a/src/app/resume-page/tech-stack-section/tags.ts
+++ b/src/app/resume-page/tech-stack-section/tags.ts
@@ -1,162 +1,212 @@
 import { InjectionToken } from '@angular/core'
 import RESUME_JSON from '@/data/resume.json'
 
-export interface TechTag {
-  readonly char: TagChar
-  readonly name: string
-}
+export const BACKEND_TAG = 'backend'
+export const FRONTEND_TAG = 'frontend'
+export const INFRA_TAG = 'infra'
+export const LANGUAGE_TAG = 'language'
+export const TEST_TAG = 'testing'
+export const EDITOR_TAG = 'editor'
+export const OTHERS_TAG = 'others'
+export const CLOUD_TAG = 'cloud'
+export const PLATFORM_TAG = 'platform'
+export const FRAMEWORK_TAG = 'framework'
+export const VCS_TAG = 'vcs'
+export const CRYPTO_TAG = 'crypto'
+export const COMMS_TAG = 'comms'
+export const SECURITY_TAG = 'security'
+export const MOBILE_TAG = 'mobile'
+export const CICD_TAG = 'cicd'
+export const PRODUCTIVITY_TAG = 'productivity'
+export const BUILD_TAG = 'build'
+export const LIBRARY_TAG = 'library'
+export const DATA_FORMAT_TAG = 'data-format'
+export const DATABASE_TAG = 'database'
+export const RUNTIME_TAG = 'runtime'
+export const DOCS_TAG = 'docs'
+export const PAYMENTS_TAG = 'payments'
+export const MONITORING_TAG = 'monitoring'
+export const QUEUING_TAG = 'queuing'
 
-export const BACKEND_TAG: TechTag = {
-  char: 'b',
-  name: 'Backend',
-}
-export const FRONTEND_TAG: TechTag = {
-  char: 'f',
-  name: 'Frontend',
-}
-export const INFRA_TAG: TechTag = {
-  char: 'i',
-  name: 'Infrastructure',
-}
-export const LANGUAGE_TAG: TechTag = {
-  char: 'l',
-  name: 'Language',
-}
-export const TEST_TAG: TechTag = {
-  char: 't',
-  name: 'Testing',
-}
-export const EDITOR_TAG: TechTag = {
-  char: 'e',
-  name: 'Editor',
-}
-export const TAGS = [
+export const TECH_TAGS = [
   BACKEND_TAG,
   FRONTEND_TAG,
   INFRA_TAG,
   LANGUAGE_TAG,
   TEST_TAG,
   EDITOR_TAG,
-]
+  OTHERS_TAG,
+  CLOUD_TAG,
+  PLATFORM_TAG,
+  FRAMEWORK_TAG,
+  VCS_TAG,
+  CRYPTO_TAG,
+  COMMS_TAG,
+  SECURITY_TAG,
+  MOBILE_TAG,
+  CICD_TAG,
+  PRODUCTIVITY_TAG,
+  BUILD_TAG,
+  LIBRARY_TAG,
+  DATA_FORMAT_TAG,
+  DATABASE_TAG,
+  RUNTIME_TAG,
+  DOCS_TAG,
+  PAYMENTS_TAG,
+  MONITORING_TAG,
+  QUEUING_TAG,
+] as const
 
-const TAG_CHARS = ['b', 'f', 'i', 'l', 't', 'e', ''] as const
-export type TagChar = (typeof TAG_CHARS)[number]
-/** @visibleForTesting **/
-export const TECHS_TAGS: Record<string, string> = {
-  amazonapigateway: 'bi',
-  amazoncognito: 'bi',
-  amazonec2: 'i',
-  amazonecs: 'i',
-  amazoneks: 'i',
-  amazonelasticache: 'bi',
-  amazoniam: 'i',
-  amazonrds: 'b',
-  amazons3: 'bi',
-  anaconda: '',
-  android: 'f',
-  androidstudio: 'f',
-  angular: 'f',
-  apachecordova: 'f',
-  apachejmeter: 'b',
-  awselasticloadbalancing: 'i',
-  awssecretsmanager: 'bi',
-  bitbucket: '',
-  bitcoin: 'b',
-  blockcerts: 'b',
-  bluetooth: 'f',
-  css: 'fl',
-  cypress: 'ft',
-  datadog: 'i',
-  docker: 'i',
-  ethereum: 'b',
-  express: 'b',
-  flask: 'b',
-  flutter: 'f',
-  git: '',
-  github: '',
-  githubactions: 'i',
-  gitlab: '',
-  gitlabcicd: 'i',
-  gitlabpages: 'fi',
-  googleworkspace: '',
-  gradle: '',
-  graphite: '',
-  helm: 'i',
-  heroku: 'i',
-  html: 'fl',
-  http: '',
-  httprest: '',
-  ios: 'f',
-  jasmine: 'ft',
-  java: 'bl',
-  javascript: 'fl',
-  jest: 't',
-  jhipster: 'b',
-  jira: '',
-  jquery: 'f',
-  json: '',
-  jsonld: '',
-  jsonwebtokens: '',
-  junit: 'bt',
-  karmarunner: 'ft',
-  kotlin: 'bfl',
-  kubernetes: 'i',
-  linux: 'i',
-  liquibase: 'b',
-  mariadb: 'b',
-  microsoftword: '',
-  mongodb: 'b',
-  mysql: 'b',
-  newrelic: 'i',
-  nodedotjs: 'b',
-  notion: '',
-  npm: '',
-  oauth2: '',
-  openapiinitiative: 'b',
-  php: 'bfl',
-  postgresql: 'b',
-  pwa: 'f',
-  pypi: '',
-  pyqt: 'f',
-  python: 'bfl',
-  'python-unittest': 't',
-  readthedocs: '',
-  redash: '',
-  redis: 'b',
-  redsys: 'b',
-  redux: 'f',
-  rollupdotjs: 'f',
-  rspec: 't',
-  rubymine: '',
-  rubyonrails: 'b',
-  sentry: 'i',
-  sidekiq: 'b',
-  slack: '',
-  sphinx: '',
-  springboot: 'b',
-  sqlalchemy: 'b',
-  terraform: 'i',
-  travisci: 'i',
-  typescript: 'bfl',
-  visualstudiocode: '',
-  webcomponents: 'f',
-  webstorm: '',
-  xcode: 'f',
-  zenqms: '',
-  zoom: '',
+export type TechTag = (typeof TECH_TAGS)[number]
+
+export const TECH_TAG_NAMES: Record<TechTag, string> = {
+  [BACKEND_TAG]: 'Backend',
+  [FRONTEND_TAG]: 'Frontend',
+  [INFRA_TAG]: 'Infrastructure',
+  [LANGUAGE_TAG]: 'Languages',
+  [TEST_TAG]: 'Testing',
+  [EDITOR_TAG]: 'Editors',
+  [OTHERS_TAG]: 'Others',
+  [CLOUD_TAG]: 'Cloud',
+  [PLATFORM_TAG]: 'Platforms',
+  [FRAMEWORK_TAG]: 'Frameworks',
+  [VCS_TAG]: 'Version Control',
+  [CRYPTO_TAG]: 'Blockchain',
+  [COMMS_TAG]: 'Communications',
+  [SECURITY_TAG]: 'Security',
+  [MOBILE_TAG]: 'Mobile',
+  [CICD_TAG]: 'CI/CD',
+  [PRODUCTIVITY_TAG]: 'Productivity',
+  [BUILD_TAG]: 'Build system',
+  [LIBRARY_TAG]: 'Library',
+  [DATA_FORMAT_TAG]: 'Data format',
+  [DATABASE_TAG]: 'Database',
+  [RUNTIME_TAG]: 'Runtime',
+  [DOCS_TAG]: 'Docs',
+  [PAYMENTS_TAG]: 'Payments',
+  [MONITORING_TAG]: 'Monitoring',
+  [QUEUING_TAG]: 'Queuing',
 }
 
-const TECHS_BY_TAG_CHAR = Object.fromEntries(
-  TAG_CHARS.map(
-    (char) =>
+export const getTechTagName = (tag: TechTag): string => TECH_TAG_NAMES[tag]
+
+/** @visibleForTesting **/
+export const TECHS_TAGS: Record<string, readonly TechTag[]> = {
+  amazonapigateway: [BACKEND_TAG, INFRA_TAG, CLOUD_TAG],
+  amazoncognito: [BACKEND_TAG, INFRA_TAG, CLOUD_TAG, SECURITY_TAG],
+  amazonec2: [INFRA_TAG, CLOUD_TAG],
+  amazonecs: [INFRA_TAG, CLOUD_TAG],
+  amazoneks: [INFRA_TAG, CLOUD_TAG],
+  amazonelasticache: [INFRA_TAG, CLOUD_TAG, BACKEND_TAG],
+  amazoniam: [INFRA_TAG, CLOUD_TAG, SECURITY_TAG],
+  amazonrds: [BACKEND_TAG, CLOUD_TAG],
+  amazons3: [INFRA_TAG, CLOUD_TAG, BACKEND_TAG],
+  anaconda: [OTHERS_TAG],
+  android: [FRONTEND_TAG, PLATFORM_TAG, MOBILE_TAG],
+  androidstudio: [FRONTEND_TAG, EDITOR_TAG, MOBILE_TAG],
+  angular: [FRONTEND_TAG, FRAMEWORK_TAG],
+  apachecordova: [FRONTEND_TAG, FRAMEWORK_TAG, MOBILE_TAG],
+  apachejmeter: [BACKEND_TAG, TEST_TAG],
+  awselasticloadbalancing: [INFRA_TAG, CLOUD_TAG],
+  awssecretsmanager: [BACKEND_TAG, INFRA_TAG, CLOUD_TAG, SECURITY_TAG],
+  bitbucket: [VCS_TAG],
+  bitcoin: [BACKEND_TAG, CRYPTO_TAG, SECURITY_TAG],
+  blockcerts: [BACKEND_TAG, FRONTEND_TAG, CRYPTO_TAG, SECURITY_TAG],
+  bluetooth: [FRONTEND_TAG, COMMS_TAG, MOBILE_TAG],
+  css: [FRONTEND_TAG, LANGUAGE_TAG],
+  cypress: [FRONTEND_TAG, TEST_TAG],
+  datadog: [BACKEND_TAG, INFRA_TAG, CLOUD_TAG, MONITORING_TAG],
+  docker: [INFRA_TAG, BUILD_TAG],
+  ethereum: [BACKEND_TAG, FRONTEND_TAG, CRYPTO_TAG],
+  express: [BACKEND_TAG, FRAMEWORK_TAG],
+  flask: [BACKEND_TAG, FRAMEWORK_TAG],
+  flutter: [FRONTEND_TAG, FRAMEWORK_TAG, MOBILE_TAG],
+  git: [VCS_TAG],
+  github: [VCS_TAG],
+  githubactions: [INFRA_TAG, CICD_TAG],
+  gitlab: [VCS_TAG],
+  gitlabcicd: [INFRA_TAG, CICD_TAG],
+  gitlabpages: [INFRA_TAG, FRONTEND_TAG, CLOUD_TAG],
+  googleworkspace: [PRODUCTIVITY_TAG],
+  gradle: [BUILD_TAG],
+  graphite: [OTHERS_TAG],
+  helm: [INFRA_TAG],
+  heroku: [INFRA_TAG, CLOUD_TAG],
+  html: [FRONTEND_TAG, LANGUAGE_TAG],
+  http: [BACKEND_TAG, FRONTEND_TAG, COMMS_TAG],
+  httprest: [BACKEND_TAG, FRONTEND_TAG, COMMS_TAG],
+  ios: [FRONTEND_TAG, PLATFORM_TAG, MOBILE_TAG],
+  jasmine: [FRONTEND_TAG, TEST_TAG],
+  java: [BACKEND_TAG, FRONTEND_TAG, LANGUAGE_TAG, MOBILE_TAG],
+  javascript: [BACKEND_TAG, FRONTEND_TAG, LANGUAGE_TAG],
+  jest: [FRONTEND_TAG, TEST_TAG],
+  jhipster: [BACKEND_TAG, FRONTEND_TAG, FRAMEWORK_TAG],
+  jira: [PRODUCTIVITY_TAG],
+  jquery: [FRONTEND_TAG, LANGUAGE_TAG],
+  json: [FRONTEND_TAG, BACKEND_TAG, DATA_FORMAT_TAG],
+  jsonld: [FRONTEND_TAG, BACKEND_TAG, DATA_FORMAT_TAG],
+  jsonwebtokens: [FRONTEND_TAG, BACKEND_TAG, DATA_FORMAT_TAG, SECURITY_TAG],
+  junit: [BACKEND_TAG, TEST_TAG],
+  karmarunner: [FRONTEND_TAG, TEST_TAG],
+  kotlin: [BACKEND_TAG, FRONTEND_TAG, LANGUAGE_TAG, MOBILE_TAG],
+  kubernetes: [INFRA_TAG, CLOUD_TAG],
+  linux: [INFRA_TAG, PLATFORM_TAG],
+  liquibase: [BACKEND_TAG, DATABASE_TAG],
+  mariadb: [BACKEND_TAG, DATABASE_TAG],
+  microsoftword: [PRODUCTIVITY_TAG],
+  mongodb: [BACKEND_TAG, DATABASE_TAG],
+  mysql: [BACKEND_TAG, DATABASE_TAG],
+  newrelic: [BACKEND_TAG, INFRA_TAG, CLOUD_TAG, MONITORING_TAG],
+  nodedotjs: [BACKEND_TAG, FRONTEND_TAG, RUNTIME_TAG],
+  notion: [PRODUCTIVITY_TAG],
+  npm: [BUILD_TAG, FRONTEND_TAG, BACKEND_TAG],
+  oauth2: [SECURITY_TAG, COMMS_TAG],
+  openapiinitiative: [BACKEND_TAG, FRONTEND_TAG, COMMS_TAG],
+  php: [BACKEND_TAG, FRONTEND_TAG, LANGUAGE_TAG],
+  postgresql: [BACKEND_TAG, DATABASE_TAG],
+  pwa: [FRONTEND_TAG, FRAMEWORK_TAG, MOBILE_TAG],
+  pypi: [BUILD_TAG],
+  pyqt: [FRONTEND_TAG, FRAMEWORK_TAG],
+  python: [BACKEND_TAG, FRONTEND_TAG, LANGUAGE_TAG],
+  'python-unittest': [BACKEND_TAG, FRONTEND_TAG, TEST_TAG],
+  readthedocs: [DOCS_TAG],
+  redash: [BACKEND_TAG, DATABASE_TAG],
+  redis: [BACKEND_TAG, DATABASE_TAG],
+  redsys: [BACKEND_TAG, SECURITY_TAG],
+  redux: [FRONTEND_TAG, FRAMEWORK_TAG],
+  rollupdotjs: [FRONTEND_TAG, BUILD_TAG],
+  rspec: [BACKEND_TAG, TEST_TAG],
+  rubymine: [BACKEND_TAG, EDITOR_TAG],
+  rubyonrails: [BACKEND_TAG, FRAMEWORK_TAG],
+  sentry: [BACKEND_TAG, INFRA_TAG, CLOUD_TAG, MONITORING_TAG],
+  sidekiq: [BACKEND_TAG, QUEUING_TAG],
+  slack: [PRODUCTIVITY_TAG],
+  sphinx: [DOCS_TAG],
+  springboot: [BACKEND_TAG, FRAMEWORK_TAG],
+  sqlalchemy: [BACKEND_TAG, DATABASE_TAG],
+  terraform: [INFRA_TAG],
+  travisci: [INFRA_TAG, CICD_TAG],
+  typescript: [BACKEND_TAG, FRONTEND_TAG, LANGUAGE_TAG],
+  visualstudiocode: [BACKEND_TAG, FRONTEND_TAG, EDITOR_TAG],
+  webcomponents: [FRONTEND_TAG, FRAMEWORK_TAG],
+  webstorm: [BACKEND_TAG, FRONTEND_TAG, EDITOR_TAG],
+  xcode: [FRONTEND_TAG, EDITOR_TAG, MOBILE_TAG],
+  zenqms: [PRODUCTIVITY_TAG],
+  zoom: [PRODUCTIVITY_TAG],
+}
+
+const TECHS_BY_TAG = Object.fromEntries(
+  TECH_TAGS.map(
+    (tag) =>
       [
-        char,
+        tag,
         Object.entries(TECHS_TAGS)
-          .filter(([, tags]) => tags.includes(char))
+          .filter(([, tags]) => tags.includes(tag))
           .map(([tech]) => tech),
       ] as const,
   ),
-) as unknown as Record<TagChar, readonly string[]>
+) as unknown as Record<TechTag, readonly string[]>
+
 export const FIND_TECHS_BY_TAG = new InjectionToken<FindTechsByTag>(
   isDevMode ? 'findTechsByTag' : 'FTBT',
   {
@@ -166,10 +216,10 @@ export const FIND_TECHS_BY_TAG = new InjectionToken<FindTechsByTag>(
 /** @visibleForTesting **/
 export type FindTechsByTag = typeof findTechsByTag
 const findTechsByTag = (
-  tagChar: TagChar,
-  opts: { excludes?: readonly TagChar[]; includes?: readonly TagChar[] } = {},
+  tag: TechTag,
+  opts: { excludes?: readonly TechTag[]; includes?: readonly TechTag[] } = {},
 ) => {
-  const techsWithTag = TECHS_BY_TAG_CHAR[tagChar]
+  const techsWithTag = TECHS_BY_TAG[tag]
   const { includes, excludes } = opts
   const withIncludes = includes?.length
     ? techsWithTag.filter((tech) =>

--- a/src/app/resume-page/tech-stack-section/tags.ts
+++ b/src/app/resume-page/tech-stack-section/tags.ts
@@ -14,8 +14,6 @@ export const TEST_TAG = 'testing'
 /** @knipIgnore **/
 export const EDITOR_TAG = 'editor'
 /** @knipIgnore **/
-export const OTHERS_TAG = 'others'
-/** @knipIgnore **/
 export const CLOUD_TAG = 'cloud'
 /** @knipIgnore **/
 export const PLATFORM_TAG = 'platform'
@@ -59,7 +57,6 @@ export const TECH_TAGS = [
   LANGUAGE_TAG,
   TEST_TAG,
   EDITOR_TAG,
-  OTHERS_TAG,
   CLOUD_TAG,
   PLATFORM_TAG,
   FRAMEWORK_TAG,
@@ -89,7 +86,6 @@ const TECH_TAG_NAMES: Record<TechTag, string> = {
   [LANGUAGE_TAG]: 'Languages',
   [TEST_TAG]: 'Testing',
   [EDITOR_TAG]: 'Editors',
-  [OTHERS_TAG]: 'Others',
   [CLOUD_TAG]: 'Cloud',
   [PLATFORM_TAG]: 'Platforms',
   [FRAMEWORK_TAG]: 'Frameworks',
@@ -123,7 +119,7 @@ export const TECHS_TAGS: Record<string, readonly TechTag[]> = {
   amazoniam: [INFRA_TAG, CLOUD_TAG, SECURITY_TAG],
   amazonrds: [BACKEND_TAG, CLOUD_TAG],
   amazons3: [INFRA_TAG, CLOUD_TAG, BACKEND_TAG],
-  anaconda: [OTHERS_TAG],
+  anaconda: [BUILD_TAG],
   android: [FRONTEND_TAG, PLATFORM_TAG, MOBILE_TAG],
   androidstudio: [FRONTEND_TAG, EDITOR_TAG, MOBILE_TAG],
   angular: [FRONTEND_TAG, FRAMEWORK_TAG],
@@ -151,7 +147,7 @@ export const TECHS_TAGS: Record<string, readonly TechTag[]> = {
   gitlabpages: [INFRA_TAG, FRONTEND_TAG, CLOUD_TAG],
   googleworkspace: [PRODUCTIVITY_TAG],
   gradle: [BUILD_TAG],
-  graphite: [OTHERS_TAG],
+  graphite: [],
   helm: [INFRA_TAG],
   heroku: [INFRA_TAG, CLOUD_TAG],
   html: [FRONTEND_TAG, LANGUAGE_TAG],

--- a/src/app/resume-page/tech-stack-section/tags.ts
+++ b/src/app/resume-page/tech-stack-section/tags.ts
@@ -18,11 +18,6 @@ export const INFRA_TAG: TechTag = {
   char: 'i',
   name: 'Infrastructure',
 }
-export const MAIN_TAGS: readonly TechTag[] = [
-  BACKEND_TAG,
-  FRONTEND_TAG,
-  INFRA_TAG,
-]
 export const LANGUAGE_TAG: TechTag = {
   char: 'l',
   name: 'Language',
@@ -35,15 +30,13 @@ export const EDITOR_TAG: TechTag = {
   char: 'e',
   name: 'Editor',
 }
-export const OTHERS_TAG: TechTag = {
-  char: '',
-  name: 'Others',
-}
-export const REST_TAGS: readonly TechTag[] = [
+export const TAGS = [
+  BACKEND_TAG,
+  FRONTEND_TAG,
+  INFRA_TAG,
   LANGUAGE_TAG,
   TEST_TAG,
   EDITOR_TAG,
-  OTHERS_TAG,
 ]
 
 const TAG_CHARS = ['b', 'f', 'i', 'l', 't', 'e', ''] as const
@@ -174,16 +167,21 @@ export const FIND_TECHS_BY_TAG = new InjectionToken<FindTechsByTag>(
 export type FindTechsByTag = typeof findTechsByTag
 const findTechsByTag = (
   tagChar: TagChar,
-  opts: { excludes?: readonly TagChar[] } = {},
+  opts: { excludes?: readonly TagChar[]; includes?: readonly TagChar[] } = {},
 ) => {
   const techsWithTag = TECHS_BY_TAG_CHAR[tagChar]
-  const { excludes } = opts
-  const filteredTechsWithTag = excludes?.length
+  const { includes, excludes } = opts
+  const withIncludes = includes?.length
     ? techsWithTag.filter((tech) =>
-        excludes.every((tag) => !TECHS_TAGS[tech].includes(tag)),
+        includes.some((tag) => TECHS_TAGS[tech].includes(tag)),
       )
     : techsWithTag
-  return [...filteredTechsWithTag].sort(
+  const withoutExcludes = excludes?.length
+    ? withIncludes.filter((tech) =>
+        excludes.every((tag) => !TECHS_TAGS[tech].includes(tag)),
+      )
+    : withIncludes
+  return [...withoutExcludes].sort(
     (a, b) => TECHS_RELEVANCE_SCORE[b] - TECHS_RELEVANCE_SCORE[a],
   )
 }

--- a/src/app/resume-page/tech-stack-section/tags.ts
+++ b/src/app/resume-page/tech-stack-section/tags.ts
@@ -1,30 +1,55 @@
 import { InjectionToken } from '@angular/core'
 import RESUME_JSON from '@/data/resume.json'
 
+/** @knipIgnore **/
 export const BACKEND_TAG = 'backend'
+/** @knipIgnore **/
 export const FRONTEND_TAG = 'frontend'
+/** @knipIgnore **/
 export const INFRA_TAG = 'infra'
+/** @knipIgnore **/
 export const LANGUAGE_TAG = 'language'
+/** @knipIgnore **/
 export const TEST_TAG = 'testing'
+/** @knipIgnore **/
 export const EDITOR_TAG = 'editor'
+/** @knipIgnore **/
 export const OTHERS_TAG = 'others'
+/** @knipIgnore **/
 export const CLOUD_TAG = 'cloud'
+/** @knipIgnore **/
 export const PLATFORM_TAG = 'platform'
+/** @knipIgnore **/
 export const FRAMEWORK_TAG = 'framework'
+/** @knipIgnore **/
 export const VCS_TAG = 'vcs'
+/** @knipIgnore **/
 export const CRYPTO_TAG = 'crypto'
+/** @knipIgnore **/
 export const COMMS_TAG = 'comms'
+/** @knipIgnore **/
 export const SECURITY_TAG = 'security'
+/** @knipIgnore **/
 export const MOBILE_TAG = 'mobile'
+/** @knipIgnore **/
 export const CICD_TAG = 'cicd'
+/** @knipIgnore **/
 export const PRODUCTIVITY_TAG = 'productivity'
+/** @knipIgnore **/
 export const BUILD_TAG = 'build'
+/** @knipIgnore **/
 export const DATA_FORMAT_TAG = 'data-format'
+/** @knipIgnore **/
 export const DATABASE_TAG = 'database'
+/** @knipIgnore **/
 export const RUNTIME_TAG = 'runtime'
+/** @knipIgnore **/
 export const DOCS_TAG = 'docs'
+/** @knipIgnore **/
 export const PAYMENTS_TAG = 'payments'
+/** @knipIgnore **/
 export const MONITORING_TAG = 'monitoring'
+/** @knipIgnore **/
 export const QUEUING_TAG = 'queuing'
 
 export const TECH_TAGS = [
@@ -57,7 +82,7 @@ export const TECH_TAGS = [
 
 export type TechTag = (typeof TECH_TAGS)[number]
 
-export const TECH_TAG_NAMES: Record<TechTag, string> = {
+const TECH_TAG_NAMES: Record<TechTag, string> = {
   [BACKEND_TAG]: 'Backend',
   [FRONTEND_TAG]: 'Frontend',
   [INFRA_TAG]: 'Infrastructure',

--- a/src/app/resume-page/tech-stack-section/tags.ts
+++ b/src/app/resume-page/tech-stack-section/tags.ts
@@ -49,6 +49,8 @@ export const PAYMENTS_TAG = 'payments'
 export const MONITORING_TAG = 'monitoring'
 /** @knipIgnore **/
 export const QUEUING_TAG = 'queuing'
+/** @knipIgnore **/
+export const DATA_TAG = 'data'
 
 export const TECH_TAGS = [
   BACKEND_TAG,
@@ -75,6 +77,7 @@ export const TECH_TAGS = [
   PAYMENTS_TAG,
   MONITORING_TAG,
   QUEUING_TAG,
+  DATA_TAG,
 ] as const
 
 export type TechTag = (typeof TECH_TAGS)[number]
@@ -104,6 +107,7 @@ const TECH_TAG_NAMES: Record<TechTag, string> = {
   [PAYMENTS_TAG]: 'Payments',
   [MONITORING_TAG]: 'Monitoring',
   [QUEUING_TAG]: 'Queuing',
+  [DATA_TAG]: 'Data',
 }
 
 export const getTechTagName = (tag: TechTag): string => TECH_TAG_NAMES[tag]
@@ -119,7 +123,7 @@ export const TECHS_TAGS: Record<string, readonly TechTag[]> = {
   amazoniam: [INFRA_TAG, CLOUD_TAG, SECURITY_TAG],
   amazonrds: [BACKEND_TAG, CLOUD_TAG],
   amazons3: [INFRA_TAG, CLOUD_TAG, BACKEND_TAG],
-  anaconda: [BUILD_TAG],
+  anaconda: [BUILD_TAG, DATA_TAG],
   android: [FRONTEND_TAG, PLATFORM_TAG, MOBILE_TAG],
   androidstudio: [FRONTEND_TAG, EDITOR_TAG, MOBILE_TAG],
   angular: [FRONTEND_TAG, FRAMEWORK_TAG],
@@ -185,10 +189,10 @@ export const TECHS_TAGS: Record<string, readonly TechTag[]> = {
   pwa: [FRONTEND_TAG, FRAMEWORK_TAG, MOBILE_TAG],
   pypi: [BUILD_TAG],
   pyqt: [FRONTEND_TAG, FRAMEWORK_TAG],
-  python: [BACKEND_TAG, FRONTEND_TAG, LANGUAGE_TAG],
+  python: [BACKEND_TAG, FRONTEND_TAG, DATA_TAG, LANGUAGE_TAG],
   'python-unittest': [BACKEND_TAG, FRONTEND_TAG, TEST_TAG],
   readthedocs: [DOCS_TAG],
-  redash: [BACKEND_TAG, DATABASE_TAG],
+  redash: [DATABASE_TAG, DATA_TAG],
   redis: [BACKEND_TAG, DATABASE_TAG],
   redsys: [BACKEND_TAG, SECURITY_TAG],
   redux: [FRONTEND_TAG, FRAMEWORK_TAG],

--- a/src/app/resume-page/tech-stack-section/tags.ts
+++ b/src/app/resume-page/tech-stack-section/tags.ts
@@ -198,6 +198,7 @@ export const TECHS_TAGS: Record<string, readonly TechTag[]> = {
   redux: [FRONTEND_TAG, FRAMEWORK_TAG],
   rollupdotjs: [FRONTEND_TAG, BUILD_TAG],
   rspec: [BACKEND_TAG, TEST_TAG],
+  ruby: [BACKEND_TAG, LANGUAGE_TAG],
   rubymine: [BACKEND_TAG, EDITOR_TAG],
   rubyonrails: [BACKEND_TAG, FRAMEWORK_TAG],
   sentry: [BACKEND_TAG, INFRA_TAG, CLOUD_TAG, MONITORING_TAG],

--- a/src/app/resume-page/tech-stack-section/tags.ts
+++ b/src/app/resume-page/tech-stack-section/tags.ts
@@ -18,7 +18,35 @@ export const INFRA_TAG: TechTag = {
   char: 'i',
   name: 'Infrastructure',
 }
-const TAG_CHARS = ['b', 'f', 'i'] as const
+export const MAIN_TAGS: readonly TechTag[] = [
+  BACKEND_TAG,
+  FRONTEND_TAG,
+  INFRA_TAG,
+]
+export const LANGUAGE_TAG: TechTag = {
+  char: 'l',
+  name: 'Language',
+}
+export const TEST_TAG: TechTag = {
+  char: 't',
+  name: 'Testing',
+}
+export const EDITOR_TAG: TechTag = {
+  char: 'e',
+  name: 'Editor',
+}
+export const OTHERS_TAG: TechTag = {
+  char: '',
+  name: 'Others',
+}
+export const REST_TAGS: readonly TechTag[] = [
+  LANGUAGE_TAG,
+  TEST_TAG,
+  EDITOR_TAG,
+  OTHERS_TAG,
+]
+
+const TAG_CHARS = ['b', 'f', 'i', 'l', 't', 'e', ''] as const
 export type TagChar = (typeof TAG_CHARS)[number]
 /** @visibleForTesting **/
 export const TECHS_TAGS: Record<string, string> = {
@@ -43,8 +71,8 @@ export const TECHS_TAGS: Record<string, string> = {
   bitcoin: 'b',
   blockcerts: 'b',
   bluetooth: 'f',
-  css: 'f',
-  cypress: 'f',
+  css: 'fl',
+  cypress: 'ft',
   datadog: 'i',
   docker: 'i',
   ethereum: 'b',
@@ -62,23 +90,23 @@ export const TECHS_TAGS: Record<string, string> = {
   graphite: '',
   helm: 'i',
   heroku: 'i',
-  html: 'f',
+  html: 'fl',
   http: '',
   httprest: '',
   ios: 'f',
-  jasmine: 'f',
-  java: 'b',
-  javascript: 'f',
-  jest: '',
+  jasmine: 'ft',
+  java: 'bl',
+  javascript: 'fl',
+  jest: 't',
   jhipster: 'b',
   jira: '',
   jquery: 'f',
   json: '',
   jsonld: '',
   jsonwebtokens: '',
-  junit: 'b',
-  karmarunner: 'f',
-  kotlin: 'bf',
+  junit: 'bt',
+  karmarunner: 'ft',
+  kotlin: 'bfl',
   kubernetes: 'i',
   linux: 'i',
   liquibase: 'b',
@@ -92,20 +120,20 @@ export const TECHS_TAGS: Record<string, string> = {
   npm: '',
   oauth2: '',
   openapiinitiative: 'b',
-  php: 'bf',
+  php: 'bfl',
   postgresql: 'b',
   pwa: 'f',
   pypi: '',
   pyqt: 'f',
-  python: 'bf',
-  'python-unittest': '',
+  python: 'bfl',
+  'python-unittest': 't',
   readthedocs: '',
   redash: '',
   redis: 'b',
   redsys: 'b',
   redux: 'f',
   rollupdotjs: 'f',
-  rspec: '',
+  rspec: 't',
   rubymine: '',
   rubyonrails: 'b',
   sentry: 'i',
@@ -116,7 +144,7 @@ export const TECHS_TAGS: Record<string, string> = {
   sqlalchemy: 'b',
   terraform: 'i',
   travisci: 'i',
-  typescript: 'bf',
+  typescript: 'bfl',
   visualstudiocode: '',
   webcomponents: 'f',
   webstorm: '',

--- a/src/app/resume-page/tech-stack-section/tags.ts
+++ b/src/app/resume-page/tech-stack-section/tags.ts
@@ -19,7 +19,6 @@ export const MOBILE_TAG = 'mobile'
 export const CICD_TAG = 'cicd'
 export const PRODUCTIVITY_TAG = 'productivity'
 export const BUILD_TAG = 'build'
-export const LIBRARY_TAG = 'library'
 export const DATA_FORMAT_TAG = 'data-format'
 export const DATABASE_TAG = 'database'
 export const RUNTIME_TAG = 'runtime'
@@ -47,7 +46,6 @@ export const TECH_TAGS = [
   CICD_TAG,
   PRODUCTIVITY_TAG,
   BUILD_TAG,
-  LIBRARY_TAG,
   DATA_FORMAT_TAG,
   DATABASE_TAG,
   RUNTIME_TAG,
@@ -78,7 +76,6 @@ export const TECH_TAG_NAMES: Record<TechTag, string> = {
   [CICD_TAG]: 'CI/CD',
   [PRODUCTIVITY_TAG]: 'Productivity',
   [BUILD_TAG]: 'Build system',
-  [LIBRARY_TAG]: 'Library',
   [DATA_FORMAT_TAG]: 'Data format',
   [DATABASE_TAG]: 'Database',
   [RUNTIME_TAG]: 'Runtime',

--- a/src/app/resume-page/tech-stack-section/tags.ts
+++ b/src/app/resume-page/tech-stack-section/tags.ts
@@ -213,7 +213,7 @@ export const TECHS_TAGS: Record<string, readonly TechTag[]> = {
   zoom: [PRODUCTIVITY_TAG],
 }
 
-const TECHS_BY_TAG = Object.fromEntries(
+export const TECHS_BY_TAG = Object.fromEntries(
   TECH_TAGS.map(
     (tag) =>
       [

--- a/src/app/resume-page/tech-stack-section/tags.ts
+++ b/src/app/resume-page/tech-stack-section/tags.ts
@@ -34,8 +34,6 @@ export const CICD_TAG = 'cicd'
 /** @knipIgnore **/
 export const PRODUCTIVITY_TAG = 'productivity'
 /** @knipIgnore **/
-export const BUILD_TAG = 'build'
-/** @knipIgnore **/
 export const DATA_FORMAT_TAG = 'data-format'
 /** @knipIgnore **/
 export const DATABASE_TAG = 'database'
@@ -51,6 +49,10 @@ export const MONITORING_TAG = 'monitoring'
 export const QUEUING_TAG = 'queuing'
 /** @knipIgnore **/
 export const DATA_TAG = 'data'
+/** @knipIgnore **/
+export const PACKAGING_TAG = 'packaging'
+/** @knipIgnore **/
+export const PACKAGE_MANAGEMENT = 'package-mgmt'
 
 export const TECH_TAGS = [
   BACKEND_TAG,
@@ -69,7 +71,6 @@ export const TECH_TAGS = [
   MOBILE_TAG,
   CICD_TAG,
   PRODUCTIVITY_TAG,
-  BUILD_TAG,
   DATA_FORMAT_TAG,
   DATABASE_TAG,
   RUNTIME_TAG,
@@ -78,6 +79,8 @@ export const TECH_TAGS = [
   MONITORING_TAG,
   QUEUING_TAG,
   DATA_TAG,
+  PACKAGING_TAG,
+  PACKAGE_MANAGEMENT,
 ] as const
 
 export type TechTag = (typeof TECH_TAGS)[number]
@@ -99,7 +102,6 @@ const TECH_TAG_NAMES: Record<TechTag, string> = {
   [MOBILE_TAG]: 'Mobile',
   [CICD_TAG]: 'CI/CD',
   [PRODUCTIVITY_TAG]: 'Productivity',
-  [BUILD_TAG]: 'Build system',
   [DATA_FORMAT_TAG]: 'Data format',
   [DATABASE_TAG]: 'Database',
   [RUNTIME_TAG]: 'Runtime',
@@ -108,6 +110,8 @@ const TECH_TAG_NAMES: Record<TechTag, string> = {
   [MONITORING_TAG]: 'Monitoring',
   [QUEUING_TAG]: 'Queuing',
   [DATA_TAG]: 'Data',
+  [PACKAGING_TAG]: 'Packaging',
+  [PACKAGE_MANAGEMENT]: 'Package management',
 }
 
 export const getTechTagName = (tag: TechTag): string => TECH_TAG_NAMES[tag]
@@ -123,7 +127,7 @@ export const TECHS_TAGS: Record<string, readonly TechTag[]> = {
   amazoniam: [INFRA_TAG, CLOUD_TAG, SECURITY_TAG],
   amazonrds: [BACKEND_TAG, CLOUD_TAG],
   amazons3: [INFRA_TAG, CLOUD_TAG, BACKEND_TAG],
-  anaconda: [BUILD_TAG, DATA_TAG],
+  anaconda: [PACKAGE_MANAGEMENT, DATA_TAG],
   android: [FRONTEND_TAG, PLATFORM_TAG, MOBILE_TAG],
   androidstudio: [FRONTEND_TAG, EDITOR_TAG, MOBILE_TAG],
   angular: [FRONTEND_TAG, FRAMEWORK_TAG],
@@ -138,7 +142,7 @@ export const TECHS_TAGS: Record<string, readonly TechTag[]> = {
   css: [FRONTEND_TAG, LANGUAGE_TAG],
   cypress: [FRONTEND_TAG, TEST_TAG],
   datadog: [BACKEND_TAG, INFRA_TAG, CLOUD_TAG, MONITORING_TAG],
-  docker: [INFRA_TAG, BUILD_TAG],
+  docker: [INFRA_TAG, PACKAGING_TAG],
   ethereum: [BACKEND_TAG, FRONTEND_TAG, CRYPTO_TAG],
   express: [BACKEND_TAG, FRAMEWORK_TAG],
   flask: [BACKEND_TAG, FRAMEWORK_TAG],
@@ -150,7 +154,7 @@ export const TECHS_TAGS: Record<string, readonly TechTag[]> = {
   gitlabcicd: [INFRA_TAG, CICD_TAG],
   gitlabpages: [INFRA_TAG, FRONTEND_TAG, CLOUD_TAG],
   googleworkspace: [PRODUCTIVITY_TAG],
-  gradle: [BUILD_TAG],
+  gradle: [PACKAGE_MANAGEMENT, PACKAGING_TAG],
   graphite: [],
   helm: [INFRA_TAG],
   heroku: [INFRA_TAG, CLOUD_TAG],
@@ -181,13 +185,13 @@ export const TECHS_TAGS: Record<string, readonly TechTag[]> = {
   newrelic: [BACKEND_TAG, INFRA_TAG, CLOUD_TAG, MONITORING_TAG],
   nodedotjs: [BACKEND_TAG, FRONTEND_TAG, RUNTIME_TAG],
   notion: [PRODUCTIVITY_TAG],
-  npm: [BUILD_TAG, FRONTEND_TAG, BACKEND_TAG],
+  npm: [PACKAGE_MANAGEMENT, FRONTEND_TAG, BACKEND_TAG, PACKAGING_TAG],
   oauth2: [SECURITY_TAG, COMMS_TAG],
   openapiinitiative: [BACKEND_TAG, FRONTEND_TAG, COMMS_TAG],
   php: [BACKEND_TAG, FRONTEND_TAG, LANGUAGE_TAG],
   postgresql: [BACKEND_TAG, DATABASE_TAG],
   pwa: [FRONTEND_TAG, FRAMEWORK_TAG, MOBILE_TAG],
-  pypi: [BUILD_TAG],
+  pypi: [PACKAGE_MANAGEMENT],
   pyqt: [FRONTEND_TAG, FRAMEWORK_TAG],
   python: [BACKEND_TAG, FRONTEND_TAG, DATA_TAG, LANGUAGE_TAG],
   'python-unittest': [BACKEND_TAG, FRONTEND_TAG, TEST_TAG],
@@ -196,7 +200,7 @@ export const TECHS_TAGS: Record<string, readonly TechTag[]> = {
   redis: [BACKEND_TAG, DATABASE_TAG],
   redsys: [BACKEND_TAG, SECURITY_TAG],
   redux: [FRONTEND_TAG, FRAMEWORK_TAG],
-  rollupdotjs: [FRONTEND_TAG, BUILD_TAG],
+  rollupdotjs: [FRONTEND_TAG, PACKAGING_TAG],
   rspec: [BACKEND_TAG, TEST_TAG],
   ruby: [BACKEND_TAG, LANGUAGE_TAG],
   rubymine: [BACKEND_TAG, EDITOR_TAG],

--- a/src/app/resume-page/tech-stack-section/tech-stack-section.component.html
+++ b/src/app/resume-page/tech-stack-section/tech-stack-section.component.html
@@ -1,10 +1,14 @@
 <h2 appSectionTitle id="tech-stack">Tech stack</h2>
-<app-tech-tags-selector></app-tech-tags-selector>
+<app-tech-tags-selector
+  [available]="_selectableTags"
+  [(selected)]="_selectedTags"
+></app-tech-tags-selector>
 <div class="container">
-  <app-filtered-techs [tag]="_frontendTag"></app-filtered-techs>
-  <app-filtered-techs
-    [tag]="_backendTag"
-    [excludeTags]="[_infraTag.char]"
-  ></app-filtered-techs>
-  <app-filtered-techs [tag]="_infraTag"></app-filtered-techs>
+  @for (selection of _techSelections(); track selection) {
+    <app-filtered-techs
+      [tag]="selection.main"
+      [includeTags]="selection.include"
+      [excludeTags]="selection.exclude"
+    ></app-filtered-techs>
+  }
 </div>

--- a/src/app/resume-page/tech-stack-section/tech-stack-section.component.html
+++ b/src/app/resume-page/tech-stack-section/tech-stack-section.component.html
@@ -1,4 +1,5 @@
 <h2 appSectionTitle id="tech-stack">Tech stack</h2>
+<app-tech-tags-selector></app-tech-tags-selector>
 <div class="container">
   <app-filtered-techs [tag]="_frontendTag"></app-filtered-techs>
   <app-filtered-techs

--- a/src/app/resume-page/tech-stack-section/tech-stack-section.component.html
+++ b/src/app/resume-page/tech-stack-section/tech-stack-section.component.html
@@ -4,7 +4,7 @@
   [(selected)]="_selectedTags"
 ></app-tech-tags-selector>
 <div class="container">
-  @for (selection of _techSelections(); track selection) {
+  @for (selection of _techSelections(); track selection.main) {
     <app-filtered-techs
       [tag]="selection.main"
       [includeTags]="selection.include"

--- a/src/app/resume-page/tech-stack-section/tech-stack-section.component.scss
+++ b/src/app/resume-page/tech-stack-section/tech-stack-section.component.scss
@@ -1,11 +1,19 @@
 @use 'borders';
 @use 'breakpoints';
+@use 'animations';
+
+app-tech-tags-selector {
+  @include borders.panel(bottom);
+  @include animations.single-transition(border-color);
+}
 
 .container {
   display: flex;
   flex-wrap: wrap;
   > * {
     flex: 1;
+
+    @include animations.single-transition(border-color);
 
     &:not(:last-child) {
       @include borders.panel(right);

--- a/src/app/resume-page/tech-stack-section/tech-stack-section.component.spec.ts
+++ b/src/app/resume-page/tech-stack-section/tech-stack-section.component.spec.ts
@@ -5,6 +5,7 @@ import { componentTestSetup } from '@/test/helpers/component-test-setup'
 import { SectionTitleComponent } from '../section-title/section-title.component'
 import { FilteredTechsComponent } from './filtered-techs/filtered-techs.component'
 import { MockComponents } from 'ng-mocks'
+import { TechTagsSelectorComponent } from './tech-tags-selector/tech-tags-selector.component'
 
 describe('TechStackSectionComponent', () => {
   let component: TechStackSectionComponent
@@ -12,7 +13,13 @@ describe('TechStackSectionComponent', () => {
 
   beforeEach(() => {
     ;[fixture, component] = componentTestSetup(TechStackSectionComponent, {
-      imports: [MockComponents(SectionTitleComponent, FilteredTechsComponent)],
+      imports: [
+        MockComponents(
+          SectionTitleComponent,
+          TechTagsSelectorComponent,
+          FilteredTechsComponent,
+        ),
+      ],
     })
     fixture.detectChanges()
   })

--- a/src/app/resume-page/tech-stack-section/tech-stack-section.component.ts
+++ b/src/app/resume-page/tech-stack-section/tech-stack-section.component.ts
@@ -8,11 +8,20 @@ import { SectionTitleComponent } from '../section-title/section-title.component'
 import { FilteredTechsComponent } from './filtered-techs/filtered-techs.component'
 import {
   BACKEND_TAG,
+  BUILD_TAG,
+  CICD_TAG,
+  CLOUD_TAG,
+  DATABASE_TAG,
+  FRAMEWORK_TAG,
   FRONTEND_TAG,
   INFRA_TAG,
   LANGUAGE_TAG,
-  TagChar,
-  TAGS,
+  MONITORING_TAG,
+  PAYMENTS_TAG,
+  PLATFORM_TAG,
+  QUEUING_TAG,
+  RUNTIME_TAG,
+  TECH_TAGS,
   TechTag,
 } from './tags'
 import { TechTagsSelectorComponent } from './tech-tags-selector/tech-tags-selector.component'
@@ -29,25 +38,38 @@ import { TechTagsSelectorComponent } from './tech-tags-selector/tech-tags-select
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class TechStackSectionComponent {
-  protected readonly _selectableTags = [...REST_TAGS]
-  protected _selectedTags = signal<readonly TechTag[]>([
-    ...DEFAULT_SELECTED_TAGS,
-  ])
+  protected readonly _selectableTags = sort([...REST_TAGS])
+  protected _selectedTags = signal<readonly TechTag[]>(DEFAULT_SELECTED_TAGS)
   protected readonly _techSelections = computed<readonly TechSelection[]>(() =>
     MAIN_TAGS.map((main) => ({
       main,
-      include: this._selectedTags().map((tag) => tag.char),
-      exclude: main === BACKEND_TAG ? [INFRA_TAG.char] : [],
+      include: this._selectedTags(),
+      exclude: main === BACKEND_TAG ? [INFRA_TAG] : [],
     })),
   )
 }
 
 interface TechSelection {
   main: TechTag
-  include: readonly TagChar[]
-  exclude: readonly TagChar[]
+  include: readonly TechTag[]
+  exclude: readonly TechTag[]
 }
 
-const MAIN_TAGS = [BACKEND_TAG, FRONTEND_TAG, INFRA_TAG]
-const REST_TAGS = TAGS.filter((tag) => !MAIN_TAGS.includes(tag))
-const DEFAULT_SELECTED_TAGS = [LANGUAGE_TAG]
+const MAIN_TAGS: readonly TechTag[] = [BACKEND_TAG, FRONTEND_TAG, INFRA_TAG]
+const REST_TAGS: readonly TechTag[] = TECH_TAGS.filter(
+  (tag) => !MAIN_TAGS.includes(tag),
+)
+const sort = <T>(a: readonly T[]): readonly T[] => [...a].sort()
+const DEFAULT_SELECTED_TAGS: readonly TechTag[] = [
+  LANGUAGE_TAG,
+  FRAMEWORK_TAG,
+  CLOUD_TAG,
+  CICD_TAG,
+  BUILD_TAG,
+  MONITORING_TAG,
+  QUEUING_TAG,
+  PAYMENTS_TAG,
+  RUNTIME_TAG,
+  DATABASE_TAG,
+  PLATFORM_TAG,
+]

--- a/src/app/resume-page/tech-stack-section/tech-stack-section.component.ts
+++ b/src/app/resume-page/tech-stack-section/tech-stack-section.component.ts
@@ -2,11 +2,15 @@ import { Component } from '@angular/core'
 import { SectionTitleComponent } from '../section-title/section-title.component'
 import { FilteredTechsComponent } from './filtered-techs/filtered-techs.component'
 import { BACKEND_TAG, FRONTEND_TAG, INFRA_TAG } from './tags'
+import { TechTagsSelectorComponent } from './tech-tags-selector/tech-tags-selector.component'
 
 @Component({
   selector: 'app-tech-stack-section',
-  standalone: true,
-  imports: [SectionTitleComponent, FilteredTechsComponent],
+  imports: [
+    SectionTitleComponent,
+    FilteredTechsComponent,
+    TechTagsSelectorComponent,
+  ],
   templateUrl: './tech-stack-section.component.html',
   styleUrl: './tech-stack-section.component.scss',
 })

--- a/src/app/resume-page/tech-stack-section/tech-stack-section.component.ts
+++ b/src/app/resume-page/tech-stack-section/tech-stack-section.component.ts
@@ -8,7 +8,6 @@ import { SectionTitleComponent } from '../section-title/section-title.component'
 import { FilteredTechsComponent } from './filtered-techs/filtered-techs.component'
 import {
   BACKEND_TAG,
-  BUILD_TAG,
   CICD_TAG,
   CLOUD_TAG,
   DATABASE_TAG,
@@ -17,6 +16,7 @@ import {
   INFRA_TAG,
   LANGUAGE_TAG,
   MONITORING_TAG,
+  PACKAGING_TAG,
   PAYMENTS_TAG,
   PLATFORM_TAG,
   QUEUING_TAG,
@@ -75,11 +75,11 @@ const DEFAULT_SELECTED_TAGS: readonly TechTag[] = [
   FRAMEWORK_TAG,
   CLOUD_TAG,
   CICD_TAG,
-  BUILD_TAG,
   MONITORING_TAG,
   QUEUING_TAG,
   PAYMENTS_TAG,
   RUNTIME_TAG,
   DATABASE_TAG,
   PLATFORM_TAG,
+  PACKAGING_TAG,
 ]

--- a/src/app/resume-page/tech-stack-section/tech-stack-section.component.ts
+++ b/src/app/resume-page/tech-stack-section/tech-stack-section.component.ts
@@ -1,7 +1,20 @@
-import { Component } from '@angular/core'
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  signal,
+} from '@angular/core'
 import { SectionTitleComponent } from '../section-title/section-title.component'
 import { FilteredTechsComponent } from './filtered-techs/filtered-techs.component'
-import { BACKEND_TAG, FRONTEND_TAG, INFRA_TAG } from './tags'
+import {
+  BACKEND_TAG,
+  FRONTEND_TAG,
+  INFRA_TAG,
+  LANGUAGE_TAG,
+  TagChar,
+  TAGS,
+  TechTag,
+} from './tags'
 import { TechTagsSelectorComponent } from './tech-tags-selector/tech-tags-selector.component'
 
 @Component({
@@ -13,9 +26,28 @@ import { TechTagsSelectorComponent } from './tech-tags-selector/tech-tags-select
   ],
   templateUrl: './tech-stack-section.component.html',
   styleUrl: './tech-stack-section.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class TechStackSectionComponent {
-  protected readonly _backendTag = BACKEND_TAG
-  protected readonly _frontendTag = FRONTEND_TAG
-  protected readonly _infraTag = INFRA_TAG
+  protected readonly _selectableTags = [...REST_TAGS]
+  protected _selectedTags = signal<readonly TechTag[]>([
+    ...DEFAULT_SELECTED_TAGS,
+  ])
+  protected readonly _techSelections = computed<readonly TechSelection[]>(() =>
+    MAIN_TAGS.map((main) => ({
+      main,
+      include: this._selectedTags().map((tag) => tag.char),
+      exclude: main === BACKEND_TAG ? [INFRA_TAG.char] : [],
+    })),
+  )
 }
+
+interface TechSelection {
+  main: TechTag
+  include: readonly TagChar[]
+  exclude: readonly TagChar[]
+}
+
+const MAIN_TAGS = [BACKEND_TAG, FRONTEND_TAG, INFRA_TAG]
+const REST_TAGS = TAGS.filter((tag) => !MAIN_TAGS.includes(tag))
+const DEFAULT_SELECTED_TAGS = [LANGUAGE_TAG]

--- a/src/app/resume-page/tech-stack-section/tech-stack-section.component.ts
+++ b/src/app/resume-page/tech-stack-section/tech-stack-section.component.ts
@@ -22,6 +22,8 @@ import {
   QUEUING_TAG,
   RUNTIME_TAG,
   TECH_TAGS,
+  TECHS_BY_TAG,
+  TECHS_TAGS,
   TechTag,
 } from './tags'
 import { TechTagsSelectorComponent } from './tech-tags-selector/tech-tags-selector.component'
@@ -38,7 +40,15 @@ import { TechTagsSelectorComponent } from './tech-tags-selector/tech-tags-select
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class TechStackSectionComponent {
-  protected readonly _selectableTags = sort([...REST_TAGS])
+  protected readonly _selectableTags = sort([
+    ...REST_TAGS.filter((tag) =>
+      // 👇 Techs using that tag have to be at least frontend, backend or infra.
+      //    Otherwise, they won't ever appear anyway
+      TECHS_BY_TAG[tag].some((tech) =>
+        TECHS_TAGS[tech].some((techTag) => MAIN_TAGS.includes(techTag)),
+      ),
+    ),
+  ])
   protected _selectedTags = signal<readonly TechTag[]>(DEFAULT_SELECTED_TAGS)
   protected readonly _techSelections = computed<readonly TechSelection[]>(() =>
     MAIN_TAGS.map((main) => ({

--- a/src/app/resume-page/tech-stack-section/tech-tags-selector/tech-tags-selector.component.html
+++ b/src/app/resume-page/tech-stack-section/tech-tags-selector/tech-tags-selector.component.html
@@ -1,0 +1,11 @@
+@for (tag of available(); track tag) {
+  @let selected = isSelected(tag);
+  <label>
+    <input
+      type="checkbox"
+      [checked]="selected"
+      (change)="selected ? unselectTag(tag) : selectTag(tag)"
+    />
+    {{ tag.name }}
+  </label>
+}

--- a/src/app/resume-page/tech-stack-section/tech-tags-selector/tech-tags-selector.component.html
+++ b/src/app/resume-page/tech-stack-section/tech-tags-selector/tech-tags-selector.component.html
@@ -6,6 +6,6 @@
       [checked]="selected"
       (change)="selected ? unselectTag(tag) : selectTag(tag)"
     />
-    {{ tag.name }}
+    {{ _getTagName(tag) }}
   </label>
 }

--- a/src/app/resume-page/tech-stack-section/tech-tags-selector/tech-tags-selector.component.html
+++ b/src/app/resume-page/tech-stack-section/tech-tags-selector/tech-tags-selector.component.html
@@ -1,7 +1,9 @@
 @for (tag of available(); track tag) {
   @let selected = isSelected(tag);
   <label>
+    <!-- Adding name so that browser doesn't complain in a DevTools issue about unnamed inputs that prevent autofill -->
     <input
+      name="selectedTags[]"
       type="checkbox"
       [checked]="selected"
       (change)="selected ? unselectTag(tag) : selectTag(tag)"

--- a/src/app/resume-page/tech-stack-section/tech-tags-selector/tech-tags-selector.component.scss
+++ b/src/app/resume-page/tech-stack-section/tech-tags-selector/tech-tags-selector.component.scss
@@ -3,6 +3,7 @@
 
 :host {
   display: flex;
+  flex-wrap: wrap;
   gap: margins.$m;
   padding: paddings.$s paddings.$l;
 }

--- a/src/app/resume-page/tech-stack-section/tech-tags-selector/tech-tags-selector.component.scss
+++ b/src/app/resume-page/tech-stack-section/tech-tags-selector/tech-tags-selector.component.scss
@@ -1,0 +1,57 @@
+@use 'margins';
+@use 'paddings';
+
+:host {
+  display: flex;
+  gap: margins.$m;
+  padding: paddings.$s paddings.$l;
+}
+
+label {
+  display: flex;
+  align-items: center;
+  gap: margins.$xs;
+}
+
+input[type='checkbox'] {
+  height: 12px;
+  width: 12px;
+  position: relative;
+  outline: none;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: var(--sys-color-cdt-base-container);
+  accent-color: var(--sys-color-primary-bright);
+  color: var(--sys-color-on-primary);
+
+  &::placeholder {
+    color: var(--override-input-placeholder-color);
+  }
+
+  &:not(:checked)::before {
+    //background-color: antiquewhite;
+    //content: '';
+    //position: absolute;
+    //width: 12px;
+    //height: 12px;
+    //border-radius: 3px;
+    //padding: 1px;
+  }
+
+  &:hover::after,
+  &:active::before {
+    content: '';
+    height: 24px;
+    width: 24px;
+    border-radius: var(--sys-shape-corner-full);
+    position: absolute;
+  }
+
+  &:not(:disabled):hover::after {
+    background-color: var(--sys-color-state-hover-on-subtle);
+  }
+  &:not(:disabled):active::before {
+    background-color: var(--sys-color-state-ripple-neutral-on-subtle);
+  }
+}

--- a/src/app/resume-page/tech-stack-section/tech-tags-selector/tech-tags-selector.component.scss
+++ b/src/app/resume-page/tech-stack-section/tech-tags-selector/tech-tags-selector.component.scss
@@ -1,5 +1,6 @@
 @use 'margins';
 @use 'paddings';
+@use 'touch-or-pointer';
 
 :host {
   display: flex;
@@ -15,38 +16,39 @@ label {
 }
 
 input[type='checkbox'] {
-  height: 12px;
-  width: 12px;
+  $size: 12px;
+  height: $size;
+  width: $size;
   position: relative;
   outline: none;
   display: flex;
   align-items: center;
   justify-content: center;
+
   background-color: var(--sys-color-cdt-base-container);
   accent-color: var(--sys-color-primary-bright);
   color: var(--sys-color-on-primary);
 
-  &::placeholder {
-    color: var(--override-input-placeholder-color);
-  }
-
+  // TODO: find out Chromium's dark mode unchecked colour
   &:not(:checked)::before {
-    //background-color: antiquewhite;
     //content: '';
-    //position: absolute;
-    //width: 12px;
-    //height: 12px;
-    //border-radius: 3px;
-    //padding: 1px;
+    //background-color: antiquewhite;
+    position: absolute;
+    width: $size;
+    height: $size;
+    border-radius: 3px;
+    padding: 1px;
   }
 
-  &:hover::after,
-  &:active::before {
-    content: '';
-    height: 24px;
-    width: 24px;
-    border-radius: var(--sys-shape-corner-full);
-    position: absolute;
+  @include touch-or-pointer.primaryInputCanHover {
+    &:hover::after,
+    &:active::before {
+      content: '';
+      height: 2 * $size;
+      width: 2 * $size;
+      border-radius: var(--sys-shape-corner-full);
+      position: absolute;
+    }
   }
 
   &:not(:disabled):hover::after {

--- a/src/app/resume-page/tech-stack-section/tech-tags-selector/tech-tags-selector.component.scss
+++ b/src/app/resume-page/tech-stack-section/tech-tags-selector/tech-tags-selector.component.scss
@@ -30,6 +30,8 @@ input[type='checkbox'] {
 
   @include animations.single-transition(accent-color);
 
+  // Unchecked accent color in dark mode is different for Chromium's internal
+  // UI and Chromium's rendered HTML checkboxes. Mimicking Chromium's UI here.
   &:not(:checked)::before {
     content: '';
     background-color: var(--unchecked-checkbox-accent);

--- a/src/app/resume-page/tech-stack-section/tech-tags-selector/tech-tags-selector.component.scss
+++ b/src/app/resume-page/tech-stack-section/tech-tags-selector/tech-tags-selector.component.scss
@@ -1,6 +1,7 @@
 @use 'margins';
 @use 'paddings';
 @use 'touch-or-pointer';
+@use 'animations';
 
 :host {
   display: flex;
@@ -25,19 +26,20 @@ input[type='checkbox'] {
   align-items: center;
   justify-content: center;
 
-  background-color: var(--sys-color-cdt-base-container);
   accent-color: var(--sys-color-primary-bright);
-  color: var(--sys-color-on-primary);
 
-  // TODO: find out Chromium's dark mode unchecked colour
+  @include animations.single-transition(accent-color);
+
   &:not(:checked)::before {
-    //content: '';
-    //background-color: antiquewhite;
+    content: '';
+    background-color: var(--unchecked-checkbox-accent);
     position: absolute;
     width: $size;
     height: $size;
+    border-width: 1px;
+    border-style: solid;
+    border-color: var(--unchecked-checkbox-border);
     border-radius: 3px;
-    padding: 1px;
   }
 
   @include touch-or-pointer.primaryInputCanHover {
@@ -56,5 +58,10 @@ input[type='checkbox'] {
   }
   &:not(:disabled):active::before {
     background-color: var(--sys-color-state-ripple-neutral-on-subtle);
+  }
+
+  &::before,
+  &::after {
+    @include animations.multiple-transitions((background-color, border-color));
   }
 }

--- a/src/app/resume-page/tech-stack-section/tech-tags-selector/tech-tags-selector.component.spec.ts
+++ b/src/app/resume-page/tech-stack-section/tech-tags-selector/tech-tags-selector.component.spec.ts
@@ -1,0 +1,126 @@
+import { Component } from '@angular/core'
+import { TechTagsSelectorComponent } from './tech-tags-selector.component'
+import { REST_TAGS, TechTag } from '../tags'
+import { By } from '@angular/platform-browser'
+import { textContent } from '@/test/helpers/text-content'
+import { componentTestSetup } from '@/test/helpers/component-test-setup'
+
+describe('TechTagsSelectorComponent', () => {
+  it('should create', () => {
+    expect(makeSut()[1]).toBeTruthy()
+  })
+
+  it('should display all available tags as checkboxes', () => {
+    const [fixture] = makeSut()
+    fixture.detectChanges()
+
+    const labels = fixture.debugElement.queryAll(By.css('label'))
+    const checkboxes = fixture.debugElement.queryAll(
+      By.css('input[type="checkbox"]'),
+    )
+
+    expect(labels.length)
+      .withContext('As many labels as available tags')
+      .toBe(AVAILABLE_TAGS.length)
+
+    expect(checkboxes.length)
+      .withContext('As many checkboxes as available tags')
+      .toBe(AVAILABLE_TAGS.length)
+
+    AVAILABLE_TAGS.forEach((tag, index) => {
+      const label = labels.at(index)!
+
+      expect(label).withContext(`Label for ${tag.name} not found`).toBeTruthy()
+      expect(textContent(label)).toEqual(tag.name)
+
+      expect(checkboxes.at(index))
+        .withContext(`Checkbox for ${tag.name} not found`)
+        .toBeTruthy()
+    })
+  })
+
+  it('should initially display selected tags', () => {
+    const selected = [A_TAG]
+    const [fixture] = makeSut({ selected })
+    fixture.detectChanges()
+
+    const labels = fixture.debugElement.queryAll(By.css('label'))
+    const checkboxes = fixture.debugElement.queryAll(
+      By.css('input[type="checkbox"]'),
+    )
+    labels.forEach((label, index) => {
+      const shouldBeSelected = selected
+        .map((tag) => tag.name)
+        .includes(textContent(label)!)
+      const checkbox = checkboxes.at(index)
+
+      expect((checkbox!.nativeElement as HTMLInputElement).checked)
+        .withContext(`Checkbox ${index} checked`)
+        .toBe(shouldBeSelected)
+    })
+  })
+
+  it('should select a tag when its unchecked checkbox is checked', () => {
+    const unselectedTag = A_TAG
+    const [fixture, component] = makeSut({ selected: [] })
+    fixture.detectChanges()
+
+    const labels = fixture.debugElement.queryAll(By.css('label'))
+    const unselectedLabel = labels.find(
+      (label) => textContent(label) === unselectedTag.name,
+    )
+    const unselectedCheckbox = unselectedLabel!.query(
+      By.css('input[type="checkbox"]'),
+    )
+
+    expect((unselectedCheckbox.nativeElement as HTMLInputElement).checked)
+      .withContext('Checkbox should be unchecked')
+      .toBeFalse()
+
+    unselectedCheckbox.triggerEventHandler('change')
+    fixture.detectChanges()
+
+    expect(component.selected).toEqual([unselectedTag])
+  })
+
+  it('should unselect a tag when its checked checkbox is unchecked', () => {
+    const selectedTag = A_TAG
+    const [fixture, component] = makeSut({ selected: [selectedTag] })
+    fixture.detectChanges()
+
+    const labels = fixture.debugElement.queryAll(By.css('label'))
+    const selectedLabel = labels.find(
+      (label) => textContent(label) === selectedTag.name,
+    )
+    const selectedCheckbox = selectedLabel!.query(
+      By.css('input[type="checkbox"]'),
+    )
+
+    expect((selectedCheckbox.nativeElement as HTMLInputElement).checked)
+      .withContext('Checkbox should be checked')
+      .toBeTrue()
+
+    selectedCheckbox.triggerEventHandler('change')
+    fixture.detectChanges()
+
+    expect(component.selected).toEqual([])
+  })
+})
+
+const [A_TAG, ANOTHER_TAG] = [...REST_TAGS]
+const AVAILABLE_TAGS = [A_TAG, ANOTHER_TAG]
+
+const makeSut = (opts: { selected?: readonly TechTag[] } = {}) => {
+  @Component({
+    template: `
+      <app-tech-tags-selector [available]="_available" [(selected)]="selected">
+      </app-tech-tags-selector>
+    `,
+    imports: [TechTagsSelectorComponent],
+  })
+  class HostComponent {
+    selected = opts.selected ?? []
+    protected readonly _available = AVAILABLE_TAGS
+  }
+  return componentTestSetup(HostComponent)
+}

--- a/src/app/resume-page/tech-stack-section/tech-tags-selector/tech-tags-selector.component.spec.ts
+++ b/src/app/resume-page/tech-stack-section/tech-tags-selector/tech-tags-selector.component.spec.ts
@@ -1,6 +1,6 @@
 import { Component } from '@angular/core'
 import { TechTagsSelectorComponent } from './tech-tags-selector.component'
-import { REST_TAGS, TechTag } from '../tags'
+import { LANGUAGE_TAG, TechTag, TEST_TAG } from '../tags'
 import { By } from '@angular/platform-browser'
 import { textContent } from '@/test/helpers/text-content'
 import { componentTestSetup } from '@/test/helpers/component-test-setup'
@@ -107,7 +107,7 @@ describe('TechTagsSelectorComponent', () => {
   })
 })
 
-const [A_TAG, ANOTHER_TAG] = [...REST_TAGS]
+const [A_TAG, ANOTHER_TAG] = [LANGUAGE_TAG, TEST_TAG]
 const AVAILABLE_TAGS = [A_TAG, ANOTHER_TAG]
 
 const makeSut = (opts: { selected?: readonly TechTag[] } = {}) => {

--- a/src/app/resume-page/tech-stack-section/tech-tags-selector/tech-tags-selector.component.spec.ts
+++ b/src/app/resume-page/tech-stack-section/tech-tags-selector/tech-tags-selector.component.spec.ts
@@ -1,6 +1,6 @@
 import { Component } from '@angular/core'
 import { TechTagsSelectorComponent } from './tech-tags-selector.component'
-import { LANGUAGE_TAG, TechTag, TEST_TAG } from '../tags'
+import { getTechTagName, LANGUAGE_TAG, TechTag, TEST_TAG } from '../tags'
 import { By } from '@angular/platform-browser'
 import { textContent } from '@/test/helpers/text-content'
 import { componentTestSetup } from '@/test/helpers/component-test-setup'
@@ -30,11 +30,11 @@ describe('TechTagsSelectorComponent', () => {
     AVAILABLE_TAGS.forEach((tag, index) => {
       const label = labels.at(index)!
 
-      expect(label).withContext(`Label for ${tag.name} not found`).toBeTruthy()
-      expect(textContent(label)).toEqual(tag.name)
+      expect(label).withContext(`Label for ${tag} not found`).toBeTruthy()
+      expect(textContent(label)).toEqual(getTechTagName(tag))
 
       expect(checkboxes.at(index))
-        .withContext(`Checkbox for ${tag.name} not found`)
+        .withContext(`Checkbox for ${tag} not found`)
         .toBeTruthy()
     })
   })
@@ -50,7 +50,7 @@ describe('TechTagsSelectorComponent', () => {
     )
     labels.forEach((label, index) => {
       const shouldBeSelected = selected
-        .map((tag) => tag.name)
+        .map((tag) => getTechTagName(tag))
         .includes(textContent(label)!)
       const checkbox = checkboxes.at(index)
 
@@ -67,7 +67,7 @@ describe('TechTagsSelectorComponent', () => {
 
     const labels = fixture.debugElement.queryAll(By.css('label'))
     const unselectedLabel = labels.find(
-      (label) => textContent(label) === unselectedTag.name,
+      (label) => textContent(label) === getTechTagName(unselectedTag),
     )
     const unselectedCheckbox = unselectedLabel!.query(
       By.css('input[type="checkbox"]'),
@@ -90,7 +90,7 @@ describe('TechTagsSelectorComponent', () => {
 
     const labels = fixture.debugElement.queryAll(By.css('label'))
     const selectedLabel = labels.find(
-      (label) => textContent(label) === selectedTag.name,
+      (label) => textContent(label) === getTechTagName(selectedTag),
     )
     const selectedCheckbox = selectedLabel!.query(
       By.css('input[type="checkbox"]'),
@@ -107,8 +107,8 @@ describe('TechTagsSelectorComponent', () => {
   })
 })
 
-const [A_TAG, ANOTHER_TAG] = [LANGUAGE_TAG, TEST_TAG]
-const AVAILABLE_TAGS = [A_TAG, ANOTHER_TAG]
+const [A_TAG, ANOTHER_TAG] = [LANGUAGE_TAG, TEST_TAG] as const
+const AVAILABLE_TAGS: readonly TechTag[] = [A_TAG, ANOTHER_TAG]
 
 const makeSut = (opts: { selected?: readonly TechTag[] } = {}) => {
   @Component({

--- a/src/app/resume-page/tech-stack-section/tech-tags-selector/tech-tags-selector.component.ts
+++ b/src/app/resume-page/tech-stack-section/tech-tags-selector/tech-tags-selector.component.ts
@@ -1,0 +1,36 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  input,
+  output,
+} from '@angular/core'
+import { REST_TAGS, TechTag } from '../tags' // Assuming '@/data/tags' is the correct path
+
+@Component({
+  selector: 'app-tech-tags-selector',
+  templateUrl: './tech-tags-selector.component.html',
+  styleUrl: './tech-tags-selector.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class TechTagsSelectorComponent {
+  available = input<readonly TechTag[]>(REST_TAGS)
+  selected = input<readonly TechTag[]>([])
+  selectedChange = output<readonly TechTag[]>()
+
+  selectTag(tag: TechTag): void {
+    if (this.isSelected(tag)) return
+    this.selectedChange.emit([...this.selected(), tag])
+  }
+
+  unselectTag(tag: TechTag): void {
+    const index = this.selected().findIndex((t) => t.char === tag.char)
+    if (index === -1) return
+    const selected = [...this.selected()]
+    selected.splice(index, 1)
+    this.selectedChange.emit(selected) // Emit the intended new selection
+  }
+
+  isSelected(tag: TechTag): boolean {
+    return this.selected().some((t) => t.char === tag.char)
+  }
+}

--- a/src/app/resume-page/tech-stack-section/tech-tags-selector/tech-tags-selector.component.ts
+++ b/src/app/resume-page/tech-stack-section/tech-tags-selector/tech-tags-selector.component.ts
@@ -20,12 +20,14 @@ export class TechTagsSelectorComponent {
   protected _getTagName = getTechTagName
 
   selectTag(tag: TechTag): void {
+    /* istanbul ignore next - Shouldn't happen */
     if (this.isSelected(tag)) return
     this.selectedChange.emit([...this.selected(), tag])
   }
 
   unselectTag(tag: TechTag): void {
     const index = this.selected().findIndex((t) => t === tag)
+    /* istanbul ignore next - Shouldn't happen */
     if (index === -1) return
     const selected = [...this.selected()]
     selected.splice(index, 1)

--- a/src/app/resume-page/tech-stack-section/tech-tags-selector/tech-tags-selector.component.ts
+++ b/src/app/resume-page/tech-stack-section/tech-tags-selector/tech-tags-selector.component.ts
@@ -4,7 +4,7 @@ import {
   input,
   output,
 } from '@angular/core'
-import { REST_TAGS, TechTag } from '../tags' // Assuming '@/data/tags' is the correct path
+import { TechTag } from '../tags' // Assuming '@/data/tags' is the correct path
 
 @Component({
   selector: 'app-tech-tags-selector',
@@ -13,7 +13,7 @@ import { REST_TAGS, TechTag } from '../tags' // Assuming '@/data/tags' is the co
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class TechTagsSelectorComponent {
-  available = input<readonly TechTag[]>(REST_TAGS)
+  available = input.required<readonly TechTag[]>()
   selected = input<readonly TechTag[]>([])
   selectedChange = output<readonly TechTag[]>()
 

--- a/src/app/resume-page/tech-stack-section/tech-tags-selector/tech-tags-selector.component.ts
+++ b/src/app/resume-page/tech-stack-section/tech-tags-selector/tech-tags-selector.component.ts
@@ -4,7 +4,7 @@ import {
   input,
   output,
 } from '@angular/core'
-import { TechTag } from '../tags' // Assuming '@/data/tags' is the correct path
+import { getTechTagName, TechTag } from '../tags' // Assuming '@/data/tags' is the correct path
 
 @Component({
   selector: 'app-tech-tags-selector',
@@ -17,13 +17,15 @@ export class TechTagsSelectorComponent {
   selected = input<readonly TechTag[]>([])
   selectedChange = output<readonly TechTag[]>()
 
+  protected _getTagName = getTechTagName
+
   selectTag(tag: TechTag): void {
     if (this.isSelected(tag)) return
     this.selectedChange.emit([...this.selected(), tag])
   }
 
   unselectTag(tag: TechTag): void {
-    const index = this.selected().findIndex((t) => t.char === tag.char)
+    const index = this.selected().findIndex((t) => t === tag)
     if (index === -1) return
     const selected = [...this.selected()]
     selected.splice(index, 1)
@@ -31,6 +33,6 @@ export class TechTagsSelectorComponent {
   }
 
   isSelected(tag: TechTag): boolean {
-    return this.selected().some((t) => t.char === tag.char)
+    return this.selected().some((t) => t === tag)
   }
 }

--- a/src/sass/themes/_devtools-common-scheme.scss
+++ b/src/sass/themes/_devtools-common-scheme.scss
@@ -31,5 +31,7 @@ $scheme: (
     ui-text: var(--sys-color-on-surface-subtle),
     // https://github.com/ChromeDevTools/devtools-frontend/blob/0f87a613d3894a26da7d14ae48e3c3804eeb3293/front_end/application_tokens.css#L54
     text-primary: var(--sys-color-on-surface),
+    // https://github.com/ChromeDevTools/devtools-frontend/blob/0f87a613d3894a26da7d14ae48e3c3804eeb3293/front_end/design_system_tokens.css#L568C1-L569C1
+    sys-shape-corner-full: 9999px,
   ),
 );

--- a/src/sass/themes/_devtools-common-scheme.scss
+++ b/src/sass/themes/_devtools-common-scheme.scss
@@ -14,6 +14,7 @@ $scheme: (
     ref-palette-secondary50: #047db7ff,
     ref-palette-neutral10: #1f1f1fff,
     ref-palette-neutral15: #282828ff,
+    ref-palette-neutral22: #343535ff,
     ref-palette-neutral25: #3c3c3cff,
     ref-palette-neutral30: #474747ff,
     ref-palette-neutral40: #5e5e5eff,

--- a/src/sass/themes/_devtools-dark-scheme.scss
+++ b/src/sass/themes/_devtools-dark-scheme.scss
@@ -77,5 +77,10 @@ $scheme: (
     adorner-border-color: var(--sys-color-tonal-outline),
     img-filter: grayscale(0.5),
     background-fg-color: var(--ref-palette-neutral25),
+    //👇 It's not the same in rendered HTML than in Chromium's UI. Same for DevTools.
+    //   Found it by using color picker #343434 and choosing a similar one.
+    unchecked-checkbox-accent: var(--ref-palette-neutral22),
+    //👇 It's actually #7a7a7a. But quite close.
+    unchecked-checkbox-border: var(--ref-palette-neutral50),
   ),
 );

--- a/src/sass/themes/_devtools-dark-scheme.scss
+++ b/src/sass/themes/_devtools-dark-scheme.scss
@@ -49,7 +49,12 @@ $scheme: (
     // https://github.com/ChromeDevTools/devtools-frontend/blob/0f87a613d3894a26da7d14ae48e3c3804eeb3293/front_end/design_system_tokens.css#L286-L287
     sys-color-tonal-outline: var(--ref-palette-secondary50),
     sys-color-neutral-outline: var(--ref-palette-neutral50),
-    // https://github.com/ChromeDevTools/devtools-frontend/blob/0f87a613d3894a26da7d14ae48e3c3804eeb3293/front_end/design_system_tokens.css#L296
+    // https://github.com/ChromeDevTools/devtools-frontend/blob/0f87a613d3894a26da7d14ae48e3c3804eeb3293/front_end/design_system_tokens.css#L297-L298
+    sys-color-state-hover-on-subtle: color-mix(
+        in srgb,
+        var(--ref-palette-neutral99) 10%,
+        transparent
+      ),
     sys-color-state-hover-on-prominent: color-mix(
         in sRGB,
         var(--ref-palette-neutral10) 6%,
@@ -57,9 +62,19 @@ $scheme: (
       ),
     // https://github.com/ChromeDevTools/devtools-frontend/blob/0f87a613d3894a26da7d14ae48e3c3804eeb3293/front_end/design_system_tokens.css#L298
     sys-color-state-hover-dim-blend-protection: rgb(31 31 31/10%),
+    // https://github.com/ChromeDevTools/devtools-frontend/blob/0f87a613d3894a26da7d14ae48e3c3804eeb3293/front_end/design_system_tokens.css#L301
+    sys-color-state-ripple-neutral-on-subtle: color-mix(
+        in srgb,
+        var(--ref-palette-neutral99) 16%,
+        transparent
+      ),
+    // https://github.com/ChromeDevTools/devtools-frontend/blob/0f87a613d3894a26da7d14ae48e3c3804eeb3293/front_end/design_system_tokens.css#L328
+    sys-color-primary-bright: var(--ref-palette-primary70),
     //👇 App tokens
     // https://github.com/ChromeDevTools/devtools-frontend/blob/0f87a613d3894a26da7d14ae48e3c3804eeb3293/front_end/application_tokens.css#L371
     app-color-toolbar-background: var(--sys-color-base),
+    // https://github.com/ChromeDevTools/devtools-frontend/blob/0f87a613d3894a26da7d14ae48e3c3804eeb3293/front_end/ui/legacy/inspectorCommon.css#L222
+    override-input-placeholder-color: rgb(230 230 230 / 54%),
     //👇 App specific
     adorner-border-color: var(--sys-color-tonal-outline),
     img-filter: grayscale(0.5),

--- a/src/sass/themes/_devtools-dark-scheme.scss
+++ b/src/sass/themes/_devtools-dark-scheme.scss
@@ -73,8 +73,6 @@ $scheme: (
     //👇 App tokens
     // https://github.com/ChromeDevTools/devtools-frontend/blob/0f87a613d3894a26da7d14ae48e3c3804eeb3293/front_end/application_tokens.css#L371
     app-color-toolbar-background: var(--sys-color-base),
-    // https://github.com/ChromeDevTools/devtools-frontend/blob/0f87a613d3894a26da7d14ae48e3c3804eeb3293/front_end/ui/legacy/inspectorCommon.css#L222
-    override-input-placeholder-color: rgb(230 230 230 / 54%),
     //👇 App specific
     adorner-border-color: var(--sys-color-tonal-outline),
     img-filter: grayscale(0.5),

--- a/src/sass/themes/_devtools-light-scheme.scss
+++ b/src/sass/themes/_devtools-light-scheme.scss
@@ -75,5 +75,9 @@ $scheme: (
     adorner-border-color: var(--sys-color-neutral-outline),
     img-filter: none,
     background-fg-color: var(--ref-palette-neutral95),
+    // See dark to see how this colour was found. In this case, colour is exact same.
+    unchecked-checkbox-accent: var(--ref-palette-neutral100),
+    //👇 It's actually #6b6b6b. But quite close.
+    unchecked-checkbox-border: var(--ref-palette-neutral50),
   ),
 );

--- a/src/sass/themes/_devtools-light-scheme.scss
+++ b/src/sass/themes/_devtools-light-scheme.scss
@@ -71,8 +71,6 @@ $scheme: (
     // 👇 App tokens
     // https://github.com/ChromeDevTools/devtools-frontend/blob/0f87a613d3894a26da7d14ae48e3c3804eeb3293/front_end/application_tokens.css#L186
     app-color-toolbar-background: var(--sys-color-surface4),
-    // https://github.com/ChromeDevTools/devtools-frontend/blob/0f87a613d3894a26da7d14ae48e3c3804eeb3293/front_end/ui/legacy/inspectorCommon.css#L215
-    override-input-placeholder-color: rgb(0 0 0 / 54%),
     // 👇 Specific to this app
     adorner-border-color: var(--sys-color-neutral-outline),
     img-filter: none,

--- a/src/sass/themes/_devtools-light-scheme.scss
+++ b/src/sass/themes/_devtools-light-scheme.scss
@@ -22,8 +22,21 @@ $scheme: (
         var(--ref-palette-neutral99) 10%,
         transparent
       ),
-    // https://github.com/ChromeDevTools/devtools-frontend/blob/0f87a613d3894a26da7d14ae48e3c3804eeb3293/front_end/design_system_tokens.css#L81
+    // https://github.com/ChromeDevTools/devtools-frontend/blob/0f87a613d3894a26da7d14ae48e3c3804eeb3293/front_end/design_system_tokens.css#L80-81
+    sys-color-state-hover-on-subtle: color-mix(
+        in srgb,
+        var(--ref-palette-neutral10) 6%,
+        transparent
+      ),
     sys-color-state-hover-dim-blend-protection: rgb(6 46 111/18%),
+    // https://github.com/ChromeDevTools/devtools-frontend/blob/0f87a613d3894a26da7d14ae48e3c3804eeb3293/front_end/design_system_tokens.css#L84
+    sys-color-state-ripple-neutral-on-subtle: color-mix(
+        in srgb,
+        var(--ref-palette-neutral10) 8%,
+        transparent
+      ),
+    // https://github.com/ChromeDevTools/devtools-frontend/blob/0f87a613d3894a26da7d14ae48e3c3804eeb3293/front_end/design_system_tokens.css#L112
+    sys-color-primary-bright: var(--ref-palette-primary50),
     // 👇 Baseline grayscale
     //    https://github.com/ChromeDevTools/devtools-frontend/blob/0f87a613d3894a26da7d14ae48e3c3804eeb3293/front_end/design_system_tokens.css#L202-L207
     sys-color-divider: var(--ref-palette-neutral90),
@@ -58,6 +71,8 @@ $scheme: (
     // 👇 App tokens
     // https://github.com/ChromeDevTools/devtools-frontend/blob/0f87a613d3894a26da7d14ae48e3c3804eeb3293/front_end/application_tokens.css#L186
     app-color-toolbar-background: var(--sys-color-surface4),
+    // https://github.com/ChromeDevTools/devtools-frontend/blob/0f87a613d3894a26da7d14ae48e3c3804eeb3293/front_end/ui/legacy/inspectorCommon.css#L215
+    override-input-placeholder-color: rgb(0 0 0 / 54%),
     // 👇 Specific to this app
     adorner-border-color: var(--sys-color-neutral-outline),
     img-filter: none,


### PR DESCRIPTION
So that just relevant technologies are shown by default, but others can be displayed if needed.

Tags have been changed from being a single character to multiple chars, as started to be confusing. 

Mimicks DevTools checkboxes style. In dark mode, the style has been added manually. As the default user agent style differs in DevTools and in the site. The accent color (box background colour) of the checkbox is gray in Chromium's DevTools and general UI (like in "Report an issue" checkbox). But is white by default when rendered in a site. 

Ruby has been added as programming language.

Tags have been refined many times until a subjectively accurate default selection is shown.

Also adds animation to panel border colours of tech stack section

