### PR TITLE
fix: keep background whitespaces

### DIFF
--- a/src/app/background/background.component.scss
+++ b/src/app/background/background.component.scss
@@ -15,11 +15,11 @@ svg {
 
 svg {
   font-size: 16px;
+  @include typographies.monospace-font;
 
-  pattern {
+  text {
     white-space: pre;
     fill: var(--background-fg-color);
-    @include typographies.monospace-font;
     @include animations.when-motion {
       @include animations.single-transition(fill, animations.$emphasized-style);
     }

--- a/src/app/background/background.component.spec.ts
+++ b/src/app/background/background.component.spec.ts
@@ -28,11 +28,8 @@ describe('BackgroundComponent', () => {
 
     const lastSvgTspan = svgPattern.query(By.css('tspan:last-child'))
       .nativeElement as SVGTSpanElement
-    const {
-      width: expectedWidth,
-      height: lineHeight,
-      y,
-    } = lastSvgTspan.getBBox()
+    const lastSvgTspanBbox = lastSvgTspan.getBBox()
+    const expectedWidth = Math.floor(lastSvgTspanBbox.width)
 
     expect(expectedWidth)
       .withContext('text width heuristic')
@@ -47,7 +44,8 @@ describe('BackgroundComponent', () => {
       )
       .toBeTrue()
 
-    const expectedHeight = y + lineHeight + HEIGHT_OFFSET
+    const expectedHeight =
+      lastSvgTspanBbox.y + lastSvgTspanBbox.height + HEIGHT_OFFSET
 
     expect(expectedHeight)
       .withContext('text height heuristic')

--- a/src/app/background/background.component.spec.ts
+++ b/src/app/background/background.component.spec.ts
@@ -26,21 +26,23 @@ describe('BackgroundComponent', () => {
   it("should apply the SVG's text size to the SVG's pattern size", () => {
     const svgPattern = fixture.debugElement.query(By.css('svg pattern'))
 
-    const svgText = svgPattern.query(By.css('text')).nativeElement as Element
-    const textWidth = svgText.clientWidth
+    const lastSvgTspan = svgPattern.query(By.css('tspan:last-child'))
+      .nativeElement as SVGTSpanElement
+    const { width: lineWidth, height: lineHeight, y } = lastSvgTspan.getBBox()
+    const flooredString = (x: number) => Math.floor(x).toString()
 
-    expect(textWidth).withContext('text width heuristic').toBeGreaterThan(100)
+    expect(lineWidth).withContext('text width heuristic').toBeGreaterThan(100)
 
     expect(svgPattern.attributes['width'])
       .withContext('width')
-      .toEqual(textWidth.toString())
+      .toEqual(flooredString(lineWidth))
 
-    const textHeight = svgText.clientHeight
+    const height = y + lineHeight + HEIGHT_OFFSET
 
-    expect(textHeight).withContext('text height heuristic').toBeGreaterThan(100)
+    expect(height).withContext('text height heuristic').toBeGreaterThan(100)
 
     expect(svgPattern.attributes['height'])
       .withContext('height')
-      .toEqual((textHeight + HEIGHT_OFFSET).toString())
+      .toEqual(flooredString(height).toString())
   })
 })

--- a/src/app/background/background.component.spec.ts
+++ b/src/app/background/background.component.spec.ts
@@ -38,9 +38,12 @@ describe('BackgroundComponent', () => {
       .withContext('text width heuristic')
       .toBeGreaterThan(100)
 
-    expect(parseInt(svgPattern.attributes['width']!))
+    //👇 A 1 px variation can exist depending if running on CI/CD or locally
+    const actualWidth = parseInt(svgPattern.attributes['width']!)
+
+    expect(actualWidth - 1 <= expectedWidth && expectedWidth <= actualWidth + 1)
       .withContext('width')
-      .toBe(Math.floor(expectedWidth))
+      .toBeTrue()
 
     const expectedHeight = y + lineHeight + HEIGHT_OFFSET
 
@@ -48,13 +51,8 @@ describe('BackgroundComponent', () => {
       .withContext('text height heuristic')
       .toBeGreaterThan(100)
 
-    const actualHeight = parseInt(svgPattern.attributes['height']!)
-
-    //👇 A 1 px variation can exist depending if running on CI/CD or locally
-    expect(
-      actualHeight - 1 <= expectedHeight && actualHeight <= expectedHeight + 1,
-    )
+    expect(parseInt(svgPattern.attributes['height']!))
       .withContext('height')
-      .toBeTrue()
+      .toBe(expectedHeight)
   })
 })

--- a/src/app/background/background.component.spec.ts
+++ b/src/app/background/background.component.spec.ts
@@ -28,20 +28,33 @@ describe('BackgroundComponent', () => {
 
     const lastSvgTspan = svgPattern.query(By.css('tspan:last-child'))
       .nativeElement as SVGTSpanElement
-    const { width: lineWidth, height: lineHeight, y } = lastSvgTspan.getBBox()
+    const {
+      width: expectedWidth,
+      height: lineHeight,
+      y,
+    } = lastSvgTspan.getBBox()
 
-    expect(lineWidth).withContext('text width heuristic').toBeGreaterThan(100)
+    expect(expectedWidth)
+      .withContext('text width heuristic')
+      .toBeGreaterThan(100)
 
     expect(parseInt(svgPattern.attributes['width']!))
       .withContext('width')
-      .toBeCloseTo(Math.floor(lineWidth), 1.5)
+      .toBe(Math.floor(expectedWidth))
 
-    const height = y + lineHeight + HEIGHT_OFFSET
+    const expectedHeight = y + lineHeight + HEIGHT_OFFSET
 
-    expect(height).withContext('text height heuristic').toBeGreaterThan(100)
+    expect(expectedHeight)
+      .withContext('text height heuristic')
+      .toBeGreaterThan(100)
 
-    expect(parseInt(svgPattern.attributes['height']!))
+    const actualHeight = parseInt(svgPattern.attributes['height']!)
+
+    //👇 A 1 px variation can exist depending if running on CI/CD or locally
+    expect(
+      actualHeight - 1 <= expectedHeight && actualHeight <= expectedHeight + 1,
+    )
       .withContext('height')
-      .toBeCloseTo(Math.floor(height), 1.5)
+      .toBeTrue()
   })
 })

--- a/src/app/background/background.component.spec.ts
+++ b/src/app/background/background.component.spec.ts
@@ -29,20 +29,19 @@ describe('BackgroundComponent', () => {
     const lastSvgTspan = svgPattern.query(By.css('tspan:last-child'))
       .nativeElement as SVGTSpanElement
     const { width: lineWidth, height: lineHeight, y } = lastSvgTspan.getBBox()
-    const flooredString = (x: number) => Math.floor(x).toString()
 
     expect(lineWidth).withContext('text width heuristic').toBeGreaterThan(100)
 
-    expect(svgPattern.attributes['width'])
+    expect(parseInt(svgPattern.attributes['width']!))
       .withContext('width')
-      .toEqual(flooredString(lineWidth))
+      .toBeCloseTo(Math.floor(lineWidth), 1)
 
     const height = y + lineHeight + HEIGHT_OFFSET
 
     expect(height).withContext('text height heuristic').toBeGreaterThan(100)
 
-    expect(svgPattern.attributes['height'])
+    expect(parseInt(svgPattern.attributes['height']!))
       .withContext('height')
-      .toEqual(flooredString(height).toString())
+      .toBeCloseTo(Math.floor(height), 1)
   })
 })

--- a/src/app/background/background.component.spec.ts
+++ b/src/app/background/background.component.spec.ts
@@ -41,8 +41,10 @@ describe('BackgroundComponent', () => {
     //👇 A 1 px variation can exist depending if running on CI/CD or locally
     const actualWidth = parseInt(svgPattern.attributes['width']!)
 
-    expect(actualWidth - 1 <= expectedWidth && expectedWidth <= actualWidth + 1)
-      .withContext('width')
+    expect(expectedWidth - 1 <= actualWidth && actualWidth <= expectedWidth + 1)
+      .withContext(
+        `actual width ${actualWidth} not into +-1px range of expected width ${expectedWidth}`,
+      )
       .toBeTrue()
 
     const expectedHeight = y + lineHeight + HEIGHT_OFFSET

--- a/src/app/background/background.component.spec.ts
+++ b/src/app/background/background.component.spec.ts
@@ -34,7 +34,7 @@ describe('BackgroundComponent', () => {
 
     expect(parseInt(svgPattern.attributes['width']!))
       .withContext('width')
-      .toBeCloseTo(Math.floor(lineWidth), 1)
+      .toBeCloseTo(Math.floor(lineWidth), 1.5)
 
     const height = y + lineHeight + HEIGHT_OFFSET
 
@@ -42,6 +42,6 @@ describe('BackgroundComponent', () => {
 
     expect(parseInt(svgPattern.attributes['height']!))
       .withContext('height')
-      .toBeCloseTo(Math.floor(height), 1)
+      .toBeCloseTo(Math.floor(height), 1.5)
   })
 })

--- a/src/app/background/background.component.ts
+++ b/src/app/background/background.component.ts
@@ -15,7 +15,7 @@ export class BackgroundComponent {
   //👇 Could be calculated on the client side.
   //   However, this component is part of the largest contentful paint (LCP)
   //   So calculating it in advance. This way, there are no changes when hydrating
-  protected readonly _textSize = { width: 730, height: 288 }
+  protected readonly _textSize = { width: 768, height: 288 }
 }
 
 /**
@@ -54,7 +54,7 @@ const hexdump = (buffer: string) => {
         /[\x00-\x1F\x20\x7F-\x9F]/g,
         '.',
       ) + SPACE.repeat(blockSize - block.length)
-    lines.push(addr + ' ' + codes + '  |' + chars + '|' + '  ')
+    lines.push(addr + codes + '  |' + chars + '|' + '  ')
   }
   return lines.join('\n')
 }


### PR DESCRIPTION
Were not there after fix in #1121 . Moving `white-space: pre` to `text` solved that. Also improved test after asking GenAI how to properly calculate the width and height. `getBBox` was the idea and rest comes from that.

Also removes an extra space in first address / code block separator. This is because the `%8` check that adds 2 spaces.That's enough to separate address from code blocks too (apart from separating code blocks in 8 byte blocks)

Some things tried that didn't work:
 - `getComputedTextLength`. Suggested by AI. Enourmous width that doesn't make any sense at all (13k). Discarded.
 - `getBBox` of `text`: there's somehow more width and more height than expected
 - `getBBox` of `tspan` `height` * amount of lines. Turns out have to count one line less for the height to make more sense. Even then extra height is there.
