### PR TITLE
refactor: move toolbar background and color to toolbar comp

### DIFF
--- a/src/app/header/header.component.html
+++ b/src/app/header/header.component.html
@@ -1,5 +1,5 @@
-<nav appNavigationTabs [items]="_navigationItems"></nav>
-<app-toolbar-divider></app-toolbar-divider>
 <app-toolbar>
+  <nav appNavigationTabs [items]="_navigationItems"></nav>
+  <app-toolbar-divider></app-toolbar-divider>
   <app-light-dark-toggle></app-light-dark-toggle>
 </app-toolbar>

--- a/src/app/header/header.component.scss
+++ b/src/app/header/header.component.scss
@@ -8,19 +8,15 @@
   position: sticky;
   top: 0;
   z-index: z-index.$header;
-  width: 100%;
 
   height: header.$height;
-  display: flex;
-  align-items: center;
   @include borders.panel(bottom);
-  background-color: var(--app-color-toolbar-background);
 
   @include quirks.leftBorderDisappearance;
 
   @include animations.when-motion {
-    @include animations.multiple-transitions(
-      (background-color, border-color),
+    @include animations.single-transition(
+      (border-color),
       animations.$emphasized-style
     );
   }
@@ -30,6 +26,12 @@
   }
 }
 
+app-toolbar {
+  flex-wrap: nowrap;
+  height: 100%;
+}
+
 nav {
+  height: 100%;
   flex-grow: 1;
 }

--- a/src/app/header/light-dark-toggle/light-dark-toggle.component.scss
+++ b/src/app/header/light-dark-toggle/light-dark-toggle.component.scss
@@ -1,4 +1,9 @@
 @use 'theming';
+@use 'toolbar';
+
+:host {
+  block-size: toolbar.$icons-height;
+}
 
 .light-only {
   @include theming.when-dark-mode {

--- a/src/app/header/tab/tab.component.scss
+++ b/src/app/header/tab/tab.component.scss
@@ -16,7 +16,7 @@ a:host,
   font-weight: 300;
 
   // Revert link style
-  color: var(--ui-text);
+  color: inherit;
   text-decoration-line: none;
 
   &[aria-selected='true'] {

--- a/src/app/header/toolbar-button/toolbar-button.component.scss
+++ b/src/app/header/toolbar-button/toolbar-button.component.scss
@@ -1,4 +1,4 @@
-@use 'header';
+@use 'toolbar';
 @use 'touch-or-pointer';
 @use 'material-symbols';
 @use 'animations';
@@ -26,6 +26,6 @@
     @include animations.single-transition(color, animations.$emphasized-style);
   }
 
-  @include material-symbols.font-size(header.$icons-height);
+  @include material-symbols.font-size(toolbar.$icons-height);
   @include material-symbols.variation-settings($fill: false, $weight: 200);
 }

--- a/src/app/header/toolbar/toolbar.component.scss
+++ b/src/app/header/toolbar/toolbar.component.scss
@@ -1,5 +1,18 @@
-@use 'header';
+@use 'animations';
+@use 'margins';
 
 :host {
-  padding: header.$vertical-padding;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+
+  background-color: var(--app-color-toolbar-background);
+  color: var(--ui-text);
+
+  @include animations.when-motion {
+    @include animations.single-transition(
+      (background-color),
+      animations.$emphasized-style
+    );
+  }
 }

--- a/src/app/resume-page/chipped-content/chipped-content.component.scss
+++ b/src/app/resume-page/chipped-content/chipped-content.component.scss
@@ -8,6 +8,7 @@
 
 .chips {
   display: flex;
+  flex-wrap: wrap;
   gap: margins.$s;
 }
 

--- a/src/app/resume-page/section-title/section-title.component.scss
+++ b/src/app/resume-page/section-title/section-title.component.scss
@@ -12,11 +12,7 @@
   transform: translateY(-#{borders.$panel-width});
   z-index: z-index.$headers;
   @include quirks.leftBorderDisappearance;
-  padding: paddings.$s paddings.$l;
   @include borders.panel(bottom, top);
-  background-color: var(--app-color-toolbar-background);
-  color: var(--ui-text);
-  font-size: 1.25rem;
 
   @include animations.when-motion {
     @include animations.multiple-transitions(
@@ -24,4 +20,9 @@
       animations.$emphasized-style
     );
   }
+}
+
+app-toolbar {
+  padding: paddings.$s paddings.$l;
+  font-size: 1.25rem;
 }

--- a/src/app/resume-page/section-title/section-title.component.ts
+++ b/src/app/resume-page/section-title/section-title.component.ts
@@ -1,9 +1,11 @@
 import { Component } from '@angular/core'
+import { ToolbarComponent } from '../../header/toolbar/toolbar.component'
 
 @Component({
   // eslint-disable-next-line @angular-eslint/component-selector
   selector: '[appSectionTitle]',
-  template: '<ng-content></ng-content>',
+  template: '<app-toolbar><ng-content></ng-content></app-toolbar>',
   styleUrls: ['./section-title.component.scss'],
+  imports: [ToolbarComponent],
 })
 export class SectionTitleComponent {}

--- a/src/sass/_header.scss
+++ b/src/sass/_header.scss
@@ -1,9 +1,8 @@
 @use 'paddings';
 @use 'borders';
+@use 'toolbar';
 
-$vertical-padding: paddings.$xs;
-$icons-height: 2rem;
-$vertical-padding-height: calc(2 * $vertical-padding);
+$padding-height: calc(2 * #{toolbar.$vertical-padding});
 $border-height: borders.$panel-width;
 
-$height: calc($icons-height + $vertical-padding-height + $border-height);
+$height: calc(#{toolbar.$icons-height} + $padding-height + $border-height);

--- a/src/sass/_toolbar.scss
+++ b/src/sass/_toolbar.scss
@@ -1,0 +1,4 @@
+@use 'paddings';
+
+$icons-height: 2rem;
+$vertical-padding: paddings.$xs;


### PR DESCRIPTION
Quite weird mix in there of abstractions TBH. The toolbar is caracterized by its background color at specific depth, layout of its elements inside (flex row) and borders. Borders are context-aware, so letting that responsibility to the consumer. However, the rest is toolbar's responsibility. Moving that code in there so component can be reused as expected.
